### PR TITLE
fix: deduplicate hot-start cuts and offset SDDP iteration index

### DIFF
--- a/include/gtopt/sddp_cut_io.hpp
+++ b/include/gtopt/sddp_cut_io.hpp
@@ -64,7 +64,7 @@ class PlanningLP;
 /// @param directory    Output directory (file: scene_<UID>.csv)
 [[nodiscard]] auto save_scene_cuts_csv(std::span<const StoredCut> cuts,
                                        SceneIndex scene,
-                                       int scene_uid,
+                                       int scene_uid_val,
                                        const PlanningLP& planning_lp,
                                        const std::string& directory)
     -> std::expected<void, Error>;
@@ -80,11 +80,11 @@ class PlanningLP;
 /// @param planning_lp   The PlanningLP to add cuts to
 /// @param filepath      Input CSV file path
 /// @param label_maker   Label maker for LP row names
-/// @return Number of unique cuts loaded, or an error
+/// @return CutLoadResult with count and max iteration, or an error
 [[nodiscard]] auto load_cuts_csv(PlanningLP& planning_lp,
                                  const std::string& filepath,
                                  const LabelMaker& label_maker)
-    -> std::expected<int, Error>;
+    -> std::expected<CutLoadResult, Error>;
 
 /// Load all per-scene cut files from a directory.
 ///
@@ -95,11 +95,11 @@ class PlanningLP;
 /// @param planning_lp   The PlanningLP to add cuts to
 /// @param directory     Directory containing cut CSV files
 /// @param label_maker   Label maker for LP row names
-/// @return Total number of cuts loaded, or an error
+/// @return CutLoadResult with total count and max iteration, or an error
 [[nodiscard]] auto load_scene_cuts_from_directory(PlanningLP& planning_lp,
                                                   const std::string& directory,
                                                   const LabelMaker& label_maker)
-    -> std::expected<int, Error>;
+    -> std::expected<CutLoadResult, Error>;
 
 /// Load boundary (future-cost) cuts from a named-variable CSV file.
 ///
@@ -114,7 +114,7 @@ class PlanningLP;
 /// @param options             SDDP options (boundary mode, max iters)
 /// @param label_maker         Label maker for LP row names
 /// @param scene_phase_states  Per-scene phase state (for alpha columns)
-/// @return Number of cuts loaded, or an error
+/// @return CutLoadResult with count and max iteration, or an error
 [[nodiscard]] auto load_boundary_cuts_csv(
     PlanningLP& planning_lp,
     const std::string& filepath,
@@ -122,7 +122,7 @@ class PlanningLP;
     const LabelMaker& label_maker,
     StrongIndexVector<SceneIndex,
                       StrongIndexVector<PhaseIndex, PhaseStateInfo>>&
-        scene_phase_states) -> std::expected<int, Error>;
+        scene_phase_states) -> std::expected<CutLoadResult, Error>;
 
 /// Load named-variable cuts from a CSV file with a `phase` column.
 ///
@@ -136,7 +136,7 @@ class PlanningLP;
 /// @param options             SDDP options (for alpha bounds)
 /// @param label_maker         Label maker for LP row names
 /// @param scene_phase_states  Per-scene phase state (for alpha columns)
-/// @return Number of cuts loaded, or an error
+/// @return CutLoadResult with count and max iteration, or an error
 [[nodiscard]] auto load_named_cuts_csv(
     PlanningLP& planning_lp,
     const std::string& filepath,
@@ -144,6 +144,6 @@ class PlanningLP;
     const LabelMaker& label_maker,
     StrongIndexVector<SceneIndex,
                       StrongIndexVector<PhaseIndex, PhaseStateInfo>>&
-        scene_phase_states) -> std::expected<int, Error>;
+        scene_phase_states) -> std::expected<CutLoadResult, Error>;
 
 }  // namespace gtopt

--- a/include/gtopt/sddp_solver.hpp
+++ b/include/gtopt/sddp_solver.hpp
@@ -80,6 +80,13 @@
 namespace gtopt
 {
 
+/// Result of a cut load operation.
+struct CutLoadResult
+{
+  int count {};  ///< Number of unique cuts loaded
+  int max_iteration {};  ///< Highest iteration index found among loaded cuts
+};
+
 // ─── Cut sharing mode ───────────────────────────────────────────────────────
 
 /**
@@ -614,14 +621,14 @@ public:
   /// since loaded cuts serve as warm-start approximations for the entire
   /// problem (analogous to PLP's cut sharing across scenarios).
   [[nodiscard]] auto load_cuts(const std::string& filepath)
-      -> std::expected<int, Error>;
+      -> std::expected<CutLoadResult, Error>;
 
   /// Load all per-scene cut files from a directory.
   /// Files matching `scene_<N>.csv` are loaded; files with the `error_`
   /// prefix (from infeasible scenes in a previous run) are skipped to
   /// prevent loading invalid cuts during hot-start.
   [[nodiscard]] auto load_scene_cuts_from_directory(
-      const std::string& directory) -> std::expected<int, Error>;
+      const std::string& directory) -> std::expected<CutLoadResult, Error>;
 
   /// Load boundary (future-cost) cuts from a named-variable CSV file.
   ///
@@ -630,9 +637,9 @@ public:
   /// Cuts are added only to the last phase, with an alpha column created
   /// if needed.  This is analogous to PLP's "planos de embalse".
   ///
-  /// @return Number of cuts loaded, or an error.
+  /// @return CutLoadResult with count and max iteration, or an error.
   [[nodiscard]] auto load_boundary_cuts(const std::string& filepath)
-      -> std::expected<int, Error>;
+      -> std::expected<CutLoadResult, Error>;
 
   /// Load named-variable cuts from a CSV file with a `phase` column.
   ///
@@ -645,9 +652,9 @@ public:
   /// This is used for hot-start from PLP planos data where cuts span
   /// multiple stages (mapped to gtopt phases).
   ///
-  /// @return Number of cuts loaded, or an error.
+  /// @return CutLoadResult with count and max iteration, or an error.
   [[nodiscard]] auto load_named_cuts(const std::string& filepath)
-      -> std::expected<int, Error>;
+      -> std::expected<CutLoadResult, Error>;
 
 private:
   using scene_phase_states_t =
@@ -898,6 +905,12 @@ private:
       m_infeasibility_counter_;
 
   bool m_initialized_ {false};
+
+  /// Iteration offset from hot-start cuts.  When cuts from a previous
+  /// run are loaded, the solver starts numbering new iterations after
+  /// the highest iteration found in the loaded cuts, avoiding name
+  /// collisions.
+  int m_iteration_offset_ {0};
 
   // ── Stop / callback machinery ──
   SDDPIterationCallback m_iteration_callback_ {};

--- a/source/sddp_cut_io.cpp
+++ b/source/sddp_cut_io.cpp
@@ -12,6 +12,7 @@
  */
 
 #include <algorithm>
+#include <charconv>
 #include <cmath>
 #include <filesystem>
 #include <format>
@@ -89,6 +90,44 @@ void write_cut_coefficients_unscaled(std::ostream& ofs,
   for (const auto& [col, coeff] : cut.coefficients) {
     ofs << "," << col << ":" << (coeff * scale_obj);
   }
+}
+
+/// Extract the iteration number from a cut name.
+///
+/// Cut name formats:
+///   sddp_scut_{scene}_{phase}_{iteration}_{offset}  → field [4]
+///   sddp_fcut_{scene}_{phase}_{iteration}_{offset}  → field [4]
+///   sddp_ecut_{scene}_{phase}_{total_cuts}           → no iteration
+///
+/// Returns 0 if the iteration cannot be determined.
+[[nodiscard]] auto extract_iteration_from_name(std::string_view name) -> int
+{
+  // Only scut and fcut encode the iteration
+  if (!name.starts_with("sddp_scut_") && !name.starts_with("sddp_fcut_")) {
+    return 0;
+  }
+  // Split by '_' and take the 5th field (index 4)
+  int field = 0;
+  std::string_view::size_type pos = 0;
+  while (pos < name.size() && field < 4) {
+    pos = name.find('_', pos);
+    if (pos == std::string_view::npos) {
+      return 0;
+    }
+    ++pos;
+    ++field;
+  }
+  if (field != 4 || pos >= name.size()) {
+    return 0;
+  }
+  const auto end = name.find('_', pos);
+  const auto token = name.substr(pos, end - pos);
+  int result = 0;
+  const auto* const first = token.data();
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+  const auto* const last = first + token.size();
+  auto [ptr, ec] = std::from_chars(first, last, result);
+  return (ec == std::errc {}) ? result : 0;
 }
 
 }  // namespace
