### PR TITLE
cleanup(sddp): adopt strong-index helpers, drop manual Index casts

### DIFF
--- a/include/gtopt/iteration.hpp
+++ b/include/gtopt/iteration.hpp
@@ -64,12 +64,45 @@ using IterationIndex = StrongIndexType<IterationTag>;
   return ++iteration_index;
 }
 
+/// @brief Advance an iteration index by `n` steps, returning a new
+///        `IterationIndex`.  Replaces the
+///        `IterationIndex{static_cast<Index>(offset) + n}` pattern used
+///        to compute an iteration budget horizon.
+///
+/// Example: `next(m_iteration_offset_, m_options_.max_iterations)`
+/// returns the exclusive upper bound of a training run that starts
+/// at `m_iteration_offset_` and takes `max_iterations` iterations.
+[[nodiscard]] constexpr auto next(IterationIndex iteration_index,
+                                  Index n) noexcept -> IterationIndex
+{
+  // Underlying strong::arithmetic supports `+ Index`, preserving the
+  // strong type without any static_cast at the call site.
+  return iteration_index + IterationIndex {n};
+}
+
 /// @brief Previous iteration index (iteration_index - 1), preserving strong
 /// type.
 [[nodiscard]] constexpr auto previous(IterationIndex iteration_index) noexcept
     -> IterationIndex
 {
   return --iteration_index;
+}
+
+/// @brief Signed distance of `cur` from a base `offset`, as a plain
+///        `Index` offset (not wrapped in `IterationIndex` — because the
+///        difference of two positional indices is not itself a
+///        positional index, it's a count).
+///
+/// Replaces the `iteration_index - m_iteration_offset_` idiom sprinkled
+/// across SDDP iteration management (relative-iteration logging,
+/// `min_iter` clamping, `max_async_spread` checks).  Having a single
+/// helper means future tweaks (e.g. bounds-checking on negative
+/// differences) land in one place.
+[[nodiscard]] constexpr auto iteration_relative(IterationIndex cur,
+                                                IterationIndex offset) noexcept
+    -> Index
+{
+  return static_cast<Index>(cur) - static_cast<Index>(offset);
 }
 
 }  // namespace gtopt

--- a/include/gtopt/linear_interface.hpp
+++ b/include/gtopt/linear_interface.hpp
@@ -529,6 +529,27 @@ public:
    */
   [[nodiscard]] size_t get_numcols() const;
 
+  /**
+   * @brief Typed row count — use instead of `RowIndex{static_cast<Index>(
+   *        li.get_numrows())}` at every call site.
+   *
+   * Narrows `size_t → Index` in exactly one place (here) so that we can
+   * later replace the conversion with a bounds-checked one without
+   * touching every caller.  Matches the typed API used across the rest
+   * of the LP layer (`add_row` → `RowIndex`, `delete_row` → `RowIndex`,
+   * …) so idiomatic call sites stay inside strong-index space.
+   */
+  [[nodiscard]] RowIndex numrows_as_index() const
+  {
+    return RowIndex {static_cast<Index>(get_numrows())};
+  }
+
+  /// See `numrows_as_index`.
+  [[nodiscard]] ColIndex numcols_as_index() const
+  {
+    return ColIndex {static_cast<Index>(get_numcols())};
+  }
+
   /// Solver backend name (e.g. "clp", "cplex", "highs").
   [[nodiscard]] std::string_view solver_name() const noexcept
   {

--- a/include/gtopt/sparse_col.hpp
+++ b/include/gtopt/sparse_col.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <limits>
+#include <ranges>
 
 #include <gtopt/basic_types.hpp>
 #include <gtopt/lp_context.hpp>
@@ -112,6 +113,27 @@ struct SparseCol
 };
 
 using ColIndex = StrongIndexType<SparseCol>;  ///< Type alias for column index
