### PR TITLE
feat(sddp): iteration-index helpers + advance / relative

### DIFF
--- a/include/gtopt/iteration.hpp
+++ b/include/gtopt/iteration.hpp
@@ -64,12 +64,45 @@ using IterationIndex = StrongIndexType<IterationTag>;
   return ++iteration_index;
 }
 
+/// @brief Advance an iteration index by `n` steps, returning a new
+///        `IterationIndex`.  Replaces the
+///        `IterationIndex{static_cast<Index>(offset) + n}` pattern used
+///        to compute an iteration budget horizon.
+///
+/// Example: `next(m_iteration_offset_, m_options_.max_iterations)`
+/// returns the exclusive upper bound of a training run that starts
+/// at `m_iteration_offset_` and takes `max_iterations` iterations.
+[[nodiscard]] constexpr auto next(IterationIndex iteration_index,
+                                  Index n) noexcept -> IterationIndex
+{
+  // Underlying strong::arithmetic supports `+ Index`, preserving the
+  // strong type without any static_cast at the call site.
+  return iteration_index + IterationIndex {n};
+}
+
 /// @brief Previous iteration index (iteration_index - 1), preserving strong
 /// type.
 [[nodiscard]] constexpr auto previous(IterationIndex iteration_index) noexcept
     -> IterationIndex
 {
   return --iteration_index;
+}
+
+/// @brief Signed distance of `cur` from a base `offset`, as a plain
+///        `Index` offset (not wrapped in `IterationIndex` — because the
+///        difference of two positional indices is not itself a
+///        positional index, it's a count).
+///
+/// Replaces the `iteration_index - m_iteration_offset_` idiom sprinkled
+/// across SDDP iteration management (relative-iteration logging,
+/// `min_iter` clamping, `max_async_spread` checks).  Having a single
+/// helper means future tweaks (e.g. bounds-checking on negative
+/// differences) land in one place.
+[[nodiscard]] constexpr auto iteration_relative(IterationIndex cur,
+                                                IterationIndex offset) noexcept
+    -> Index
+{
+  return static_cast<Index>(cur) - static_cast<Index>(offset);
 }
 
 }  // namespace gtopt

--- a/test/source/test_iteration.cpp
+++ b/test/source/test_iteration.cpp
@@ -113,3 +113,47 @@ TEST_CASE("Iteration array for SDDP control")  // NOLINT
   // Tenth iteration: skip update again
   CHECK(iterations[3].should_update_lp() == false);
 }
+
+TEST_CASE("IterationIndex helpers — next/previous/advance/relative")  // NOLINT
+{
+  SUBCASE("next advances by 1")
+  {
+    constexpr auto a = IterationIndex {7};
+    static_assert(next(a) == IterationIndex {8});
+    CHECK(next(IterationIndex {0}) == IterationIndex {1});
+  }
+
+  SUBCASE("previous retreats by 1")
+  {
+    constexpr auto a = IterationIndex {7};
+    static_assert(previous(a) == IterationIndex {6});
+    CHECK(previous(IterationIndex {5}) == IterationIndex {4});
+  }
+
+  SUBCASE("next(idx, n) advances by n — replaces offset + max_iter pattern")
+  {
+    constexpr auto base = IterationIndex {10};
+    static_assert(next(base, 0) == IterationIndex {10});
+    static_assert(next(base, 5) == IterationIndex {15});
+    // Used as an exclusive upper bound: training runs [base, base + n)
+    CHECK(next(base, 20) == IterationIndex {30});
+  }
+
+  SUBCASE("iteration_relative returns a plain Index offset")
+  {
+    constexpr auto cur = IterationIndex {12};
+    constexpr auto offset = IterationIndex {3};
+    static_assert(iteration_relative(cur, offset) == Index {9});
+    // Same iteration: relative = 0
+    CHECK(iteration_relative(cur, cur) == Index {0});
+    // Negative when cur < offset — preserved without underflow surprises
+    CHECK(iteration_relative(IterationIndex {1}, IterationIndex {4})
+          == Index {-3});
+  }
+
+  SUBCASE("next(idx, n) composes with next(idx) — same result")
+  {
+    constexpr auto a = IterationIndex {42};
+    static_assert(next(next(a)) == next(a, 2));
+  }
+}


### PR DESCRIPTION
## Summary

Third PR of the strong-type hygiene series (after #400, #401).  Adds two `iteration.hpp` helpers — no call-site migration in this PR.

- `next(IterationIndex, Index n)` — advances by `n`, returning a new `IterationIndex`.  Replaces the `IterationIndex{static_cast<Index>(offset) + max_iter}` pattern (e.g. `sddp_method.cpp:1406`).
- `iteration_relative(cur, offset) -> Index` — single-source for the repeated `iteration_index - m_iteration_offset_` idiom (`sddp_iteration.cpp:124/132/210/995`).  Returns a plain `Index` because the difference of two positional indices is a count, not a positional index.

Kept out of this PR to avoid merge conflicts with the other agent's in-flight SDDP work:

- All call-site migrations in `source/sddp_*.cpp`.

## Test plan

- [x] `ctest -j20`: 2540/2540 pass.
- [x] `./test/gtoptTests -tc="IterationIndex helpers*"`: 5 assertions pass.
- [x] `static_assert` subcases prove `constexpr` evaluability and the `next(next(a)) == next(a, 2)` composition identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)