### PR TITLE
ci(lint): strong-type hygiene guardrails (warnings-only)

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -142,3 +142,42 @@ jobs:
           # Always exit 0 — violations are warnings, not errors
           exit 0
 
+  check-strong-types:
+    # Forbid re-introduction of the `static_cast<Uid>(...)`,
+    # `StrongIndex{static_cast<Index>(...size())}`, and raw `±1` arithmetic
+    # on positional strong indices that the strong-type hygiene PRs
+    # eliminated.  Runs the repo-local `tools/lint_strong_types.sh`.
+    #
+    # Marked as warnings-only (always exits 0) while the call-site
+    # migration PRs are in flight — master still carries a handful of
+    # hits that those PRs will clear.  Flip `exit 0` → `exit $EXIT_CODE`
+    # in a follow-up PR once the cleanup is complete.
+    if: "!contains(github.event.head_commit.message, 'style: auto-apply')"
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: run strong-type hygiene lint
+        run: |
+          set +e
+          LINT_OUT=$(bash tools/lint_strong_types.sh 2>&1)
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "$LINT_OUT"
+            echo "::warning title=strong-type-lint::Strong-type hygiene violations detected. See tools/lint_strong_types.sh for the ruleset."
+            echo "## ⚠️ strong-type-lint: violations detected" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "$LINT_OUT" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          else
+            echo "$LINT_OUT"
+            echo "## ✅ strong-type-lint: no violations" >> $GITHUB_STEP_SUMMARY
+          fi
+          # Warnings-only while call-site migration is in flight.
+          exit 0
+

--- a/tools/lint_strong_types.sh
+++ b/tools/lint_strong_types.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# tools/lint_strong_types.sh
+#
+# Forbid re-introducing the strong-type hygiene issues that the
+# `cleanup(format)` / `feat(strong-index)` / `feat(sddp)` PRs eliminated.
+#
+# Runs a handful of regex patterns over `source/` and `include/gtopt/`.  Each
+# pattern has a per-file allow-list for the handful of legitimate uses the
+# review identified.
+#
+# Exits 0 when every pattern has either zero hits or only allow-listed hits;
+# exits 1 (with a human-readable summary on stderr) otherwise.
+#
+# Uses POSIX `grep -E` — no ripgrep dependency, so it runs on any CI runner
+# or developer machine without extra install steps.
+# ─────────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+# Resolve repo root so the script is location-independent.
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+SEARCH_PATHS=(source include/gtopt)
+
+# Portable recursive regex search: scan every file under each path, emit
+# `path:line:match` for hits.  `grep -rEn` is universal across GNU and BSD
+# greps; we pass `--include='*.cpp' --include='*.hpp'` to keep it C++-only.
+run_grep() {
+  local pattern="$1"
+  shift
+  grep --include='*.cpp' --include='*.hpp' --recursive --line-number \
+    --extended-regexp "$pattern" "$@" 2>/dev/null || true
+}
+
+fail=0
+
+# ── Rule 1: no redundant `static_cast<Uid>(...)` ─────────────────────────────
+# Allow-list:
+#   - source/inertia_provision_lp.cpp  (parses Uid from a string via std::stoi)
+#   - source/reserve_provision_lp.cpp  (same)
+# `UidOf<Tag>` ships with a `std::formatter` specialisation, so the cast is
+# never needed when feeding a strong Uid into `std::format` / spdlog / logs.
+uid_hits=$(run_grep 'static_cast<Uid>\(' "${SEARCH_PATHS[@]}" \
+           | grep -vE '^source/(inertia|reserve)_provision_lp\.cpp:' \
+           || true)
+if [[ -n "$uid_hits" ]]; then
+  echo "❌ redundant static_cast<Uid>(…) found (UidOf<Tag> is already formattable):" >&2
+  echo "$uid_hits" >&2
+  echo "   fix: drop the cast — std::format, spdlog, etc. handle UidOf<Tag> directly." >&2
+  echo "" >&2
+  fail=1
+fi
+
+# ── Rule 2: no `StrongIndex{static_cast<Index>(... .size())}` ────────────────
+# Use the sized-range factories (`col_index_size`, `row_index_size`) or the
+# typed accessors (`LinearInterface::numcols_as_index()` / `numrows_as_index()`)
+# instead.  Caught pattern covers every strong-index family.
+idx_ctor=$(run_grep \
+  '(SceneIndex|PhaseIndex|StageIndex|BlockIndex|ScenarioIndex|IterationIndex|ColIndex|RowIndex)[[:space:]]*\{[[:space:]]*static_cast<Index>[[:space:]]*\([^)]*\.[[:space:]]*size[[:space:]]*\(' \
+  "${SEARCH_PATHS[@]}" || true)
+if [[ -n "$idx_ctor" ]]; then
+  echo "❌ StrongIndex{static_cast<Index>(container.size())} found:" >&2
+  echo "$idx_ctor" >&2
+  echo "   fix: use col_index_size(...) / row_index_size(...) from sparse_col.hpp / sparse_row.hpp," >&2
+  echo "        or li.numcols_as_index() / li.numrows_as_index() from linear_interface.hpp." >&2
+  echo "" >&2
+  fail=1
+fi
+
+# ── Rule 3: no raw `+ 1` / `- 1` arithmetic on positional strong indices ────
+# Positional indices (scene, phase, stage, scenario, block, iteration) step
+# through `next()` / `previous()` helpers so the strong type stays visible and
+# the arithmetic is concept-checked.  `ColIndex` / `RowIndex` stay off the
+# list — they keep full arithmetic for row/column bookkeeping.
+pos_arith=$(run_grep \
+  '(SceneIndex|PhaseIndex|StageIndex|BlockIndex|ScenarioIndex|IterationIndex)[[:space:]]*[+-][[:space:]]*1([^0-9]|$)' \
+  "${SEARCH_PATHS[@]}" || true)
+if [[ -n "$pos_arith" ]]; then
+  echo "❌ raw ±1 arithmetic on a positional strong index:" >&2
+  echo "$pos_arith" >&2
+  echo "   fix: use next(idx) / previous(idx) from the corresponding header." >&2
+  echo "" >&2
+  fail=1
+fi
+
+if [[ $fail -ne 0 ]]; then
+  echo "lint_strong_types.sh: strong-type hygiene violations above ↑" >&2
+  exit 1
+fi
+
+echo "lint_strong_types.sh: ok"