+
+/**
+ * @brief Build a `ColIndex` from the size of any sized range.
+ *
+ * Centralises the `ColIndex{static_cast<Index>(r.size())}` pattern so
+ * that callers stay in strong-index space.  Typical call sites:
+ *
+ * @code
+ *   if (col < col_index_size(col_sol)) { ... }
+ *   for (auto idx : iota_range<ColIndex>(ColIndex{0}, col_index_size(cols)))
+ * @endcode
+ *
+ * @tparam R  Any `std::ranges::sized_range`.
+ * @param  r  The range whose size should be interpreted as a column count.
+ * @return    `ColIndex{static_cast<Index>(std::ranges::size(r))}`.
+ */
+template<std::ranges::sized_range R>
+[[nodiscard]] constexpr auto col_index_size(const R& r) noexcept -> ColIndex
+{
+  return ColIndex {static_cast<Index>(std::ranges::size(r))};
+}
 
 // ── Scale-aware output helpers ───────────────────────────────────────────────
 

--- a/include/gtopt/sparse_row.hpp
+++ b/include/gtopt/sparse_row.hpp
@@ -21,6 +21,7 @@
 
 #include <cmath>  // for std::abs
 #include <limits>
+#include <ranges>
 #include <utility>  // for std::pair
 #include <vector>
 
@@ -209,5 +210,15 @@ struct SparseRow
 };
 
 using RowIndex = StrongIndexType<SparseRow>;  ///< Type alias for row index
+
+/**
+ * @brief Build a `RowIndex` from the size of any sized range.  Mirror
+ *        of `col_index_size()` — see that helper for rationale.
+ */
+template<std::ranges::sized_range R>
+[[nodiscard]] constexpr auto row_index_size(const R& r) noexcept -> RowIndex
+{
+  return RowIndex {static_cast<Index>(std::ranges::size(r))};
+}
 
 }  // namespace gtopt

--- a/source/sddp_iteration.cpp
+++ b/source/sddp_iteration.cpp
@@ -121,7 +121,7 @@ auto SDDPMethod::solve(const SolverOptions& lp_opts)
             "SDDP Iter [i{}]: stop requested, halting after {}"
             " iterations",
             iteration_index,
-            iteration_index - m_iteration_offset_);
+            iteration_relative(iteration_index, m_iteration_offset_));
         break;
       }
 
