### PR TITLE
cleanup(tidy): address 30 clang-tidy hits across source/ and headers

### DIFF
--- a/include/gtopt/inertia_provision_lp.hpp
+++ b/include/gtopt/inertia_provision_lp.hpp
@@ -34,7 +34,7 @@ public:
 
   using Base = ObjectLP<InertiaProvision>;
 
-  explicit InertiaProvisionLP(const InertiaProvision& inertia_provision,
+  explicit InertiaProvisionLP(const InertiaProvision& ip,
                               const InputContext& ic);
 
   [[nodiscard]] constexpr auto&& inertia_provision(this auto&& self) noexcept

--- a/include/gtopt/linear_interface.hpp
+++ b/include/gtopt/linear_interface.hpp
@@ -920,6 +920,12 @@ public:
    * When row scales are empty, returns raw values unchanged.
    * @return ScaledView over solver row lower bounds
    */
+  // `backend()` may call `ensure_backend()`, which can throw on a
+  // rebuild failure — a programmer-bug path we intentionally allow to
+  // terminate instead of unwinding partial LP state.  Keep `noexcept`
+  // on the API surface and suppress tidy; NOLINT lines are narrower
+  // than dropping the guarantee from every caller.
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   [[nodiscard]] ScaledView get_row_low() const noexcept
   {
     const auto n = get_numrows();
@@ -934,6 +940,7 @@ public:
    * @brief Gets physical upper bounds for all constraint rows.
    * @return ScaledView over solver row upper bounds
    */
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   [[nodiscard]] ScaledView get_row_upp() const noexcept
   {
     const auto n = get_numrows();
@@ -978,6 +985,7 @@ public:
    * returns raw values unchanged.
    * @return ScaledView over solver column lower bounds
    */
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   [[nodiscard]] ScaledView get_col_low() const noexcept
   {
     const auto n = get_numcols();
@@ -995,6 +1003,7 @@ public:
    * `LP_bound × col_scale` on the fly.
    * @return ScaledView over solver column upper bounds
    */
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   [[nodiscard]] ScaledView get_col_upp() const noexcept
   {
     const auto n = get_numcols();
@@ -1033,6 +1042,7 @@ public:
    * release.
    * @return ScaledView over solver solution memory
    */
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   [[nodiscard]] ScaledView get_col_sol() const noexcept
   {
     const auto n = get_numcols();
@@ -1072,6 +1082,7 @@ public:
    * Precondition: backend must be live.
    * @return ScaledView over solver reduced-cost memory
    */
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   [[nodiscard]] ScaledView get_col_cost() const noexcept
   {
     const auto n = get_numcols();
@@ -1447,6 +1458,12 @@ private:
       interface->backend().set_log_filename(filename, level);
     }
 
+    // `backend().clear_log_filename()` delegates to `ensure_backend()`
+    // + `SolverBackend::clear_log_filename`; both can theoretically
+    // throw on a rebuild/solver-specific failure.  We intentionally
+    // keep the implicit-noexcept destructor — a failure here is a
+    // programmer bug that should terminate rather than unwind.
+    // NOLINTNEXTLINE(bugprone-exception-escape)
     ~LogFileGuard() { interface->backend().clear_log_filename(); }
   };
 

--- a/include/gtopt/sddp_cut_io.hpp
+++ b/include/gtopt/sddp_cut_io.hpp
@@ -161,8 +161,8 @@ class PlanningLP;
     const std::string& filepath,
     const SDDPOptions& options,
     const LabelMaker& label_maker,
-    StrongIndexVector<SceneIndex,
-                      StrongIndexVector<PhaseIndex, PhaseStateInfo>>&
+    const StrongIndexVector<SceneIndex,
+                            StrongIndexVector<PhaseIndex, PhaseStateInfo>>&
         scene_phase_states) -> std::expected<CutLoadResult, Error>;
 
 /// Load named-variable cuts from a CSV file with a `phase` column.
@@ -183,8 +183,8 @@ class PlanningLP;
     const std::string& filepath,
     const SDDPOptions& options,
     const LabelMaker& label_maker,
-    StrongIndexVector<SceneIndex,
-                      StrongIndexVector<PhaseIndex, PhaseStateInfo>>&
+    const StrongIndexVector<SceneIndex,
+                            StrongIndexVector<PhaseIndex, PhaseStateInfo>>&
         scene_phase_states) -> std::expected<CutLoadResult, Error>;
 
 // ─── JSON save/load functions ───────────────────────────────────────────────

--- a/source/hardware_info.cpp
+++ b/source/hardware_info.cpp
@@ -56,6 +56,9 @@ namespace gtopt
           return -1;
         }
         int val = -1;
+        // `std::from_chars` requires raw pointer bounds; pointer
+        // arithmetic is inherent to its contract.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         std::from_chars(buf.data(), buf.data() + buf.size(), val);
         return val;
       };
@@ -77,8 +80,12 @@ namespace gtopt
           std::thread::hardware_concurrency() / count);
       return count;
     }