### PR DESCRIPTION
## Summary

Fourth PR of the strong-type hygiene series (after #400, #401, #402).  Adds `tools/lint_strong_types.sh` and wires it into `style.yml` as a `check-strong-types` job.

Three regex rules:

1. `static_cast<Uid>(x)` — forbidden because `UidOf<Tag>` ships `std::formatter`.  Allow-list: `inertia_provision_lp.cpp`, `reserve_provision_lp.cpp` (legitimate `std::stoi → Uid` parsing).
2. `StrongIndex{static_cast<Index>(container.size())}` — replaced by `col_index_size(...)` / `row_index_size(...)` / `li.numcols_as_index()`.
3. Raw `±1` arithmetic on positional strong indices (scene, phase, stage, scenario, block, iteration) — replaced by `next()` / `previous()`.  `ColIndex` / `RowIndex` stay off the list — they keep full arithmetic for row/column bookkeeping.

## Rollout

The job is **warnings-only** (`exit 0` even on failure) in this PR.  Master still carries a handful of hits that will be cleared by the SDDP call-site migration PRs (follow-ups).  A final one-line follow-up will flip `exit 0` → `exit $EXIT_CODE` to make the check hard-gating.

## Test plan

- [x] `bash tools/lint_strong_types.sh` on current master → exits 1 with an annotated list of the exact hits the review identified (5 in `output_context.cpp`, 2 in `sddp_method.cpp`, 2 in `linear_problem.hpp`).
- [x] Script is portable: uses `git` + `grep -E` only, no ripgrep dependency.
- [ ] Style workflow green on CI (job reports warnings via `::warning` annotations, step summary, and `$GITHUB_STEP_SUMMARY`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)