@@ -129,7 +129,7 @@ auto SDDPMethod::solve(const SolverOptions& lp_opts)
       // confusing (e.g. "=== 0/0 ===" for max_iterations=1).
       SPDLOG_INFO("SDDP Iter [i{}]: === starting ({} of {}) ===",
                   iteration_index,
-                  (iteration_index - m_iteration_offset_) + 1,
+                  iteration_relative(iteration_index, m_iteration_offset_) + 1,
                   m_options_.max_iterations);
 
       SDDPIterationResult ir {
@@ -207,7 +207,7 @@ auto SDDPMethod::solve(const SolverOptions& lp_opts)
           && m_options_.cut_prune_interval > 0)
       {
         const auto iteration_offset_diff =
-            iteration_index - m_iteration_offset_;
+            iteration_relative(iteration_index, m_iteration_offset_);
         if (iteration_offset_diff > 0
             && iteration_offset_diff % m_options_.cut_prune_interval == 0)
         {
@@ -974,7 +974,8 @@ auto SDDPMethod::solve_async(SDDPWorkPool& pool,
                 sp.current_iteration_index,
                 scene_uid(scene),
                 sp.scene_converged,
-                sp.current_iteration_index - m_iteration_offset_,
+                iteration_relative(sp.current_iteration_index,
+                                   m_iteration_offset_),
                 sp.upper_bound,
                 scenes_still_active,
                 num_scenes);

--- a/source/sddp_method.cpp
+++ b/source/sddp_method.cpp
@@ -514,7 +514,7 @@ void SDDPMethod::capture_state_variable_values(
   for (const auto& [key, svar] : sim.state_variables(scene_index, phase_index))
   {
     const auto col = svar.col();
-    if (col < ColIndex {static_cast<Index>(col_sol.size())}) {
+    if (col < col_index_size(col_sol)) {
       svar.set_col_sol(col_sol[col]);
     }
   }
@@ -533,7 +533,7 @@ void SDDPMethod::capture_state_variable_values(
       continue;
     }
     const auto dep = link.dependent_col;
-    if (dep < ColIndex {static_cast<Index>(reduced_costs.size())}) {
+    if (dep < col_index_size(reduced_costs)) {
       link.state_var->set_reduced_cost(reduced_costs[dep]);
     }
   }
@@ -628,7 +628,7 @@ bool SDDPMethod::should_dispatch_update_lp(IterationIndex iteration_index) const
     }
     // Default: apply global skip count using relative iteration
     const auto skip = planning_lp().options().sddp_update_lp_skip();
-    const auto rel = iteration_index - m_iteration_offset_;
+    const auto rel = iteration_relative(iteration_index, m_iteration_offset_);
     if (skip > 0 && rel > 0 && (rel % (skip + 1)) != 0) {
       return false;
     }
@@ -1402,13 +1402,20 @@ auto SDDPMethod::initialize_solver() -> std::expected<void, Error>
 
   // ── Build preallocated iteration vector ───────────────────────────────────
   {
+    // `next(offset, n)` returns the exclusive upper bound of a training
+    // run starting at `m_iteration_offset_` and taking `max_iterations`
+    // steps — the strong-index analogue of `offset + n` kept strongly
+    // typed so the iota_range and array subscripts below don't need
+    // any cast back from `Index`.
     const auto total_iterations =
-        static_cast<Index>(m_iteration_offset_) + m_options_.max_iterations;
+        next(m_iteration_offset_, m_options_.max_iterations);
     m_iterations_.resize(total_iterations);
-    for (const auto iidx : iota_range<IterationIndex>(0, total_iterations)) {
+    for (const auto iidx :
+         iota_range<IterationIndex>(IterationIndex {0}, total_iterations))
+    {
       m_iterations_[iidx] = IterationLP {
           Iteration {
-              .index = static_cast<Index>(iidx),
+              .index = value_of(iidx),
           },
           iidx,
       };

--- a/test/source/test_iteration.cpp
+++ b/test/source/test_iteration.cpp
@@ -113,3 +113,47 @@ TEST_CASE("Iteration array for SDDP control")  // NOLINT
   // Tenth iteration: skip update again
   CHECK(iterations[3].should_update_lp() == false);
 }
+
+TEST_CASE("IterationIndex helpers — next/previous/advance/relative")  // NOLINT
+{
+  SUBCASE("next advances by 1")
+  {
+    constexpr auto a = IterationIndex {7};
+    static_assert(next(a) == IterationIndex {8});
+    CHECK(next(IterationIndex {0}) == IterationIndex {1});
+  }
+
+  SUBCASE("previous retreats by 1")
+  {
+    constexpr auto a = IterationIndex {7};
+    static_assert(previous(a) == IterationIndex {6});
+    CHECK(previous(IterationIndex {5}) == IterationIndex {4});
+  }
+
+  SUBCASE("next(idx, n) advances by n — replaces offset + max_iter pattern")
+  {
+    constexpr auto base = IterationIndex {10};
+    static_assert(next(base, 0) == IterationIndex {10});
+    static_assert(next(base, 5) == IterationIndex {15});
+    // Used as an exclusive upper bound: training runs [base, base + n)
+    CHECK(next(base, 20) == IterationIndex {30});
+  }
+
+  SUBCASE("iteration_relative returns a plain Index offset")
+  {
+    constexpr auto cur = IterationIndex {12};
+    constexpr auto offset = IterationIndex {3};
+    static_assert(iteration_relative(cur, offset) == Index {9});
+    // Same iteration: relative = 0
+    CHECK(iteration_relative(cur, cur) == Index {0});
+    // Negative when cur < offset — preserved without underflow surprises
+    CHECK(iteration_relative(IterationIndex {1}, IterationIndex {4})
+          == Index {-3});
+  }
+
+  SUBCASE("next(idx, n) composes with next(idx) — same result")
+  {
+    constexpr auto a = IterationIndex {42};
+    static_assert(next(next(a)) == next(a, 2));
+  }
+}

--- a/test/source/test_sparse_col.cpp
+++ b/test/source/test_sparse_col.cpp
@@ -1,3 +1,6 @@
+#include <array>
+#include <vector>
+
 #include <doctest/doctest.h>
 #include <gtopt/linear_problem.hpp>
 #include <gtopt/sparse_col.hpp>
@@ -138,5 +141,27 @@ TEST_SUITE("SparseCol")
     CHECK(col2.lowb == 3.0);
     CHECK(col2.uppb == 3.0);
     CHECK(col2.is_integer == true);
+  }
+
+  TEST_CASE("col_index_size — sized-range factory")
+  {
+    // Avoids the `ColIndex{static_cast<Index>(r.size())}` boilerplate
+    // at every call site; narrowing happens in one place.
+    SUBCASE("empty container")
+    {
+      const std::vector<double> v;
+      CHECK(col_index_size(v) == ColIndex {0});
+    }
+    SUBCASE("non-empty container")
+    {
+      const std::vector<double> v(42, 0.0);
+      CHECK(col_index_size(v) == ColIndex {42});
+    }
+    SUBCASE("constexpr-friendly")
+    {
+      constexpr std::array<int, 7> arr {};
+      constexpr auto idx = col_index_size(arr);
+      static_assert(idx == ColIndex {7});
+    }
   }
 }

--- a/test/source/test_sparse_row.cpp
+++ b/test/source/test_sparse_row.cpp
@@ -1,3 +1,6 @@
+#include <array>
+#include <vector>
+
 #include <doctest/doctest.h>
 #include <gtopt/linear_problem.hpp>
 #include <gtopt/sparse_row.hpp>
@@ -261,5 +264,25 @@ TEST_SUITE("SparseRow")
     CHECK(values[0] == 0.0);
     CHECK(values[1] == 1e-15);
     CHECK(values[2] == 1.0);
+  }
+
+  TEST_CASE("row_index_size — sized-range factory")
+  {
+    SUBCASE("empty container")
+    {
+      const std::vector<double> v;
+      CHECK(row_index_size(v) == RowIndex {0});
+    }
+    SUBCASE("non-empty container")
+    {
+      const std::vector<double> v(128, 0.0);
+      CHECK(row_index_size(v) == RowIndex {128});
+    }
+    SUBCASE("constexpr-friendly")
+    {
+      constexpr std::array<int, 3> arr {};
+      constexpr auto idx = row_index_size(arr);
+      static_assert(idx == RowIndex {3});
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fifth PR of the strong-type hygiene series (after #400, #401, #402, #403).  Migrates `sddp_method.cpp` and `sddp_iteration.cpp` call sites to the helpers from #401 and #402.

**Depends on #401 and #402 landing first** — this PR's branch base carries a local merge of both so CI can build.  Rebase is clean once the helpers merge.

## Changes

### `sddp_method.cpp`
- State-var `col_sol` / `reduced_cost` bound checks: `ColIndex{static_cast<Index>(container.size())}` → `col_index_size(container)`.
- `initialize_solver` iteration preallocation: `static_cast<Index>(offset) + max_iter` → `next(m_iteration_offset_, max_iterations)` returning `IterationIndex`.  `iota_range` bounds stay strongly typed; the `.index = static_cast<Index>(iidx)` becomes `.index = value_of(iidx)`.
- `should_dispatch_update_lp`: `iteration_index - m_iteration_offset_` → `iteration_relative(...)`.

### `sddp_iteration.cpp`
- 4 sites migrated to `iteration_relative(...)`: stop-requested log, iteration banner, cut-pruning interval, async per-scene iter count.

Two `SceneIndex{static_cast<Index>(si_sz)}` sites (`sddp_iteration.cpp:551, :1208`) are *not* migrated because the loop counter is a raw `size_t` indexing a `std::vector` (not a `.size()` expression), so the lint regex deliberately does not match them.  A future PR can re-type `sim_before_scene_sizes` to a `StrongIndexVector<SceneIndex, std::size_t>` to clean those up.

## Test plan

- [x] `ctest -j20`: 2542/2542 pass.
- [x] `tools/lint_strong_types.sh` no longer flags the 4 migrated sites (2 `ColIndex` + 2 `iteration_index - offset`).
- [ ] CI green on all solvers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)