### PR TITLE
feat(planning): hour_block_map schema + cascade write_out delegate

### DIFF
--- a/include/gtopt/json/json_planning.hpp
+++ b/include/gtopt/json/json_planning.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <gtopt/json/json_basic_types.hpp>
 #include <gtopt/json/json_options.hpp>
 #include <gtopt/json/json_simulation.hpp>
 #include <gtopt/json/json_system.hpp>
@@ -19,20 +20,40 @@
 namespace daw::json
 {
 
+using gtopt::HourBlockEntry;
 using gtopt::Planning;
 using gtopt::PlanningOptions;
 
 template<>
+struct json_data_contract<HourBlockEntry>
+{
+  using type = json_member_list<json_number<"hour", Uid>,
+                                json_number<"stage", Uid>,
+                                json_number<"block", Uid>>;
+
+  [[nodiscard]] constexpr static auto to_json_data(HourBlockEntry const& entry)
+  {
+    return std::forward_as_tuple(entry.hour, entry.stage, entry.block);
+  }
+};
+
+template<>
 struct json_data_contract<Planning>
 {
-  using type = json_member_list<json_class_null<"options", PlanningOptions>,
-                                json_class_null<"simulation", Simulation>,
-                                json_class_null<"system", System>>;
+  using type = json_member_list<
+      json_class_null<"options", PlanningOptions>,
+      json_class_null<"simulation", Simulation>,
+      json_class_null<"system", System>,
+      json_array_null<"hour_block_map",
+                      std::optional<gtopt::Array<HourBlockEntry>>,
+                      HourBlockEntry>>;
 
   [[nodiscard]] constexpr static auto to_json_data(Planning const& planning)
   {
-    return std::forward_as_tuple(
-        planning.options, planning.simulation, planning.system);
+    return std::forward_as_tuple(planning.options,
+                                 planning.simulation,
+                                 planning.system,
+                                 planning.hour_block_map);
   }
 };
 }  // namespace daw::json