-  } catch (...) {
-    // Fall through to default
+  } catch (const std::exception& ex) {
+    // Any sysfs read / parse failure falls back to
+    // `std::thread::hardware_concurrency()` below.  Trace the reason so
+    // operators investigating unexpected core counts can spot the cause
+    // without needing to reproduce the probe failure.
+    SPDLOG_TRACE("Physical-core probe failed: {}", ex.what());
   }
 #endif
 

--- a/source/linear_interface.cpp
+++ b/source/linear_interface.cpp
@@ -638,6 +638,14 @@ ColIndex LinearInterface::add_col(const std::string& name,
                                   double collb,
                                   double colub)
 {
+  // Ensure the backend is live before we touch it.  Under
+  // `LowMemoryMode::compress` / `rebuild`, `m_backend_` may have been
+  // released; `ensure_backend()` lazily reconstructs it.  The assert
+  // doubles as a hint to clang-static-analyzer, which otherwise can't
+  // see through the rebuild callback and flags every subsequent
+  // `m_backend_->…` as a potential null dereference.
+  ensure_backend();
+  assert(m_backend_ != nullptr);
   const auto index = m_backend_->get_num_cols();
   const auto col = ColIndex {index};
   check_name_unique(m_col_names_,
@@ -1016,12 +1024,14 @@ void LinearInterface::set_obj_coeff(const ColIndex index, const double value)
 void LinearInterface::set_col_low_raw(const ColIndex index, const double value)
 {
   ensure_backend();
+  assert(m_backend_ != nullptr);
   m_backend_->set_col_lower(static_cast<int>(index), normalize_bound(value));
 }
 
 void LinearInterface::set_col_upp_raw(const ColIndex index, const double value)
 {
   ensure_backend();
+  assert(m_backend_ != nullptr);
   m_backend_->set_col_upper(static_cast<int>(index), normalize_bound(value));
 }
 
@@ -1058,17 +1068,24 @@ void LinearInterface::set_col(const ColIndex index, const double physical_value)
 void LinearInterface::set_row_low_raw(const RowIndex index, const double value)
 {
   ensure_backend();
+  assert(m_backend_ != nullptr);
   m_backend_->set_row_lower(static_cast<int>(index), normalize_bound(value));
 }
 
 void LinearInterface::set_row_upp_raw(const RowIndex index, const double value)
 {
   ensure_backend();
+  assert(m_backend_ != nullptr);
   m_backend_->set_row_upper(static_cast<int>(index), normalize_bound(value));
 }
 
 void LinearInterface::set_rhs_raw(const RowIndex row, const double rhs)
 {
+  // Match the rest of the raw-mutation setters above: ensure the
+  // backend is live before delegating.  Without this, a mutation
+  // issued after `release_backend()` would null-deref `m_backend_`
+  // (flagged by clang-analyzer-core.CallAndMessage).
+  ensure_backend();
   m_backend_->set_row_bounds(static_cast<int>(row), rhs, rhs);
 }
 

--- a/source/planning_lp.cpp
+++ b/source/planning_lp.cpp
@@ -472,7 +472,7 @@ auto PlanningLP::create_systems(System& system,
   // user constraints, the map stays empty and add_ampl_variable is a
   // no-op — saving allocation/hashing overhead.
   if (!system.user_constraint_array.empty()) {
-    simulation.set_need_ampl_variables(true);
+    simulation.set_need_ampl_variables(/*v=*/true);
   }
 
   // Note: AMPL element-name and compound registries are populated by
@@ -718,6 +718,12 @@ auto PlanningLP::create_systems(System& system,
       PlanningLP::phase_systems_t phase_systems;
       phase_systems.reserve(phases.size());
       for (auto& slot : build_buf[scene_index]) {
+        // `build_buf` is guaranteed populated by the build pool before
+        // we reach this merge step — every slot must hold a value.  A
+        // missing slot indicates a silent pool-task failure and is a
+        // crash-worthy programmer bug, so let `.value()`'s exception
+        // propagate.
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         phase_systems.emplace_back(std::move(slot).value());
       }
       tighten_scene_phase_links(phase_systems, simulation);
@@ -826,6 +832,9 @@ auto PlanningLP::create_systems(System& system,
         PlanningLP::phase_systems_t phase_systems;
         phase_systems.reserve(phases.size());
         for (auto& slot : build_buf[scene_index]) {
+          // See full-parallel merge above — same invariant, same reason
+          // for accepting `.value()` to throw on a pool-task bug.
+          // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
           phase_systems.emplace_back(std::move(slot).value());
         }
         tighten_scene_phase_links(phase_systems, simulation);

--- a/source/sddp_cut_io.cpp
+++ b/source/sddp_cut_io.cpp
@@ -823,7 +823,7 @@ void write_cut_coefficients_unscaled(std::ostream& ofs,
     const std::string& filepath,
     const SDDPOptions& options,
     [[maybe_unused]] const LabelMaker& label_maker,
-    [[maybe_unused]] StrongIndexVector<
+    [[maybe_unused]] const StrongIndexVector<
         SceneIndex,
         StrongIndexVector<PhaseIndex, PhaseStateInfo>>& scene_phase_states)
     -> std::expected<CutLoadResult, Error>
@@ -1183,17 +1183,17 @@ void write_cut_coefficients_unscaled(std::ostream& ofs,
             planning_lp.system(scene_index, last_phase).linear_interface();
         std::istringstream coeff_ss(rc.coeff_line);
         std::string token;
-        for (std::size_t ci = 0; ci < header_col_map.size(); ++ci) {
+        for (const auto& col_opt : header_col_map) {
           if (!std::getline(coeff_ss, token, ',')) {
             break;
           }
-          if (!header_col_map[ci].has_value()) {
+          if (!col_opt.has_value()) {
             continue;  // skip_coeff: drop missing coefficient
           }
           const auto coeff = std::stod(token);
           if (coeff != 0.0) {
-            const auto scale = li.get_col_scale(*header_col_map[ci]);
-            row[*header_col_map[ci]] = -coeff * scale * bc_discount / scale_obj;
+            const auto scale = li.get_col_scale(*col_opt);
+            row[*col_opt] = -coeff * scale * bc_discount / scale_obj;
           }
         }
 
@@ -1239,7 +1239,7 @@ void write_cut_coefficients_unscaled(std::ostream& ofs,
     const std::string& filepath,
     const SDDPOptions& options,
     [[maybe_unused]] const LabelMaker& label_maker,
-    [[maybe_unused]] StrongIndexVector<
+    [[maybe_unused]] const StrongIndexVector<
         SceneIndex,
         StrongIndexVector<PhaseIndex, PhaseStateInfo>>& scene_phase_states)
     -> std::expected<CutLoadResult, Error>
@@ -1468,8 +1468,11 @@ void write_cut_coefficients_unscaled(std::ostream& ofs,
                 .uid = sddp_alpha_uid,
                 .col_name = sddp_alpha_col_name,
                 .class_name = sddp_alpha_class_name,
-                .lp_key = {.scene_index = scene_index,
-                           .phase_index = phase_index},
+                .lp_key =
+                    {
+                        .scene_index = scene_index,
+                        .phase_index = phase_index,
+                    },
             },
             alpha_col,
             0.0,
@@ -1538,11 +1541,10 @@ void write_cut_coefficients_unscaled(std::ostream& ofs,
             planning_lp.system(scene_index, phase_index).linear_interface();
         std::istringstream coeff_ss(remainder);
         std::string ctok;
-        for (std::size_t ci = 0; ci < col_map.size(); ++ci) {
+        for (const auto& col_opt : col_map) {
           if (!std::getline(coeff_ss, ctok, ',')) {
             break;
           }
-          const auto& col_opt = col_map[ci];
           if (!col_opt.has_value()) {
             continue;
           }

--- a/source/sddp_state_io.cpp
+++ b/source/sddp_state_io.cpp
@@ -190,7 +190,10 @@ auto load_state_csv(PlanningLP& planning_lp, const std::string& filepath)
           });
           if (!label.empty()) {
             rmap.emplace(std::move(label),
-                         ColResolveEntry {sv.col(), sv.var_scale()});
+                         ColResolveEntry {
+                             .col = sv.col(),
+                             .scale = sv.var_scale(),
+                         });
           }
         }
         resolve_maps.push_back(std::move(rmap));
@@ -203,7 +206,7 @@ auto load_state_csv(PlanningLP& planning_lp, const std::string& filepath)
                                 PhaseIndex pi) -> std::optional<size_t>
     {
       const auto idx =
-          static_cast<size_t>(si) * nphases + static_cast<size_t>(pi);
+          (static_cast<size_t>(si) * nphases) + static_cast<size_t>(pi);
       if (idx < entries.size() && entries[idx].scene_index == si
           && entries[idx].phase_index == pi)
       {

--- a/source/system_lp.cpp
+++ b/source/system_lp.cpp
@@ -852,16 +852,16 @@ void SystemLP::rebuild_in_place()
         , active(activate)
     {
       if (active) {
-        ctx.set_rebuild_pass(true);
+        ctx.set_rebuild_pass(/*v=*/true);
       }
     }
     ~RebuildPassGuard()
     {
       if (active) {
-        ctx.set_rebuild_pass(false);
+        ctx.set_rebuild_pass(/*v=*/false);
       }
     }
-  } guard {system_context(), m_fingerprint_was_set_};
+  } const guard {system_context(), m_fingerprint_was_set_};
 
   auto [flat_lp, fingerprint, label_maker] =
       flatten_from_collections(collections(),
@@ -936,10 +936,10 @@ void SystemLP::rebuild_collections_if_needed()
     explicit RebuildPassGuard(SystemContext& c)
         : ctx(c)
     {
-      ctx.set_rebuild_pass(true);
+      ctx.set_rebuild_pass(/*v=*/true);
     }
-    ~RebuildPassGuard() { ctx.set_rebuild_pass(false); }
-  } guard {system_context()};
+    ~RebuildPassGuard() { ctx.set_rebuild_pass(/*v=*/false); }
+  } const guard {system_context()};
 
   // Discard the produced FlatLinearProblem; we only care about the
   // `add_to_lp` side effects on the XLP wrappers inside


### PR DESCRIPTION
## Summary

Clears the 30 clang-tidy warnings flagged by `run-clang-tidy -p build source/*.cpp` on master (see strong-type-hygiene review).  Final state: **0 real diagnostics** (85 PCH-mismatch notes remain, environmental — GCC-built PCH can't be read by clang-tidy).

### Low-risk, mechanical fixes

| file | warning | fix |
|---|---|---|
| `hardware_info.cpp` | `pointer-arithmetic` + `empty-catch` | NOLINT on `std::from_chars`; log `exception::what()` on fallback |
| `system_lp.cpp` ×4 | `const-correctness` + `argument-comment` | `const RebuildPassGuard guard`; `set_rebuild_pass(/*v=*/true|false)` |
| `planning_lp.cpp` ×3 | `argument-comment` + `unchecked-optional-access` | literal arg comment; explicit NOLINT on build-pool invariant slots |
| `sddp_state_io.cpp` ×2 | `use-designated-initializers` + `math-parens` | designated init + `(s * nphases) + pi` parens |
| `sddp_cut_io.cpp` ×5 | `const-correctness` + `loop-convert` + `trailing-comma` | `const StrongIndexVector<…>&` (header + .cpp); `for (auto& col_opt : col_map)`; trailing comma |
| `inertia_provision_lp.hpp` | `inconsistent-declaration-parameter-name` | header param renamed `ip` to match `.cpp` |

### noexcept vs. `backend()` throw — NOLINT kept

`LinearInterface::get_{row,col}_{low,upp,sol,cost}()` and `~LogFileGuard` transitively call `backend()`, which can theoretically throw on a rebuild failure.  We intentionally keep `noexcept` on the API surface — a rebuild failure is a programmer bug we accept terminating on — and suppress the 7 sites with inline rationales.

### Null-deref analyzer hits — latent bug fixed

`add_col` and `set_rhs_raw` called `m_backend_->…` without first calling `ensure_backend()`; under `LowMemoryMode::compress` / `rebuild` with a released backend, that would null-deref.  Fixed both.  Added `assert(m_backend_ != nullptr)` on the five raw-mutation setters to narrow the analyzer's abstract domain (it can't see through the rebuild callback).

## Test plan

- [x] `ctest -j20`: **2544/2544** pass.
- [x] `run-clang-tidy -p build source/*.cpp`: **0 non-PCH diagnostics** (down from 30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)