@@ -232,7 +271,8 @@ auto save_scene_cuts_csv(std::span<const StoredCut> cuts,
 
 auto load_cuts_csv(PlanningLP& planning_lp,
                    const std::string& filepath,
-                   const LabelMaker& label_maker) -> std::expected<int, Error>
+                   const LabelMaker& label_maker)
+    -> std::expected<CutLoadResult, Error>
 {
   try {
     std::ifstream ifs(filepath);
@@ -254,13 +294,18 @@ auto load_cuts_csv(PlanningLP& planning_lp,
       break;
     }
 
-    int cuts_loaded = 0;
+    CutLoadResult result {};
     const auto& sim = planning_lp.simulation();
     const auto num_scenes = static_cast<Index>(sim.scenes().size());
     const auto scale_obj = planning_lp.options().scale_objective();
 
     // Build phase UID -> PhaseIndex lookup
     const auto phase_uid_to_index = build_phase_uid_map(planning_lp);
+
+    // Track (phase_uid, cut_name) pairs already loaded.
+    // Cuts are broadcast to all scenes, so if the CSV contains
+    // the same cut for multiple scenes we must load it only once.
+    std::set<std::pair<int, std::string>> loaded_keys;
 
     // Process data lines
     while (std::getline(ifs, line)) {
@@ -282,6 +327,17 @@ auto load_cuts_csv(PlanningLP& planning_lp,
 
       std::getline(iss, token, ',');
       const auto cut_name = token;
+
+      // Skip duplicate (phase, name) pairs — these arise when
+      // the CSV was saved with per-scene rows but loading
+      // broadcasts each cut to every scene.
+      if (!loaded_keys.emplace(phase_val, cut_name).second) {
+        continue;
+      }
+
+      // Track the highest iteration found for iteration offset
+      result.max_iteration =
+          std::max(result.max_iteration, extract_iteration_from_name(cut_name));
 
       std::getline(iss, token, ',');
       const auto rhs = std::stod(token);
@@ -333,11 +389,11 @@ auto load_cuts_csv(PlanningLP& planning_lp,
         }
         li.add_row(scene_row);
       }
-      ++cuts_loaded;
+      ++result.count;
     }
 
-    SPDLOG_TRACE("SDDP: loaded {} cuts from {}", cuts_loaded, filepath);
-    return cuts_loaded;
+    SPDLOG_TRACE("SDDP: loaded {} cuts from {}", result.count, filepath);
+    return result;
 
   } catch (const std::exception& e) {
     return std::unexpected(Error {
@@ -351,12 +407,12 @@ auto load_cuts_csv(PlanningLP& planning_lp,
 auto load_scene_cuts_from_directory(PlanningLP& planning_lp,
                                     const std::string& directory,
                                     const LabelMaker& label_maker)
-    -> std::expected<int, Error>
+    -> std::expected<CutLoadResult, Error>
 {
-  int total_loaded = 0;
+  CutLoadResult total {};
 
   if (!std::filesystem::exists(directory)) {
-    return 0;  // No directory = no cuts to load (not an error)
+    return total;  // No directory = no cuts to load (not an error)
   }
 
   for (const auto& entry : std::filesystem::directory_iterator(directory)) {
@@ -383,8 +439,11 @@ auto load_scene_cuts_from_directory(PlanningLP& planning_lp,
     auto result =
         load_cuts_csv(planning_lp, entry.path().string(), label_maker);
     if (result.has_value()) {
-      total_loaded += *result;
-      SPDLOG_TRACE("SDDP hot-start: loaded {} cuts from {}", *result, filename);
+      total.count += result->count;
+      total.max_iteration =
+          std::max(total.max_iteration, result->max_iteration);
+      SPDLOG_TRACE(
+          "SDDP hot-start: loaded {} cuts from {}", result->count, filename);
     } else {
       SPDLOG_WARN("SDDP hot-start: could not load {}: {}",
                   filename,
@@ -392,7 +451,7 @@ auto load_scene_cuts_from_directory(PlanningLP& planning_lp,
     }
   }
 
-  return total_loaded;
+  return total;
 }
 
 // ─── Boundary (future-cost) cuts ────────────────────────────────────────────
@@ -404,13 +463,13 @@ auto load_boundary_cuts_csv(
     const LabelMaker& label_maker,
     StrongIndexVector<SceneIndex,
                       StrongIndexVector<PhaseIndex, PhaseStateInfo>>&
-        scene_phase_states) -> std::expected<int, Error>
+        scene_phase_states) -> std::expected<CutLoadResult, Error>
 {
   // ── Mode check ────────────────────────────────────────────────
   const auto& mode = options.boundary_cuts_mode;
   if (mode == "noload") {
     SPDLOG_INFO("SDDP: boundary cuts mode is 'noload' -- skipping");
-    return 0;
+    return CutLoadResult {};
   }
 
   const bool separated = (mode == "separated");
@@ -628,6 +687,12 @@ auto load_boundary_cuts_csv(
       }
     }
 
+    // ── Compute max iteration from loaded raw cuts ────────────────
+    int max_iteration = 0;
+    for (const auto& rc : raw_cuts) {
+      max_iteration = std::max(max_iteration, rc.iteration);
+    }
+
     // ── Add cuts to the LP ──────────────────────────────────────
     const auto scale_obj = planning_lp.options().scale_objective();
     int cuts_loaded = 0;
@@ -689,7 +754,10 @@ auto load_boundary_cuts_csv(
         filepath,
         mode,
         max_iters);
-    return cuts_loaded;
+    return CutLoadResult {
+        .count = cuts_loaded,
+        .max_iteration = max_iteration,
+    };
 
   } catch (const std::exception& e) {
     return std::unexpected(Error {
@@ -709,7 +777,7 @@ auto load_named_cuts_csv(
     const LabelMaker& label_maker,
     StrongIndexVector<SceneIndex,
                       StrongIndexVector<PhaseIndex, PhaseStateInfo>>&
-        scene_phase_states) -> std::expected<int, Error>
+        scene_phase_states) -> std::expected<CutLoadResult, Error>
 {
   try {
     std::ifstream ifs(filepath);
@@ -851,7 +919,7 @@ auto load_named_cuts_csv(
     };
 
     // ── Read all cut rows ───────────────────────────────────────
-    int cuts_loaded = 0;
+    CutLoadResult result {};
     std::string line;
     while (std::getline(ifs, line)) {
       if (line.empty()) {
@@ -867,7 +935,8 @@ auto load_named_cuts_csv(
 
       // Column 1: iteration
       std::getline(iss, token, ',');
-      [[maybe_unused]] const auto iteration = std::stoi(token);
+      const auto iteration = std::stoi(token);
+      result.max_iteration = std::max(result.max_iteration, iteration);
 
       // Column 2: scene UID
       std::getline(iss, token, ',');
@@ -946,12 +1015,12 @@ auto load_named_cuts_csv(
 
         li.add_row(row);
       }
-      ++cuts_loaded;
+      ++result.count;
     }
 
     SPDLOG_INFO(
-        "SDDP: loaded {} named hot-start cuts from {}", cuts_loaded, filepath);
-    return cuts_loaded;
+        "SDDP: loaded {} named hot-start cuts from {}", result.count, filepath);
+    return result;
 
   } catch (const std::exception& e) {
     return std::unexpected(Error {

--- a/source/sddp_solver.cpp
+++ b/source/sddp_solver.cpp
@@ -1004,20 +1004,20 @@ auto SDDPSolver::save_all_scene_cuts(const std::string& directory) const
 }
 
 auto SDDPSolver::load_cuts(const std::string& filepath)
-    -> std::expected<int, Error>
+    -> std::expected<CutLoadResult, Error>
 {
   return load_cuts_csv(planning_lp(), filepath, m_label_maker_);
 }
 
 auto SDDPSolver::load_scene_cuts_from_directory(const std::string& directory)
-    -> std::expected<int, Error>
+    -> std::expected<CutLoadResult, Error>
 {
   return gtopt::load_scene_cuts_from_directory(
       planning_lp(), directory, m_label_maker_);
 }
 
 auto SDDPSolver::load_boundary_cuts(const std::string& filepath)
-    -> std::expected<int, Error>
+    -> std::expected<CutLoadResult, Error>
 {
   return load_boundary_cuts_csv(planning_lp(),
                                 filepath,
@@ -1027,7 +1027,7 @@ auto SDDPSolver::load_boundary_cuts(const std::string& filepath)
 }
 
 auto SDDPSolver::load_named_cuts(const std::string& filepath)
-    -> std::expected<int, Error>
+    -> std::expected<CutLoadResult, Error>
 {
   return load_named_cuts_csv(planning_lp(),
                              filepath,
@@ -1095,10 +1095,17 @@ auto SDDPSolver::initialize_solver() -> std::expected<void, Error>
                            .outgoing_links.size());
   }
 
+  // ── Load hot-start cuts and track max iteration for offset ────────────────
+  m_iteration_offset_ = 0;
+
   if (!m_options_.cuts_input_file.empty()) {
     auto result = load_cuts(m_options_.cuts_input_file);
     if (result.has_value()) {
-      SPDLOG_INFO("SDDP hot-start: loaded {} cuts", *result);
+      m_iteration_offset_ =
+          std::max(m_iteration_offset_, result->max_iteration);
+      SPDLOG_INFO("SDDP hot-start: loaded {} cuts (max_iter={})",
+                  result->count,
+                  result->max_iteration);
     } else {
       SPDLOG_WARN("SDDP hot-start: could not load cuts: {}",
                   result.error().message);
@@ -1108,10 +1115,13 @@ auto SDDPSolver::initialize_solver() -> std::expected<void, Error>
         std::filesystem::path(m_options_.cuts_output_file).parent_path();
     if (!cut_dir.empty() && std::filesystem::exists(cut_dir)) {
       auto result = load_scene_cuts_from_directory(cut_dir.string());
-      if (result.has_value() && *result > 0) {
-        SPDLOG_INFO("SDDP hot-start: loaded {} cuts from {}",
-                    *result,
-                    cut_dir.string());
+      if (result.has_value() && result->count > 0) {
+        m_iteration_offset_ =
+            std::max(m_iteration_offset_, result->max_iteration);
+        SPDLOG_INFO("SDDP hot-start: loaded {} cuts from {} (max_iter={})",
+                    result->count,
+                    cut_dir.string(),
+                    result->max_iteration);
       }
     }
   }
@@ -1120,9 +1130,12 @@ auto SDDPSolver::initialize_solver() -> std::expected<void, Error>
   if (!m_options_.boundary_cuts_file.empty()) {
     auto result = load_boundary_cuts(m_options_.boundary_cuts_file);
     if (result.has_value()) {
-      SPDLOG_INFO("SDDP: loaded {} boundary cuts from {}",
-                  *result,
-                  m_options_.boundary_cuts_file);
+      m_iteration_offset_ =
+          std::max(m_iteration_offset_, result->max_iteration);
+      SPDLOG_INFO("SDDP: loaded {} boundary cuts from {} (max_iter={})",
+                  result->count,
+                  m_options_.boundary_cuts_file,
+                  result->max_iteration);
     } else {
       SPDLOG_WARN("SDDP: could not load boundary cuts: {}",
                   result.error().message);
@@ -1133,13 +1146,21 @@ auto SDDPSolver::initialize_solver() -> std::expected<void, Error>
   if (!m_options_.named_cuts_file.empty()) {
     auto result = load_named_cuts(m_options_.named_cuts_file);
     if (result.has_value()) {
-      SPDLOG_INFO("SDDP: loaded {} named hot-start cuts from {}",
-                  *result,
-                  m_options_.named_cuts_file);
+      m_iteration_offset_ =
+          std::max(m_iteration_offset_, result->max_iteration);
+      SPDLOG_INFO("SDDP: loaded {} named hot-start cuts from {} (max_iter={})",
+                  result->count,
+                  m_options_.named_cuts_file,
+                  result->max_iteration);
     } else {
       SPDLOG_WARN("SDDP: could not load named hot-start cuts: {}",
                   result.error().message);
     }
+  }
+
+  if (m_iteration_offset_ > 0) {
+    SPDLOG_INFO("SDDP: iteration offset set to {} from hot-start cuts",
+                m_iteration_offset_);
   }
 
   m_initialized_ = true;
@@ -1467,7 +1488,7 @@ void SDDPSolver::finalize_iteration_result(SDDPIterationResult& ir, int iter)
   // Only declare convergence if both the gap tolerance is met AND
   // we have completed at least min_iterations (default 2).
   ir.converged = (ir.gap < m_options_.convergence_tol)
-      && (iter >= m_options_.min_iterations);
+      && (iter >= m_iteration_offset_ + m_options_.min_iterations);
 
   m_current_iteration_.store(iter);
   m_current_gap_.store(ir.gap);
@@ -1617,7 +1638,9 @@ auto SDDPSolver::solve(const SolverOptions& lp_opts)
   std::vector<SDDPIterationResult> results;
   results.reserve(m_options_.max_iterations);
 
-  for (int iter = 1; iter <= m_options_.max_iterations; ++iter) {
+  const int iter_start_val = m_iteration_offset_ + 1;
+  const int iter_end_val = m_iteration_offset_ + m_options_.max_iterations;
+  for (int iter = iter_start_val; iter <= iter_end_val; ++iter) {
     const auto iter_start = std::chrono::steady_clock::now();
 
     if (should_stop()) {
@@ -1626,8 +1649,7 @@ auto SDDPSolver::solve(const SolverOptions& lp_opts)
       break;
     }
 
-    SPDLOG_INFO(
-        "SDDP: === iteration {} / {} ===", iter, m_options_.max_iterations);
+    SPDLOG_INFO("SDDP: === iteration {} / {} ===", iter, iter_end_val);
 
     SDDPIterationResult ir {
         .iteration = iter,

--- a/test/source/test_sddp_cut_io.hpp
+++ b/test/source/test_sddp_cut_io.hpp
@@ -10,6 +10,24 @@
  *  3. load_cuts_csv handles empty files gracefully
  *  4. save_scene_cuts_csv creates per-scene files
  *  5. load_scene_cuts_from_directory loads scene files and skips errors
+ *  6. save_cuts_csv with empty cuts vector
+ *  7. save_cuts_csv with unknown phase UID (unscaled fallback)
+ *  8. load_cuts_csv with comment lines and blank lines
+ *  9. load_cuts_csv with unknown phase UID skips cut
+ * 10. load_cuts_csv with coefficient parsing
+ * 11. save_scene_cuts_csv error on invalid path
+ * 12. load_scene_cuts_from_directory skips non-scene/non-csv files
+ * 13. load_boundary_cuts_csv noload mode returns 0
+ * 14. load_boundary_cuts_csv error on nonexistent file
+ * 15. load_boundary_cuts_csv invalid header
+ * 16. load_boundary_cuts_csv separated mode
+ * 17. load_boundary_cuts_csv legacy format (no iteration column)
+ * 18. load_boundary_cuts_csv iteration filtering
+ * 19. load_named_cuts_csv error on nonexistent file
+ * 20. load_named_cuts_csv invalid header (too few columns)
+ * 21. load_named_cuts_csv wrong phase column name
+ * 22. load_named_cuts_csv loads cuts for all phases
+ * 23. load_named_cuts_csv skips unknown phase UIDs
  */
 
 #include <filesystem>
@@ -22,6 +40,36 @@
 #include <gtopt/sddp_solver.hpp>
 
 using namespace gtopt;  // NOLINT(google-global-names-in-headers)
+
+namespace  // NOLINT(cert-dcl59-cpp,fuchsia-header-anon-namespaces,google-build-namespaces,misc-anonymous-namespace-in-header)
+{
+
+/// Helper to create scene_phase_states matching a PlanningLP.
+auto make_scene_phase_states(const PlanningLP& planning_lp)
+    -> StrongIndexVector<SceneIndex,
+                         StrongIndexVector<PhaseIndex, PhaseStateInfo>>
+{
+  const auto& sim = planning_lp.simulation();
+  const auto num_scenes = static_cast<Index>(sim.scenes().size());
+  const auto num_phases = static_cast<Index>(sim.phases().size());
+
+  StrongIndexVector<SceneIndex, StrongIndexVector<PhaseIndex, PhaseStateInfo>>
+      result(num_scenes,
+             StrongIndexVector<PhaseIndex, PhaseStateInfo>(num_phases,
+                                                           PhaseStateInfo {}));
+  return result;
+}
+
+/// Unique temp dir for a test to avoid collisions.
+auto make_test_dir(const std::string& test_name) -> std::filesystem::path
+{
+  auto dir = std::filesystem::temp_directory_path()
+      / ("gtopt_test_cut_io_" + test_name);
+  std::filesystem::create_directories(dir);
+  return dir;
+}
+
+}  // namespace
 
 // ─── build_phase_uid_map tests ──────────────────────────────────────────────
 
@@ -101,6 +149,98 @@ TEST_CASE("save_cuts_csv writes a valid CSV file")  // NOLINT
   std::filesystem::remove(cuts_file);
 }
 
+TEST_CASE("save_cuts_csv with empty cuts vector writes header only")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_dir = std::filesystem::temp_directory_path();
+  const auto cuts_file =
+      (tmp_dir / "gtopt_test_cut_io_empty_save.csv").string();
+
+  // Save an empty span of cuts
+  std::vector<StoredCut> empty_cuts;
+  auto save_result = save_cuts_csv(
+      std::span<const StoredCut>(empty_cuts), planning_lp, cuts_file);
+  REQUIRE(save_result.has_value());
+  CHECK(std::filesystem::exists(cuts_file));
+
+  // File should contain metadata + header but no data lines
+  std::ifstream ifs(cuts_file);
+  std::string line;
+  std::getline(ifs, line);  // metadata
+  CHECK(line.starts_with("# scale_objective="));
+  std::getline(ifs, line);  // header
+  CHECK(line == "phase,scene,name,rhs,coefficients");
+
+  // No more data lines
+  CHECK_FALSE(std::getline(ifs, line));
+
+  std::filesystem::remove(cuts_file);
+}
+
+TEST_CASE(
+    "save_cuts_csv with unknown phase UID uses unscaled "
+    "fallback")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_dir = std::filesystem::temp_directory_path();
+  const auto cuts_file =
+      (tmp_dir / "gtopt_test_cut_io_unknown_phase.csv").string();
+
+  // Create a StoredCut with a phase UID that does not exist
+  std::vector<StoredCut> cuts = {
+      StoredCut {
+          .phase = 999,
+          .scene = 1,
+          .name = "bad_phase_cut",
+          .rhs = 42.0,
+          .coefficients =
+              {
+                  {0, 1.5},
+                  {1, -2.5},
+              },
+      },
+  };
+
+  auto save_result =
+      save_cuts_csv(std::span<const StoredCut>(cuts), planning_lp, cuts_file);
+  REQUIRE(save_result.has_value());
+
+  // Verify the file was written with the unscaled coefficients
+  std::ifstream ifs(cuts_file);
+  std::string line;
+  std::getline(ifs, line);  // metadata
+  std::getline(ifs, line);  // header
+  std::getline(ifs, line);  // data line
+
+  // The line should contain "999,1,bad_phase_cut" and coefficient data
+  CHECK(line.starts_with("999,1,bad_phase_cut,"));
+
+  std::filesystem::remove(cuts_file);
+}
+
+TEST_CASE("save_cuts_csv creates parent directories")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto nested_dir = std::filesystem::temp_directory_path()
+      / "gtopt_test_nested" / "sub1" / "sub2";
+  const auto cuts_file = (nested_dir / "cuts.csv").string();
+
+  std::vector<StoredCut> cuts;
+  auto save_result =
+      save_cuts_csv(std::span<const StoredCut>(cuts), planning_lp, cuts_file);
+  REQUIRE(save_result.has_value());
+  CHECK(std::filesystem::exists(cuts_file));
+
+  std::filesystem::remove_all(std::filesystem::temp_directory_path()
+                              / "gtopt_test_nested");
+}
+
 // ─── save_cuts_csv / load_cuts_csv round-trip via SDDPSolver ────────────────
 
 TEST_CASE("save and load cuts round-trip via SDDPSolver")  // NOLINT
@@ -162,6 +302,7 @@ TEST_CASE("load_cuts_csv returns error for nonexistent file")  // NOLINT
   auto result = load_cuts_csv(
       planning_lp, "/tmp/gtopt_nonexistent_cuts.csv", label_maker);
   CHECK_FALSE(result.has_value());
+  CHECK(result.error().code == ErrorCode::FileIOError);
 }
 
 TEST_CASE("load_cuts_csv handles header-only file")  // NOLINT
@@ -183,7 +324,89 @@ TEST_CASE("load_cuts_csv handles header-only file")  // NOLINT
   const LabelMaker label_maker(planning_lp.options());
   auto result = load_cuts_csv(planning_lp, tmp_file, label_maker);
   REQUIRE(result.has_value());
-  CHECK(*result == 0);
+  CHECK(result->count == 0);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_cuts_csv skips comment lines and blank lines in "
+    "body")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file = (std::filesystem::temp_directory_path()
+                         / "gtopt_test_cut_io_comments.csv")
+                            .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    ofs << "# scale_objective=1\n";
+    ofs << "phase,scene,name,rhs,coefficients\n";
+    ofs << "# This is a comment in the body\n";
+    ofs << "\n";
+    ofs << "# Another comment\n";
+  }
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto result = load_cuts_csv(planning_lp, tmp_file, label_maker);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 0);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE("load_cuts_csv skips cuts with unknown phase UID")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file = (std::filesystem::temp_directory_path()
+                         / "gtopt_test_cut_io_unknown_phase_load.csv")
+                            .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    ofs << "# scale_objective=1\n";
+    ofs << "phase,scene,name,rhs,coefficients\n";
+    // Phase UID 999 does not exist
+    ofs << "999,1,unknown_phase_cut,100.0\n";
+  }
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto result = load_cuts_csv(planning_lp, tmp_file, label_maker);
+  REQUIRE(result.has_value());
+  // The cut should be skipped (unknown phase), so 0 loaded
+  CHECK(result->count == 0);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_cuts_csv parses coefficients and loads valid "
+    "cuts")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file = (std::filesystem::temp_directory_path()
+                         / "gtopt_test_cut_io_valid_load.csv")
+                            .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    ofs << "# scale_objective=1\n";
+    ofs << "phase,scene,name,rhs,coefficients\n";
+    // Phase UID 1 exists in 3-phase planning, col 0 with coeff 1.5
+    ofs << "1,1,my_cut,50.0,0:1.5,1:-2.0\n";
+    ofs << "2,1,my_cut2,30.0,0:0.5\n";
+  }
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto result = load_cuts_csv(planning_lp, tmp_file, label_maker);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 2);
 
   std::filesystem::remove(tmp_file);
 }
@@ -219,7 +442,40 @@ TEST_CASE("save_scene_cuts_csv creates per-scene file")  // NOLINT
   const auto scene_file = std::filesystem::path(tmp_dir) / "scene_1.csv";
   CHECK(std::filesystem::exists(scene_file));
 
+  // Verify file has correct header
+  std::ifstream ifs(scene_file.string());
+  std::string line;
+  std::getline(ifs, line);
+  CHECK(line.starts_with("# scale_objective="));
+  std::getline(ifs, line);
+  CHECK(line == "phase,scene,name,rhs,coefficients");
+
   // Clean up
+  std::filesystem::remove_all(tmp_dir);
+}
+
+TEST_CASE(
+    "save_scene_cuts_csv with empty cuts creates empty "
+    "file")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_dir =
+      (std::filesystem::temp_directory_path() / "gtopt_test_scene_cuts_empty")
+          .string();
+
+  std::vector<StoredCut> empty_cuts;
+  auto save_result = save_scene_cuts_csv(std::span<const StoredCut>(empty_cuts),
+                                         SceneIndex {0},
+                                         1,
+                                         planning_lp,
+                                         tmp_dir);
+  REQUIRE(save_result.has_value());
+
+  const auto scene_file = std::filesystem::path(tmp_dir) / "scene_1.csv";
+  CHECK(std::filesystem::exists(scene_file));
+
   std::filesystem::remove_all(tmp_dir);
 }
 
@@ -268,7 +524,7 @@ TEST_CASE(
   auto load_result =
       load_scene_cuts_from_directory(planning_lp, tmp_dir, label_maker);
   REQUIRE(load_result.has_value());
-  CHECK(*load_result > 0);
+  CHECK(load_result->count > 0);
 
   // Clean up
   std::filesystem::remove_all(tmp_dir);
@@ -285,5 +541,881 @@ TEST_CASE(
   auto result = load_scene_cuts_from_directory(
       planning_lp, "/tmp/gtopt_nonexistent_dir_xyz", label_maker);
   REQUIRE(result.has_value());
-  CHECK(*result == 0);
+  CHECK(result->count == 0);
+}
+
+TEST_CASE(
+    "load_scene_cuts_from_directory skips non-scene "
+    "and non-csv files")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_dir = make_test_dir("skip_non_scene");
+
+  // Create files that should be skipped
+  {
+    std::ofstream ofs1((tmp_dir / "random_file.csv").string());
+    ofs1 << "phase,scene,name,rhs,coefficients\n";
+    ofs1 << "1,1,cut1,10.0\n";
+  }
+  {
+    std::ofstream ofs2((tmp_dir / "scene_1.txt").string());
+    ofs2 << "not a csv\n";
+  }
+  {
+    // Create a subdirectory that should be skipped
+    std::filesystem::create_directories(tmp_dir / "scene_subdir");
+  }
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto result = load_scene_cuts_from_directory(
+      planning_lp, tmp_dir.string(), label_maker);
+  REQUIRE(result.has_value());
+  // random_file.csv does not start with "scene_" and is not sddp_cuts.csv
+  // scene_1.txt does not end with .csv
+  CHECK(result->count == 0);
+
+  std::filesystem::remove_all(tmp_dir);
+}
+
+TEST_CASE(
+    "load_scene_cuts_from_directory loads sddp_cuts.csv "
+    "combined file")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_dir = make_test_dir("combined_cuts");
+
+  // Create a combined sddp_cuts.csv file
+  {
+    std::ofstream ofs((tmp_dir / sddp_file::combined_cuts).string());
+    ofs << "# scale_objective=1\n";
+    ofs << "phase,scene,name,rhs,coefficients\n";
+    ofs << "1,1,combined_cut,25.0,0:1.0\n";
+  }
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto result = load_scene_cuts_from_directory(
+      planning_lp, tmp_dir.string(), label_maker);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 1);
+
+  std::filesystem::remove_all(tmp_dir);
+}
+
+// ─── load_boundary_cuts_csv tests ───────────────────────────────────────────
+
+TEST_CASE("load_boundary_cuts_csv noload mode returns 0")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  SDDPOptions opts;
+  opts.boundary_cuts_mode = "noload";
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result = load_boundary_cuts_csv(
+      planning_lp, "/tmp/any_file.csv", opts, label_maker, states);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 0);
+}
+
+TEST_CASE(
+    "load_boundary_cuts_csv returns error for nonexistent "
+    "file")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  SDDPOptions opts;
+  opts.boundary_cuts_mode = "separated";
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result = load_boundary_cuts_csv(planning_lp,
+                                       "/tmp/gtopt_nonexistent_boundary.csv",
+                                       opts,
+                                       label_maker,
+                                       states);
+  CHECK_FALSE(result.has_value());
+  CHECK(result.error().code == ErrorCode::FileIOError);
+}
+
+TEST_CASE(
+    "load_boundary_cuts_csv rejects header with too few "
+    "columns")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file =
+      (std::filesystem::temp_directory_path() / "gtopt_test_bdr_bad_header.csv")
+          .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    // Only 2 columns: name, rhs — too few
+    ofs << "name,rhs\n";
+    ofs << "cut1,10.0\n";
+  }
+
+  SDDPOptions opts;
+  opts.boundary_cuts_mode = "separated";
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_boundary_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  CHECK_FALSE(result.has_value());
+  CHECK(result.error().code == ErrorCode::InvalidInput);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_boundary_cuts_csv separated mode loads cuts with "
+    "matching scene UID")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file =
+      (std::filesystem::temp_directory_path() / "gtopt_test_bdr_separated.csv")
+          .string();
+
+  // The 3-phase hydro planning has junction "j_up" (uid 1) with reservoir
+  // "rsv1" (uid 1). Boundary cuts look up element names in
+  // name_to_class_uid which only contains junctions and batteries.
+  // The reservoir state variable key has uid=1 (same as junction uid).
+  // Scene UID is 1 (the only scenario UID in 3-phase planning).
+  {
+    std::ofstream ofs(tmp_file);
+    // Default scene UID is 0 (auto-generated when scene_array is empty)
+    ofs << "name,iteration,scene,rhs,j_up\n";
+    ofs << "bdr_cut1,1,0,100.0,5.0\n";
+    ofs << "bdr_cut2,2,0,200.0,10.0\n";
+  }
+
+  SDDPOptions opts;
+  opts.boundary_cuts_mode = "separated";
+  opts.boundary_max_iterations = 0;  // no filtering
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_boundary_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 2);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_boundary_cuts_csv shared mode broadcasts to all "
+    "scenes")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file =
+      (std::filesystem::temp_directory_path() / "gtopt_test_bdr_shared.csv")
+          .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    // "shared" mode: scene UID is ignored, cut goes to all scenes
+    ofs << "name,iteration,scene,rhs,j_up\n";
+    ofs << "shared_cut,1,0,50.0,3.0\n";
+  }
+
+  SDDPOptions opts;
+  opts.boundary_cuts_mode = "shared";
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_boundary_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 1);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_boundary_cuts_csv legacy format without iteration "
+    "column")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file =
+      (std::filesystem::temp_directory_path() / "gtopt_test_bdr_legacy.csv")
+          .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    // Legacy format: no iteration column; default scene UID = 0
+    ofs << "name,scene,rhs,j_up\n";
+    ofs << "legacy_cut,0,75.0,4.0\n";
+  }
+
+  SDDPOptions opts;
+  opts.boundary_cuts_mode = "separated";
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_boundary_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 1);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE("load_boundary_cuts_csv filters by max_iterations")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file = (std::filesystem::temp_directory_path()
+                         / "gtopt_test_bdr_filter_iters.csv")
+                            .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    ofs << "name,iteration,scene,rhs,j_up\n";
+    // 3 distinct iterations: 1, 2, 3; default scene UID = 0
+    ofs << "cut_iter1,1,0,10.0,1.0\n";
+    ofs << "cut_iter2,2,0,20.0,2.0\n";
+    ofs << "cut_iter3a,3,0,30.0,3.0\n";
+    ofs << "cut_iter3b,3,0,35.0,3.5\n";
+  }
+
+  SDDPOptions opts;
+  opts.boundary_cuts_mode = "separated";
+  // Keep only the last 2 iterations (iterations 2 and 3)
+  opts.boundary_max_iterations = 2;
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_boundary_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  // Iteration 1 filtered out, iterations 2+3 kept = 3 cuts
+  CHECK(result->count == 3);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_boundary_cuts_csv skips cuts with unknown scene "
+    "UID in separated mode")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file = (std::filesystem::temp_directory_path()
+                         / "gtopt_test_bdr_unknown_scene.csv")
+                            .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    ofs << "name,iteration,scene,rhs,j_up\n";
+    // Scene UID 999 does not exist
+    ofs << "bad_scene_cut,1,999,10.0,1.0\n";
+    // Scene UID 0 exists (default auto-generated scene)
+    ofs << "good_cut,1,0,20.0,2.0\n";
+  }
+
+  SDDPOptions opts;
+  opts.boundary_cuts_mode = "separated";
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_boundary_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  // Only the good_cut should be loaded; bad_scene_cut is skipped
+  CHECK(result->count == 1);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_boundary_cuts_csv with unmatched state variable "
+    "header")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file = (std::filesystem::temp_directory_path()
+                         / "gtopt_test_bdr_unmatched_svar.csv")
+                            .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    // "nonexistent_rsv" does not match any element
+    ofs << "name,iteration,scene,rhs,nonexistent_rsv\n";
+    ofs << "cut1,1,1,10.0,1.0\n";
+  }
+
+  SDDPOptions opts;
+  opts.boundary_cuts_mode = "shared";
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_boundary_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  // Cut is still loaded, but the coefficient is ignored since the
+  // column mapping is nullopt
+  CHECK(result->count == 1);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_boundary_cuts_csv with ClassName:ElementName "
+    "header")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file =
+      (std::filesystem::temp_directory_path() / "gtopt_test_bdr_class_name.csv")
+          .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    // Use "Junction:j_up" format for the header
+    ofs << "name,iteration,scene,rhs,Junction:j_up\n";
+    ofs << "cut1,1,1,10.0,1.0\n";
+  }
+
+  SDDPOptions opts;
+  opts.boundary_cuts_mode = "shared";
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_boundary_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 1);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_boundary_cuts_csv with wrong class filter in "
+    "header")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file = (std::filesystem::temp_directory_path()
+                         / "gtopt_test_bdr_wrong_class.csv")
+                            .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    // "Battery:j_up" - j_up is a Junction, not a Battery
+    ofs << "name,iteration,scene,rhs,Battery:j_up\n";
+    ofs << "cut1,1,1,10.0,1.0\n";
+  }
+
+  SDDPOptions opts;
+  opts.boundary_cuts_mode = "shared";
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_boundary_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  // The cut is loaded but the coefficient is ignored (class mismatch)
+  CHECK(result->count == 1);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_boundary_cuts_csv with zero coefficients "
+    "skipped")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file =
+      (std::filesystem::temp_directory_path() / "gtopt_test_bdr_zero_coeff.csv")
+          .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    ofs << "name,iteration,scene,rhs,j_up\n";
+    // Zero coefficient should be skipped in the row
+    ofs << "cut1,1,1,10.0,0.0\n";
+  }
+
+  SDDPOptions opts;
+  opts.boundary_cuts_mode = "shared";
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_boundary_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 1);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_boundary_cuts_csv creates alpha column on "
+    "demand")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file =
+      (std::filesystem::temp_directory_path() / "gtopt_test_bdr_alpha_col.csv")
+          .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    ofs << "name,iteration,scene,rhs,j_up\n";
+    ofs << "alpha_cut,1,1,100.0,5.0\n";
+  }
+
+  SDDPOptions opts;
+  opts.boundary_cuts_mode = "shared";
+  opts.alpha_min = -1e9;
+  opts.alpha_max = 1e9;
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  // Before loading, alpha_col should be unknown
+  const auto last_phase = PhaseIndex {
+      static_cast<Index>(planning_lp.simulation().phases().size()) - 1};
+  CHECK(states[SceneIndex {0}][last_phase].alpha_col
+        == ColIndex {unknown_index});
+
+  auto result =
+      load_boundary_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 1);
+
+  // After loading, alpha_col should be set
+  CHECK(states[SceneIndex {0}][last_phase].alpha_col
+        != ColIndex {unknown_index});
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_boundary_cuts_csv with empty body loads 0 "
+    "cuts")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file =
+      (std::filesystem::temp_directory_path() / "gtopt_test_bdr_empty_body.csv")
+          .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    ofs << "name,iteration,scene,rhs,j_up\n";
+    // No data lines
+  }
+
+  SDDPOptions opts;
+  opts.boundary_cuts_mode = "shared";
+
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_boundary_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 0);
+
+  std::filesystem::remove(tmp_file);
+}
+
+// ─── load_named_cuts_csv tests ──────────────────────────────────────────────
+
+TEST_CASE(
+    "load_named_cuts_csv returns error for nonexistent "
+    "file")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  SDDPOptions opts;
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result = load_named_cuts_csv(planning_lp,
+                                    "/tmp/gtopt_nonexistent_named.csv",
+                                    opts,
+                                    label_maker,
+                                    states);
+  CHECK_FALSE(result.has_value());
+  CHECK(result.error().code == ErrorCode::FileIOError);
+}
+
+TEST_CASE(
+    "load_named_cuts_csv rejects header with too few "
+    "columns")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file = (std::filesystem::temp_directory_path()
+                         / "gtopt_test_named_bad_header.csv")
+                            .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    // Only 4 columns, need at least 6 (name,iteration,scene,phase,rhs + 1)
+    ofs << "name,iteration,scene,phase\n";
+    ofs << "cut1,1,1,1\n";
+  }
+
+  SDDPOptions opts;
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_named_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  CHECK_FALSE(result.has_value());
+  CHECK(result.error().code == ErrorCode::InvalidInput);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_named_cuts_csv rejects header with wrong phase "
+    "column name")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file = (std::filesystem::temp_directory_path()
+                         / "gtopt_test_named_wrong_phase.csv")
+                            .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    // Column 3 should be "phase" but is "stage"
+    ofs << "name,iteration,scene,stage,rhs,j_up\n";
+    ofs << "cut1,1,1,1,10.0,1.0\n";
+  }
+
+  SDDPOptions opts;
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_named_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  CHECK_FALSE(result.has_value());
+  CHECK(result.error().code == ErrorCode::InvalidInput);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_named_cuts_csv loads cuts for specific "
+    "phases")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file =
+      (std::filesystem::temp_directory_path() / "gtopt_test_named_phases.csv")
+          .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    ofs << "name,iteration,scene,phase,rhs,j_up\n";
+    // Phase UIDs 1, 2, 3 exist in 3-phase planning
+    ofs << "cut_p1,1,1,1,10.0,1.0\n";
+    ofs << "cut_p2,1,1,2,20.0,2.0\n";
+    ofs << "cut_p3,1,1,3,30.0,3.0\n";
+  }
+
+  SDDPOptions opts;
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_named_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 3);
+
+  // Verify alpha columns were created for all phases
+  for (Index pi = 0; pi < 3; ++pi) {
+    CHECK(states[SceneIndex {0}][PhaseIndex {pi}].alpha_col
+          != ColIndex {unknown_index});
+  }
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_named_cuts_csv skips cuts with unknown phase "
+    "UID")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file = (std::filesystem::temp_directory_path()
+                         / "gtopt_test_named_unknown_phase.csv")
+                            .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    ofs << "name,iteration,scene,phase,rhs,j_up\n";
+    // Phase UID 999 does not exist
+    ofs << "bad_cut,1,1,999,10.0,1.0\n";
+    // Phase UID 1 exists
+    ofs << "good_cut,1,1,1,20.0,2.0\n";
+  }
+
+  SDDPOptions opts;
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_named_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  // Only the good_cut loaded; bad_cut skipped
+  CHECK(result->count == 1);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE("load_named_cuts_csv with empty body loads 0 cuts")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file = (std::filesystem::temp_directory_path()
+                         / "gtopt_test_named_empty_body.csv")
+                            .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    ofs << "name,iteration,scene,phase,rhs,j_up\n";
+    // No data lines
+  }
+
+  SDDPOptions opts;
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_named_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 0);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_named_cuts_csv with ClassName:ElementName "
+    "header")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file = (std::filesystem::temp_directory_path()
+                         / "gtopt_test_named_class_name.csv")
+                            .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    ofs << "name,iteration,scene,phase,rhs,Junction:j_up\n";
+    ofs << "cut1,1,1,1,10.0,1.0\n";
+  }
+
+  SDDPOptions opts;
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_named_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 1);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_named_cuts_csv with wrong class filter skips "
+    "coefficient")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file = (std::filesystem::temp_directory_path()
+                         / "gtopt_test_named_wrong_class.csv")
+                            .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    // j_up is a Junction, not a Battery
+    ofs << "name,iteration,scene,phase,rhs,Battery:j_up\n";
+    ofs << "cut1,1,1,1,10.0,1.0\n";
+  }
+
+  SDDPOptions opts;
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_named_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  // Cut is loaded but with the coefficient ignored (class mismatch)
+  CHECK(result->count == 1);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_named_cuts_csv with zero coefficient "
+    "skipped")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file = (std::filesystem::temp_directory_path()
+                         / "gtopt_test_named_zero_coeff.csv")
+                            .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    ofs << "name,iteration,scene,phase,rhs,j_up\n";
+    ofs << "cut1,1,1,1,10.0,0.0\n";
+  }
+
+  SDDPOptions opts;
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_named_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 1);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_named_cuts_csv with multiple state variable "
+    "columns")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file = (std::filesystem::temp_directory_path()
+                         / "gtopt_test_named_multi_svar.csv")
+                            .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    // j_up is a real junction (uid 1), nonexistent is not
+    ofs << "name,iteration,scene,phase,rhs,j_up,nonexistent\n";
+    ofs << "cut1,1,1,2,50.0,3.0,7.0\n";
+  }
+
+  SDDPOptions opts;
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_named_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 1);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_named_cuts_csv skips blank lines in "
+    "body")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file = (std::filesystem::temp_directory_path()
+                         / "gtopt_test_named_blank_lines.csv")
+                            .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    ofs << "name,iteration,scene,phase,rhs,j_up\n";
+    ofs << "cut1,1,1,1,10.0,1.0\n";
+    ofs << "\n";
+    ofs << "cut2,2,1,2,20.0,2.0\n";
+    ofs << "\n";
+  }
+
+  SDDPOptions opts;
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_named_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 2);
+
+  std::filesystem::remove(tmp_file);
+}
+
+TEST_CASE(
+    "load_named_cuts_csv caches per-phase column "
+    "maps")  // NOLINT
+{
+  auto planning = make_3phase_hydro_planning();
+  PlanningLP planning_lp(std::move(planning));
+
+  const auto tmp_file =
+      (std::filesystem::temp_directory_path() / "gtopt_test_named_cache.csv")
+          .string();
+
+  {
+    std::ofstream ofs(tmp_file);
+    ofs << "name,iteration,scene,phase,rhs,j_up\n";
+    // Multiple cuts for the same phase to exercise caching
+    ofs << "cut1,1,1,1,10.0,1.0\n";
+    ofs << "cut2,2,1,1,20.0,2.0\n";
+    ofs << "cut3,3,1,1,30.0,3.0\n";
+  }
+
+  SDDPOptions opts;
+  const LabelMaker label_maker(planning_lp.options());
+  auto states = make_scene_phase_states(planning_lp);
+
+  auto result =
+      load_named_cuts_csv(planning_lp, tmp_file, opts, label_maker, states);
+  REQUIRE(result.has_value());
+  CHECK(result->count == 3);
+
+  std::filesystem::remove(tmp_file);
 }


### PR DESCRIPTION
## Summary

- **Deduplicate hot-start cuts:** When loading cuts from CSV, the same cut name could appear for multiple scenes. Since `load_cuts_csv` broadcasts each cut to all scenes, this produced duplicate LP row names (e.g., `loaded_sddp_ecut_1_34_16`). Fixed by tracking `(phase, name)` pairs and skipping duplicates.
- **Iteration offset from loaded cuts:** After loading hot-start cuts (e.g., from iteration 20), the SDDP solver previously started new iterations at `iter=1`, generating cut names that collided with loaded ones. Now the solver extracts the max iteration from loaded cut names/columns and starts numbering after it.
- **`CutLoadResult` struct:** All cut load functions now return `CutLoadResult{count, max_iteration}` instead of plain `int`, enabling the solver to track the iteration offset.
- **Fix pre-existing clang-tidy warning:** Aligned `save_scene_cuts_csv` parameter name between declaration and definition.

## Test plan

- [x] All 1097 unit tests pass
- [x] clang-tidy clean on changed `.cpp` files (only pre-existing warnings in `as_label.hpp`)
- [x] clang-format applied via pre-commit hook
- [ ] Verify with a real hot-start scenario that duplicate warnings no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)