--- a/include/gtopt/linear_problem.hpp
+++ b/include/gtopt/linear_problem.hpp
@@ -213,7 +213,7 @@ public:
   [[nodiscard]]
   constexpr ColIndex add_col(SparseCol&& col)
   {
-    const auto index = ColIndex {static_cast<Index>(cols.size())};
+    const auto index = col_index_size(cols);
 
     if (col.is_integer) {
       ++colints;
@@ -249,7 +249,7 @@ public:
   [[nodiscard]]
   constexpr RowIndex add_row(SparseRow&& row)
   {
-    const auto index = RowIndex {static_cast<Index>(rows.size())};
+    const auto index = row_index_size(rows);
 
     // Normalize DblMax bounds to the configured infinity.
     normalize_bound(row.lowb);

--- a/include/gtopt/planning.hpp
+++ b/include/gtopt/planning.hpp
@@ -19,6 +19,25 @@ namespace gtopt
 {
 
 /**
+ * @brief Hour → (stage, block) mapping persisted alongside the planning
+ *        JSON so Python post-processing tools (`ts2gtopt`,
+ *        `reconstruct_output_hours`) can expand block-level solver
+ *        output back to an hourly series.
+ *
+ * The solver itself does not consume this data — it is a pure
+ * passthrough stored in the planning JSON.  Declaring it in the schema
+ * lets `StrictParsePolicy` accept planning files produced by case
+ * writers that emit the map, without opening the door to arbitrary
+ * unknown members.
+ */
+struct HourBlockEntry
+{
+  Uid hour {};
+  Uid stage {};
+  Uid block {};
+};
+
+/**
  * @brief Represents a complete power planning model
  */
 struct Planning
@@ -26,6 +45,11 @@ struct Planning
   PlanningOptions options {};
   Simulation simulation {};
   System system {};
+  /// Optional hour→(stage, block) mapping for downstream hourly
+  /// reconstruction; not used by the solver, but accepted in the JSON
+  /// schema so strict-parse cases from `ts2gtopt` pass.  See
+  /// `scripts/ts2gtopt/ts2gtopt.py::build_hour_block_map`.
+  std::optional<Array<HourBlockEntry>> hour_block_map {};
 
   /**
    * @brief Merges another planning object into this one
@@ -44,6 +68,9 @@ struct Planning
     options.merge(std::move(plan.options));
     simulation.merge(std::move(plan.simulation));
     system.merge(std::move(plan.system));
+    if (plan.hour_block_map.has_value()) {
+      hour_block_map = std::move(plan.hour_block_map);
+    }
 
     auto _ = std::move(plan);
   }

--- a/include/gtopt/planning_lp.hpp
+++ b/include/gtopt/planning_lp.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -205,9 +206,33 @@ public:
   void build_all_lps_eagerly();
 
   /**
-   * @brief Writes solution output (implementation-defined destination)
+   * @brief Writes solution output (implementation-defined destination).
+   *
+   * When a write-out delegate has been installed via
+   * `set_output_delegate()` (used by the cascade solver to hand back
+   * the final level's LP), this call is forwarded to the delegate and
+   * writes the delegate's systems, not this instance's.  Without the
+   * delegate, the cascade's mid-loop `release_cells()` would leave
+   * the caller PlanningLP with an empty system grid and the final
+   * level's LP would die unused.
    */
   void write_out();
+
+  /**
+   * @brief Install a surrogate PlanningLP whose systems provide the
+   *        solution data for `write_out()`.
+   *
+   * Intended for the cascade solver: the final-level LP lives in the
+   * `CascadePlanningMethod` owned-LPs vector, which is destroyed when
+   * `PlanningLP::resolve()` returns.  Before returning, the cascade
+   * transfers ownership of the final level's LP here so that its
+   * populated systems remain reachable for output writing.
+   *
+   * The delegate is destroyed when this PlanningLP is destroyed (the
+   * destructor is defined out-of-line so the incomplete-type
+   * `unique_ptr<PlanningLP>` member compiles cleanly).
+   */
+  void set_output_delegate(std::unique_ptr<PlanningLP> delegate) noexcept;
 
   /**
    * @brief Release the per-(scene, phase) LP cells and their solver
@@ -306,6 +331,19 @@ private:
 
   scene_phase_systems_t m_systems_;
   SddpSummary m_sddp_summary_ {};
+
+  /// Surrogate PlanningLP whose systems provide `write_out()` data
+  /// when set (see `set_output_delegate`).  nullptr in the common
+  /// path; populated by cascade at end of `resolve()` when the final
+  /// level built its own LP.  Declared last so it is destroyed first,
+  /// before this instance's simulation/options it may reference.
+  std::unique_ptr<PlanningLP> m_output_delegate_ {};
+
+public:
+  /// Out-of-line to allow `std::unique_ptr<PlanningLP>` as a member
+  /// of `PlanningLP` itself — requires the type to be complete at the
+  /// destructor's definition point, which is the `.cpp`.
+  ~PlanningLP() noexcept;
 };
 
 }  // namespace gtopt

--- a/scripts/ts2gtopt/tests/test_bat4b_annual.py
+++ b/scripts/ts2gtopt/tests/test_bat4b_annual.py
@@ -988,9 +988,19 @@ class TestGtoptEndToEnd:
         assert rc == 0, f"gtopt crashed: {stderr}"
         out = tmp_path / "case" / "output"
         assert (out / "solution.csv").exists(), "solution.csv not found"
-        assert (out / "Demand" / "fail_sol.csv").exists(), "fail_sol.csv not found"
-        assert (out / "Generator" / "generation_sol.csv").exists(), (
-            "generation_sol.csv not found"
+        # CSV shards are suffixed `_s<scene>_p<phase>` in the current
+        # output format; accept any sharded file whose stem starts
+        # with the variable name.
+        demand_csvs = list((out / "Demand").glob("fail_sol*.csv"))
+        assert demand_csvs, (
+            "Demand/fail_sol[*].csv not found; "
+            f"Demand dir contents: {[p.name for p in (out / 'Demand').iterdir()]}"
+        )
+        gen_csvs = list((out / "Generator").glob("generation_sol*.csv"))
+        assert gen_csvs, (
+            "Generator/generation_sol[*].csv not found; "
+            f"Generator dir contents: "
+            f"{[p.name for p in (out / 'Generator').iterdir()]}"
         )
 
     @pytest.mark.integration

--- a/source/cascade_method.cpp
+++ b/source/cascade_method.cpp
@@ -748,6 +748,33 @@ auto CascadePlanningMethod::solve(PlanningLP& planning_lp,
     }
   }
 
+  // ── Transfer the final level's LP to the caller for write_out ──
+  // If the final active level built its own PlanningLP (i.e. the
+  // caller's cells were released at a prior level→level cleanup, so
+  // `planning_lp.systems()` is now empty), that LP lives in
+  // `m_owned_lps_` and would be destroyed together with this
+  // CascadePlanningMethod instance.  Without this transfer,
+  // `gtopt_lp_runner` would call `planning_lp.write_out()` on an
+  // empty system grid and emit only `planning.json` — solution.csv
+  // stays header-only and element parquets are never written.
+  //
+  // Hand the owned LP over to the caller via the new output-delegate
+  // channel so `write_out()` forwards to it, producing the full
+  // per-(scene, phase) output.
+  if (current_lp != nullptr && current_lp != &planning_lp) {
+    auto it = std::ranges::find_if(m_owned_lps_,
+                                   [current_lp](const auto& p)
+                                   { return p.get() == current_lp; });
+    if (it != m_owned_lps_.end()) {
+      auto owned = std::move(*it);
+      m_owned_lps_.erase(it);
+      planning_lp.set_output_delegate(std::move(owned));
+      SPDLOG_INFO(
+          "Cascade: transferred final-level LP to caller as write_out "
+          "delegate");
+    }
+  }
+
   const bool converged =
       !m_all_results_.empty() && m_all_results_.back().converged;
 

--- a/source/planning_lp.cpp
+++ b/source/planning_lp.cpp
@@ -972,8 +972,27 @@ void PlanningLP::build_all_lps_eagerly()
   SPDLOG_INFO("  Eager LP build done in {:.3f}s", elapsed);
 }
 
+PlanningLP::~PlanningLP() noexcept = default;
+
+void PlanningLP::set_output_delegate(
+    std::unique_ptr<PlanningLP> delegate) noexcept
+{
+  m_output_delegate_ = std::move(delegate);
+}
+
 void PlanningLP::write_out()
 {
+  // Cascade hand-off: when a non-level-0 cascade pass transferred
+  // ownership of the final-level LP here (see
+  // `CascadePlanningMethod::solve`), our own `m_systems_` is empty
+  // (released at the level 0→1 cleanup) and the delegate holds the
+  // populated grid.  Forward the call so `solution.csv` + element
+  // parquets come from the level that actually solved.
+  if (m_output_delegate_) {
+    m_output_delegate_->write_out();
+    return;
+  }
+
   const auto num_scenes = std::ssize(m_systems_);
   const auto num_phases =
       num_scenes > 0 ? std::ssize(m_systems_.front()) : std::ptrdiff_t {0};

--- a/source/planning_lp.cpp
+++ b/source/planning_lp.cpp
@@ -980,6 +980,14 @@ void PlanningLP::set_output_delegate(
   m_output_delegate_ = std::move(delegate);
 }
 
+// `write_out` calls its delegate's `write_out` (see below); clang-tidy
+// flags that as a recursive call chain.  `set_output_delegate` is
+// only called by cascade with an owned LP that itself has no delegate
+// installed, so the recursion depth is at most 1 — but the invariant
+// is not expressible in the type system.  Suppress at the function
+// level since the warning is attached to the whole function, not the
+// specific call.
+// NOLINTNEXTLINE(misc-no-recursion)
 void PlanningLP::write_out()
 {
   // Cascade hand-off: when a non-level-0 cascade pass transferred

--- a/source/system_lp.cpp
+++ b/source/system_lp.cpp
@@ -1174,8 +1174,8 @@ void SystemLP::write_out()
       "SystemLP::write_out [scene={} phase={}]: "
       "rebuild_coll={:.1f}ms, OutputContext={:.1f}ms, "
       "visit_elements={:.1f}ms, oc.write={:.1f}ms, total={:.1f}ms",
-      static_cast<Uid>(scene().uid()),
-      static_cast<Uid>(phase().uid()),
+      scene().uid(),
+      phase().uid(),
       std::chrono::duration<double, std::milli>(t_rebuild - t_start).count(),
       std::chrono::duration<double, std::milli>(t_oc - t_rebuild).count(),
       std::chrono::duration<double, std::milli>(t_visit - t_oc).count(),

--- a/test/source/test_cascade_integration.cpp
+++ b/test/source/test_cascade_integration.cpp
@@ -1148,10 +1148,15 @@ TEST_CASE(
   auto result = solver.solve(planning_lp, lp_opts);
 
   REQUIRE(result.has_value());
-  // Level 0 reused caller's PlanningLP → only level 1 owned.
-  CHECK(solver.owned_lps_count() == 1);
-  // Caller's LP cells were released at the level-0 → level-1 boundary
-  // so the two levels never hold solver backends simultaneously.
+  // Level 0 reused caller's PlanningLP.  Level 1 built its own LP;
+  // `solve()` then transferred it to `planning_lp` as the write_out
+  // delegate so `write_out()` finds populated systems when this
+  // solver is destroyed.  The owned-LPs vector is therefore empty
+  // after a successful solve (see
+  // `CascadePlanningMethod::solve` → `planning_lp.set_output_delegate`).
+  CHECK(solver.owned_lps_count() == 0);
+  // Caller's own LP cells were released at the level-0 → level-1
+  // boundary; the delegate now carries the final-level systems.
   CHECK(planning_lp.systems().empty());
 }
 
@@ -1209,7 +1214,10 @@ TEST_CASE("Cascade rebuilds level 0 PlanningLP when model overrides are set")
 
   REQUIRE(result.has_value());
   // Level 0 had model overrides → a fresh LP was built and owned.
-  CHECK(solver.owned_lps_count() == 1);
+  // After solve(), the final-level LP is transferred to the caller
+  // as the write_out delegate (see `CascadePlanningMethod::solve`),
+  // so the owned-LPs vector ends up empty.
+  CHECK(solver.owned_lps_count() == 0);
 }
 
 }  // anonymous namespace

--- a/tools/lint_strong_types.sh
+++ b/tools/lint_strong_types.sh
@@ -27,11 +27,22 @@ SEARCH_PATHS=(source include/gtopt)
 # Portable recursive regex search: scan every file under each path, emit
 # `path:line:match` for hits.  `grep -rEn` is universal across GNU and BSD
 # greps; we pass `--include='*.cpp' --include='*.hpp'` to keep it C++-only.
+#
+# Comment filter: grep's output is `path:line:content`.  Drop hits whose
+# `content` is either
+#   * a C++ single-line comment (`//…`) — filter `content` starting with `//`,
+#   * a Doxygen / block comment continuation (`* …`), OR
+#   * any occurrence where the match is preceded by `//` on the same line.
+# This prevents the patterns below from firing on doc-block examples that
+# literally mention the anti-pattern being flagged (e.g. sparse_col.hpp's
+# `col_index_size` docstring referencing `ColIndex{static_cast<Index>(r.size())}`).
 run_grep() {
   local pattern="$1"
   shift
   grep --include='*.cpp' --include='*.hpp' --recursive --line-number \
-    --extended-regexp "$pattern" "$@" 2>/dev/null || true
+    --extended-regexp "$pattern" "$@" 2>/dev/null \
+    | grep -v -E '^[^:]+:[0-9]+:[[:space:]]*(//|\*([[:space:]]|$|/))' \
+    || true
 }
 
 fail=0


### PR DESCRIPTION
## Summary

Follow-up on the integration-test audit.  Two extensions so end-to-end suites line up with the current C++ binary again.

### 1. `hour_block_map` in Planning JSON

`scripts/ts2gtopt/cases/bat4b_annual.py::write_bat4b_case` emits a top-level `"hour_block_map"` array alongside `options`/`simulation`/`system`.  The solver doesn't consume it — it's metadata for Python post-processing to reconstruct hourly series from block-level output.  Under `StrictParsePolicy` the unknown member was rejected and gtopt exited 2.

Add a proper, strongly-typed slot on `Planning`:

- `HourBlockEntry { Uid hour, stage, block }`.
- `Planning::hour_block_map: std::optional<Array<HourBlockEntry>>`.
- JSON contract with `json_array_null<"hour_block_map", ...>` so the field is absent/empty/populated.

### 2. Cascade write_out delegate (→ populated `solution.csv`)

`plp2gtopt/tests/test_integration_solver.py::test_hydro_4b_cascade_gtopt_solve` saw `status=None` because `solution.csv` was header-only.  Root cause: cascade's level 0→1 cleanup calls `planning_lp.release_cells()`, levels 1..N build their own LPs inside `m_owned_lps_`, then `solve()` returns and the method (including the final-level LP) is destroyed — `planning_lp.write_out()` iterates an empty grid.

Fix: hand the final-level LP to the caller as a write-out delegate.

- `PlanningLP::set_output_delegate(std::unique_ptr<PlanningLP>)` + new `m_output_delegate_` member; `write_out()` forwards to the delegate when present.  Destructor moved out-of-line so the unique_ptr-to-self compiles.
- `CascadePlanningMethod::solve`: after the level loop, move the owning ptr out of `m_owned_lps_` into the caller's delegate slot.

Test invariants updated: `owned_lps_count() == 0` after solve.

### Minor

- `test_gtopt_output_files_exist` previously expected unsharded `fail_sol.csv`, but the output format always shards as `fail_sol_s<N>_p<M>.csv`.  Updated to glob for any matching shard.

## Verification

- `ctest -j20` unit + integration builds: **2548/2548 + 358/358** pass.
- `pytest -n auto` on `ts2gtopt/` / `plp2gtopt/` / touched `igtopt/` tests: all related cases pass (the 1 remaining igtopt failure is `test_cascade_level_fields_sync_with_cpp`, fixed by PR #406).
- ruff format (no change), ruff check clean, pylint exit 0 on the touched Python file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)