### PR TITLE
fix(ci): invariance on kappa + Python CascadeLevel field sync

### DIFF
--- a/scripts/igtopt/tests/test_template_builder.py
+++ b/scripts/igtopt/tests/test_template_builder.py
@@ -396,7 +396,14 @@ class TestCascadeOptionKeys:
 
         block = match.group()
         cpp_fields = set(re.findall(r'json_\w+<"(\w+)"', block))
-        expected = {"uid", "name", "model_options", "sddp_options", "transition"}
+        expected = {
+            "uid",
+            "name",
+            "active",
+            "model_options",
+            "sddp_options",
+            "transition",
+        }
         assert expected == cpp_fields, (
             f"CascadeLevel fields mismatch: expected {expected}, got {cpp_fields}"
         )

--- a/source/linear_interface.cpp
+++ b/source/linear_interface.cpp
@@ -111,7 +111,7 @@ void LinearInterface::cache_and_release()
   // dropped only by an explicit `release_backend()`, never automatically
   // inside resolve/initial_solve.  Callers that need sol/rc must read
   // them after resolve and before release_backend.
-  if (m_low_memory_mode_ == LowMemoryMode::off || m_backend_released_) {
+  if (m_backend_released_) {
     return;
   }
 
@@ -120,8 +120,12 @@ void LinearInterface::cache_and_release()
   }
 
   // Cache post-solve scalars so that get_status() / get_obj_value() /
-  // get_kappa() / get_numrows() / get_numcols() still return sensible
-  // values after a later release_backend().
+  // get_kappa() / get_numrows() / get_numcols() return the same
+  // solve-time values regardless of `low_memory_mode` — the live
+  // backend is free to recompute (or silently drop) kappa on every
+  // query, which breaks `solution.csv` invariance between `off` and
+  // `compress` modes (observed on CLP via OSI: `backend->get_kappa()`
+  // returned 5e-18 at solve-time but 0 on a later re-query).
   m_cached_obj_value_ = m_backend_->obj_value();
   m_cached_kappa_ = m_backend_->get_kappa();
   m_cached_numrows_ = get_numrows();
@@ -1496,8 +1500,16 @@ int LinearInterface::get_status() const
 
 std::optional<double> LinearInterface::get_kappa() const
 {
-  if (m_backend_released_) {
+  // Prefer the solve-time cache when available so a later backend
+  // re-query (which some backends answer with a recomputed / stale
+  // value) cannot perturb downstream readers.  Falls through to the
+  // live backend only when the cache hasn't been populated yet
+  // (pre-solve reads, LP under construction).
+  if (m_cached_kappa_.has_value()) {
     return m_cached_kappa_;
+  }
+  if (m_backend_released_) {
+    return std::nullopt;
   }
   return m_backend_->get_kappa();
 }


### PR DESCRIPTION
## Summary

Fixes the three Ubuntu CI failures on master (seen on PR #400's run):

- **Tests #2048/#2049** — `SDDPMethod — pure sim pass / multi-iter training output invariance across low_memory modes`: `solution.csv` diverged on the `kappa` column between `off` and `compress`.  Root cause: under `off`, `cache_and_release` early-returned so `m_cached_kappa_` stayed empty.  Every call to `get_kappa()` went through `backend().get_kappa()`; CLP/OSI (the CI backend) computes kappa lazily and a re-query returned `0` at write-time even though the solve-time value was `5e-18`.  Under `compress`, the solve-time value was frozen in the cache and replayed.  Fix: always cache post-solve scalars (drop the `off` early-return), and make `get_kappa()` prefer the cache when populated (falls back to the live backend only for pre-solve reads).
- **Test #2907** — `scripts-igtopt-unit::TestCascadeOptionKeys::test_cascade_level_fields_sync_with_cpp`: hard-coded the pre-`active` field set.  PR #400 (and its predecessor `feat(cascade,sddp): active levels, write_out invariance across low_memory modes`) added `active` to `CascadeLevel`.  Fix: add `"active"` to the expected set.

## Test plan

- [x] `ctest -j20`: **2544/2544** pass locally, including both invariance cases.
- [x] `./gtoptTests -tc="SDDPMethod*invariance*"`: 2/2 cases, 38/38 assertions pass.
- [x] `ruff format scripts/` — no changes.
- [x] `ruff check igtopt` — "All checks passed".
- [x] `pylint --jobs=0 igtopt/tests/test_template_builder.py` — exit 0.
- [x] `mypy --ignore-missing-imports igtopt/tests/test_template_builder.py` — no issues.
- [x] `pytest igtopt/tests/test_template_builder.py::TestCascadeOptionKeys` — 5/5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)