### PR TITLE
fix(plp2gtopt): update indhor_parser to ignore csv column names

### DIFF
--- a/scripts/plp2gtopt/indhor_parser.py
+++ b/scripts/plp2gtopt/indhor_parser.py
@@ -58,7 +58,7 @@ class IndhorParser:
                     self.file_path,
                     encoding=enc,
                     header=0,
-                    names=["year", "month", "day", "hour", "block"]
+                    names=["year", "month", "day", "hour", "block"],
                 )
                 break
             except UnicodeDecodeError:
@@ -68,7 +68,9 @@ class IndhorParser:
                 continue
             except ValueError as e:
                 # Catches mismatched column counts if the file format is unexpected
-                raise ValueError(f"Error parsing {self.file_path} with encoding {enc}: {e}")
+                raise ValueError(
+                    f"Error parsing {self.file_path} with encoding {enc}: {e}"
+                )
 
         if df is None:
             raise ValueError(


### PR DESCRIPTION
indhor.csv  has columns 'Año' 'Mes' 'Día' 'Hora 'Bloque'.
in order to avoid accents or encoding error, column names should be ignored.
previous version of indhor_parser expected columns 'Año' 'Mes' 'Dia' <-- (without accent) 'Hora' 'Bloque'. This raised ValueError when reading indhor.csv from Coordinador' scenarios.