### PR TITLE
fix(test): explicit MIP solver so CI's GTOPT_SOLVER=clp pin can't downgrade 4 MIP tests

### DIFF
--- a/test/source/test_commitment.cpp
+++ b/test/source/test_commitment.cpp
@@ -2848,6 +2848,23 @@ TEST_CASE(  // NOLINT
   LpMatrixOptions flat_opts;
   flat_opts.col_with_names = true;
   flat_opts.col_with_name_map = true;
+  // Pick the first MIP-capable solver explicitly so we don't fall through
+  // to the GTOPT_SOLVER env override (which CI pins to "clp" — LP-only).
+  // Defensive: skip if no MIP solver was found, even though
+  // has_mip_solver() returned true above (guards against an inconsistency
+  // between has_mip_solver() and supports_mip()).
+  for (const auto& name : reg.available_solvers()) {
+    if (reg.supports_mip(name)) {
+      flat_opts.solver_name = name;
+      break;
+    }
+  }
+  if (flat_opts.solver_name.empty()) {
+    MESSAGE(
+        "Skipping MIP test — supports_mip() returned false for "
+        "every loaded solver despite has_mip_solver()=true");
+    return;
+  }
 
   SimulationLP simulation_lp(simulation, options);
   SystemLP system_lp(system, simulation_lp, flat_opts);

--- a/test/source/test_generator.cpp
+++ b/test/source/test_generator.cpp
@@ -591,7 +591,26 @@ TEST_CASE("GeneratorLP — integer_expmod MIP gives integer expansion modules")
   popts.model_options.demand_fail_cost = 10000.0;
   const PlanningOptionsLP options(popts);
   SimulationLP simulation_lp(simulation, options);
-  SystemLP system_lp(system, simulation_lp);
+
+  // Pick the first MIP-capable solver explicitly so we don't fall
+  // through to the GTOPT_SOLVER env override (CI pins to "clp" —
+  // LP-only).  Defensive: skip if no MIP solver was found, even
+  // though has_mip_solver() returned true above (guards against an
+  // inconsistency between has_mip_solver() and supports_mip()).
+  LpMatrixOptions flat_opts;
+  for (const auto& name : reg.available_solvers()) {
+    if (reg.supports_mip(name)) {
+      flat_opts.solver_name = name;
+      break;
+    }
+  }
+  if (flat_opts.solver_name.empty()) {
+    MESSAGE(
+        "Skipping MIP test — supports_mip() returned false for "
+        "every loaded solver despite has_mip_solver()=true");
+    return;
+  }
+  SystemLP system_lp(system, simulation_lp, flat_opts);
 
   auto&& lp = system_lp.linear_interface();
 

--- a/test/source/test_mip_solvers.cpp
+++ b/test/source/test_mip_solvers.cpp
@@ -349,9 +349,11 @@ TEST_CASE(  // NOLINT
           .simple_commitment_array = simple_commitment_array,
       };
 
+      LpMatrixOptions flat_opts;
+      flat_opts.solver_name = solver_name;
       const PlanningOptionsLP options(opts);
       SimulationLP simulation_lp(single_block_simulation, options);
-      SystemLP system_lp(system, simulation_lp);
+      SystemLP system_lp(system, simulation_lp, flat_opts);
 
       auto&& lp = system_lp.linear_interface();
 

--- a/test/source/test_simple_commitment.cpp
+++ b/test/source/test_simple_commitment.cpp
@@ -401,7 +401,26 @@ TEST_CASE(  // NOLINT
 
   const PlanningOptionsLP options(opts);
   SimulationLP simulation_lp(simulation, options);
-  SystemLP system_lp(system, simulation_lp);
+
+  // Pick the first MIP-capable solver explicitly so we don't fall
+  // through to the GTOPT_SOLVER env override (CI pins to "clp" —
+  // LP-only).  Defensive: skip if no MIP solver was found, even
+  // though has_mip_solver() returned true above (guards against an
+  // inconsistency between has_mip_solver() and supports_mip()).
+  LpMatrixOptions flat_opts;
+  for (const auto& name : reg.available_solvers()) {
+    if (reg.supports_mip(name)) {
+      flat_opts.solver_name = name;
+      break;
+    }
+  }
+  if (flat_opts.solver_name.empty()) {
+    MESSAGE(
+        "Skipping MIP test — supports_mip() returned false for "
+        "every loaded solver despite has_mip_solver()=true");
+    return;
+  }
+  SystemLP system_lp(system, simulation_lp, flat_opts);
 
   auto&& lp = system_lp.linear_interface();
 


### PR DESCRIPTION
## Summary

Fixes the **4 MIP unit tests** that started failing on Ubuntu CI after PR #410 pinned \`GTOPT_SOLVER=clp\`. These tests want a MIP solver but never set \`flat_opts.solver_name\`, so \`default_solver()\` falls through to the env override (CLP, LP-only) and the LP relaxation values fail the binary assertions.

Affected tests:
- #528  \`CommitmentLP — MIP u/v/w binary values for startup profile\`
- #933  \`GeneratorLP — integer_expmod MIP gives integer expansion modules\`
- #1507 \`MIP solvers — simple commitment status u binary when pmin exceeds demand\`
- #2160 \`SimpleCommitmentLP — MIP status u binary when pmin exceeds demand\`

## Changes

Each affected test now:
1. Iterates \`reg.available_solvers()\` and picks the first one where \`reg.supports_mip(name)\` returns true
2. Sets \`flat_opts.solver_name = name\` and passes \`flat_opts\` to the \`SystemLP\` constructor
3. Defensively skips with \`MESSAGE(...)\` if the loop doesn't find a MIP solver, even though \`has_mip_solver()\` returned true above (guards against any inconsistency between the two registry queries)

## Test plan
- [x] \`GTOPT_SOLVER=clp gtoptTests --test-case='*MIP*'\`: **8/8 pass, 177 assertions**
- [x] \`GTOPT_SOLVER=clp ctest -R 'MIP|integer_expmod' -j4\`: **7/7 pass**
- [ ] Wait for full Ubuntu CI run on this branch to confirm the 4 ctest failures are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)