### PR TITLE
fix(ci): pin GTOPT_SOLVER=clp for Ubuntu ctest run

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -170,6 +170,17 @@ jobs:
         run: |
           set -o pipefail
           cd build
+          # Pin the active LP solver to CLP so that:
+          #   - the SDDP validator's per-solver golden lookup picks
+          #     `golden_iter*_clp.json` (see tools/validate_sddp_output.py),
+          #   - gtopt's auto-priority resolver deterministically uses CLP
+          #     regardless of which other COIN-OR plugins got built on the
+          #     runner (CBC occasionally loads first and hits different
+          #     degenerate optima).
+          # Removing the export here would require the validator to
+          # auto-detect the solver from solver_status.json — only
+          # produced for iter>0 runs, so not a drop-in replacement.
+          export GTOPT_SOLVER=clp
           # --build-config is only meaningful for multi-config generators
           # (Ninja Multi-Config, Visual Studio); ignored by single-config
           # Ninja/Make runs, which is what this workflow uses.  Left here


### PR DESCRIPTION
## Summary

Finishes the CI-un-red work from PR #409.  That PR added per-solver golden variants (`golden_iter*_clp.json`) and made the validator pick them via `\$GTOPT_SOLVER`, but the Ubuntu workflow never exported the variable — so the validator kept using the CPLEX-tuned shared golden against CLP output and the 7 `e2e_sddp_hydro_3phase_*_sddp_validate` tests still failed.

One-line fix: `export GTOPT_SOLVER=clp` before ctest in `.github/workflows/ubuntu.yml`.

## Test plan

- [ ] Ubuntu workflow on this PR reaches the `test` step and the 7 `e2e_sddp_hydro_3phase_*_sddp_validate` tests pass (they passed locally in PR #409 with the env var set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)