### PR TITLE
feat(strong-index): from_size factories + typed numcols/numrows accessors

### DIFF
--- a/include/gtopt/linear_interface.hpp
+++ b/include/gtopt/linear_interface.hpp
@@ -529,6 +529,27 @@ public:
    */
   [[nodiscard]] size_t get_numcols() const;
 
+  /**
+   * @brief Typed row count — use instead of `RowIndex{static_cast<Index>(
+   *        li.get_numrows())}` at every call site.
+   *
+   * Narrows `size_t → Index` in exactly one place (here) so that we can
+   * later replace the conversion with a bounds-checked one without
+   * touching every caller.  Matches the typed API used across the rest
+   * of the LP layer (`add_row` → `RowIndex`, `delete_row` → `RowIndex`,
+   * …) so idiomatic call sites stay inside strong-index space.
+   */
+  [[nodiscard]] RowIndex numrows_as_index() const
+  {
+    return RowIndex {static_cast<Index>(get_numrows())};
+  }
+
+  /// See `numrows_as_index`.
+  [[nodiscard]] ColIndex numcols_as_index() const
+  {
+    return ColIndex {static_cast<Index>(get_numcols())};
+  }
+
   /// Solver backend name (e.g. "clp", "cplex", "highs").
   [[nodiscard]] std::string_view solver_name() const noexcept
   {

--- a/include/gtopt/sparse_col.hpp
+++ b/include/gtopt/sparse_col.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <limits>
+#include <ranges>
 
 #include <gtopt/basic_types.hpp>
 #include <gtopt/lp_context.hpp>
@@ -112,6 +113,27 @@ struct SparseCol
 };
 
 using ColIndex = StrongIndexType<SparseCol>;  ///< Type alias for column index
+
+/**
+ * @brief Build a `ColIndex` from the size of any sized range.
+ *
+ * Centralises the `ColIndex{static_cast<Index>(r.size())}` pattern so
+ * that callers stay in strong-index space.  Typical call sites:
+ *
+ * @code
+ *   if (col < col_index_size(col_sol)) { ... }
+ *   for (auto idx : iota_range<ColIndex>(ColIndex{0}, col_index_size(cols)))
+ * @endcode
+ *
+ * @tparam R  Any `std::ranges::sized_range`.
+ * @param  r  The range whose size should be interpreted as a column count.
+ * @return    `ColIndex{static_cast<Index>(std::ranges::size(r))}`.
+ */
+template<std::ranges::sized_range R>
+[[nodiscard]] constexpr auto col_index_size(const R& r) noexcept -> ColIndex
+{
+  return ColIndex {static_cast<Index>(std::ranges::size(r))};
+}
 
 // ── Scale-aware output helpers ───────────────────────────────────────────────
 

--- a/include/gtopt/sparse_row.hpp
+++ b/include/gtopt/sparse_row.hpp
@@ -21,6 +21,7 @@
 
 #include <cmath>  // for std::abs
 #include <limits>
+#include <ranges>
 #include <utility>  // for std::pair
 #include <vector>
 
@@ -209,5 +210,15 @@ struct SparseRow
 };
 
 using RowIndex = StrongIndexType<SparseRow>;  ///< Type alias for row index
+
+/**
+ * @brief Build a `RowIndex` from the size of any sized range.  Mirror
+ *        of `col_index_size()` — see that helper for rationale.
+ */
+template<std::ranges::sized_range R>
+[[nodiscard]] constexpr auto row_index_size(const R& r) noexcept -> RowIndex
+{
+  return RowIndex {static_cast<Index>(std::ranges::size(r))};
+}
 
 }  // namespace gtopt

--- a/test/source/test_sparse_col.cpp
+++ b/test/source/test_sparse_col.cpp
@@ -1,3 +1,6 @@
+#include <array>
+#include <vector>
+
 #include <doctest/doctest.h>
 #include <gtopt/linear_problem.hpp>
 #include <gtopt/sparse_col.hpp>
@@ -138,5 +141,27 @@ TEST_SUITE("SparseCol")
     CHECK(col2.lowb == 3.0);
     CHECK(col2.uppb == 3.0);
     CHECK(col2.is_integer == true);
+  }
+
+  TEST_CASE("col_index_size — sized-range factory")
+  {
+    // Avoids the `ColIndex{static_cast<Index>(r.size())}` boilerplate
+    // at every call site; narrowing happens in one place.
+    SUBCASE("empty container")
+    {
+      const std::vector<double> v;
+      CHECK(col_index_size(v) == ColIndex {0});
+    }
+    SUBCASE("non-empty container")
+    {
+      const std::vector<double> v(42, 0.0);
+      CHECK(col_index_size(v) == ColIndex {42});
+    }
+    SUBCASE("constexpr-friendly")
+    {
+      constexpr std::array<int, 7> arr {};
+      constexpr auto idx = col_index_size(arr);
+      static_assert(idx == ColIndex {7});
+    }
   }
 }

--- a/test/source/test_sparse_row.cpp
+++ b/test/source/test_sparse_row.cpp
@@ -1,3 +1,6 @@
+#include <array>
+#include <vector>
+
 #include <doctest/doctest.h>
 #include <gtopt/linear_problem.hpp>
 #include <gtopt/sparse_row.hpp>
@@ -261,5 +264,25 @@ TEST_SUITE("SparseRow")
     CHECK(values[0] == 0.0);
     CHECK(values[1] == 1e-15);
     CHECK(values[2] == 1.0);
+  }
+
+  TEST_CASE("row_index_size — sized-range factory")
+  {
+    SUBCASE("empty container")
+    {
+      const std::vector<double> v;
+      CHECK(row_index_size(v) == RowIndex {0});
+    }
+    SUBCASE("non-empty container")
+    {
+      const std::vector<double> v(128, 0.0);
+      CHECK(row_index_size(v) == RowIndex {128});
+    }
+    SUBCASE("constexpr-friendly")
+    {
+      constexpr std::array<int, 3> arr {};
+      constexpr auto idx = row_index_size(arr);
+      static_assert(idx == RowIndex {3});
+    }
   }
 }


### PR DESCRIPTION
## Summary

Second PR of the strong-type hygiene series (first was #400).  Adds four small helpers — no call-site migration in this PR.

- `sparse_col.hpp::col_index_size(R)` — free helper over any `std::ranges::sized_range`; returns `ColIndex`.
- `sparse_row.hpp::row_index_size(R)` — mirror helper returning `RowIndex`.
- `linear_interface.hpp::numcols_as_index()` / `numrows_as_index()` — thin wrappers over `get_numcols()` / `get_numrows()`, narrowing `size_t → Index` in one place.

The motivating call sites (migrated in a follow-up PR, gated on the other agent's SDDP work landing first):

- `sddp_method.cpp:517,536` — `ColIndex{static_cast<Index>(col_sol.size())}` → `col_index_size(col_sol)`.
- `sddp_method.cpp:1406` — `static_cast<Index>(m_iteration_offset_) + max_iterations` → `next(m_iteration_offset_, max_iterations)`.
- `sddp_cut_store.cpp:213,214` — `static_cast<Index>(li.get_numrows())` → `li.numrows_as_index()`.
- `sddp_state_io.cpp:81,84` — same pattern for `get_numcols()`.

Keeping that migration in a separate PR avoids conflicts with the SDDP agent's in-flight work.

## Test plan

- [x] `ctest -j20`: 2541/2541 pass.
- [x] `./test/gtoptTests -tc="*col_index_size*,*row_index_size*"`: 2 cases / 4 assertions pass.
- [x] `constexpr` subcases verify compile-time evaluation (via `static_assert`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)