### PR TITLE
feat(sddp): per-backward-step timers in SolverStats

### DIFF
--- a/include/gtopt/linear_interface.hpp
+++ b/include/gtopt/linear_interface.hpp
@@ -799,6 +799,21 @@ public:
   }
 
   /**
+   * @brief Mutable accessor to the solver-counter block.
+   *
+   * Exposed for out-of-class instrumentation — specifically
+   * `SDDPMethod::backward_pass_single_phase`, which bumps the six
+   * `bwd_*_s` timers plus `bwd_step_count` on the previous-phase LP as
+   * it installs each optimality cut.  Callers are expected to be
+   * single-writer threads for the underlying LP (same contract as every
+   * other mutating method on `LinearInterface`).
+   */
+  [[nodiscard]] constexpr SolverStats& mutable_solver_stats() noexcept
+  {
+    return m_solver_stats_;
+  }
+
+  /**
    * @brief Fold another LP's counters into this one.
    *
    * Used by elastic-filter paths that resolve a `clone()`d LP and

--- a/include/gtopt/solver_stats.hpp
+++ b/include/gtopt/solver_stats.hpp
@@ -64,6 +64,46 @@ struct SolverStats
   /// Sum of row counts observed at each top-level solve.
   std::size_t total_nrows {0};
 
+  // ── SDDP backward-step timers ─────────────────────────────────────────
+  //
+  // Populated by `SDDPMethod::backward_pass_single_phase` (one sample per
+  // cut it installs on this LP).  All six `bwd_*_s` fields are wall-clock
+  // seconds accumulated across every step that landed on this LP; sum
+  // them across all `(scene, phase)` LPs to break down the global
+  // backward-pass wall time into its stages, or diff snapshots between
+  // iterations to see whether individual stages grow as cuts accumulate.
+  //
+  // The instrumentation is always on — each step contributes six
+  // `chrono::steady_clock::now()` pairs, which is negligible next to the
+  // LP resolve it wraps (O(µs) vs O(s)).
+
+  /// Number of backward-pass cut-installation steps that landed on this LP.
+  std::size_t bwd_step_count {0};
+  /// Time spent in `SystemLP::ensure_lp_built()` before the cut is added
+  /// (snapshot/compress reload; 0 under `low_memory_mode=off`).
+  double bwd_lp_rebuild_s {0.0};
+  /// Time spent constructing the cut row (`build_benders_cut`,
+  /// `rescale_benders_cut`, `filter_cut_coefficients`).  Pure CPU on the
+  /// calling thread.
+  double bwd_cut_build_s {0.0};
+  /// Time spent in `LinearInterface::add_row(cut)` — this is the single-row
+  /// CPLEX `addRow` (or equivalent) and the row-name bookkeeping that
+  /// accompanies it.
+  double bwd_add_row_s {0.0};
+  /// Time spent pushing the new `StoredCut` onto the per-scene vector
+  /// (`SDDPCutStore::store_cut`).
+  double bwd_store_cut_s {0.0};
+  /// Time spent in the post-cut `LinearInterface::resolve()` (simplex
+  /// warm-start after adding the new row).  Distinct from the existing
+  /// `total_solve_time_s`, which covers every `initial_solve`/`resolve`
+  /// invocation on the LP, so the two overlap intentionally; diffing
+  /// this in isolation shows the per-iteration backward-resolve cost.
+  double bwd_resolve_s {0.0};
+  /// Time spent in `SDDPMethod::update_max_kappa` — dominated by the
+  /// backend `get_kappa()` call (CPLEX `CPXgetdblquality(CPX_KAPPA)`,
+  /// HiGHS basis-condition query).
+  double bwd_kappa_s {0.0};
+
   [[nodiscard]] constexpr std::size_t total_solve_calls() const noexcept
   {
     return initial_solve_calls + resolve_calls;
@@ -88,6 +128,42 @@ struct SolverStats
     max_kappa = std::max(max_kappa, rhs.max_kappa);
     total_ncols += rhs.total_ncols;
     total_nrows += rhs.total_nrows;
+    bwd_step_count += rhs.bwd_step_count;
+    bwd_lp_rebuild_s += rhs.bwd_lp_rebuild_s;
+    bwd_cut_build_s += rhs.bwd_cut_build_s;
+    bwd_add_row_s += rhs.bwd_add_row_s;
+    bwd_store_cut_s += rhs.bwd_store_cut_s;
+    bwd_resolve_s += rhs.bwd_resolve_s;
+    bwd_kappa_s += rhs.bwd_kappa_s;
+    return *this;
+  }
+
+  /// Subtract a snapshot of counters — used to obtain per-iteration
+  /// deltas from two consecutive snapshots of the same aggregated
+  /// `SolverStats`.  `max_kappa` is copied from @p rhs (not differenced)
+  /// because "max seen so far" has no meaningful subtraction; the delta
+  /// snapshot holds the *post-iteration* max, which monotonically grows.
+  constexpr SolverStats& operator-=(const SolverStats& rhs) noexcept
+  {
+    load_problem_calls -= rhs.load_problem_calls;
+    initial_solve_calls -= rhs.initial_solve_calls;
+    resolve_calls -= rhs.resolve_calls;
+    fallback_solves -= rhs.fallback_solves;
+    crossover_solves -= rhs.crossover_solves;
+    infeasible_count -= rhs.infeasible_count;
+    primal_infeasible -= rhs.primal_infeasible;
+    dual_infeasible -= rhs.dual_infeasible;
+    total_solve_time_s -= rhs.total_solve_time_s;
+    // max_kappa deliberately not subtracted (see above).
+    total_ncols -= rhs.total_ncols;
+    total_nrows -= rhs.total_nrows;
+    bwd_step_count -= rhs.bwd_step_count;
+    bwd_lp_rebuild_s -= rhs.bwd_lp_rebuild_s;
+    bwd_cut_build_s -= rhs.bwd_cut_build_s;
+    bwd_add_row_s -= rhs.bwd_add_row_s;
+    bwd_store_cut_s -= rhs.bwd_store_cut_s;
+    bwd_resolve_s -= rhs.bwd_resolve_s;
+    bwd_kappa_s -= rhs.bwd_kappa_s;
     return *this;
   }
 

--- a/source/sddp_aperture_pass.cpp
+++ b/source/sddp_aperture_pass.cpp
@@ -11,6 +11,7 @@
  */
 
 #include <algorithm>
+#include <chrono>
 #include <format>
 #include <future>
 #include <ranges>
@@ -132,6 +133,21 @@ auto SDDPMethod::install_aperture_backward_cut(
     LinearInterface& src_li,
     const SolverOptions& opts) -> int
 {
+  // Fine-grained stage timers — same semantics as the Benders-only
+  // path in `backward_pass_single_phase`.  `cut_build_s` only fires
+  // when we fall through to the bcut path (the aperture-built cut
+  // arrived already built in @p expected_cut, so its build cost is
+  // captured by `total_solve_time_s` on the aperture clones — not
+  // attributable to a single per-step bwd_cut_build bucket).
+  using Clock = std::chrono::steady_clock;
+  const auto elapsed_s = [](Clock::time_point start) noexcept
+  { return std::chrono::duration<double>(Clock::now() - start).count(); };
+  double dt_cut_build = 0.0;
+  double dt_add_row = 0.0;
+  double dt_resolve = 0.0;
+  double dt_kappa = 0.0;
+  double dt_store = 0.0;
+
   const auto sa = m_options_.scale_alpha;
   const auto ceps = m_options_.cut_coeff_eps;
   const auto cmax = m_options_.cut_coeff_max;
@@ -141,10 +157,14 @@ auto SDDPMethod::install_aperture_backward_cut(
   // resolve leaves src_li non-optimal, back it out and fall through to
   // the bcut path.  `expected_cut` is consumed on the success path.
   if (expected_cut.has_value()) {
+    const auto t_build = Clock::now();
     rescale_benders_cut(*expected_cut, src_alpha_col, cmax);
     filter_cut_coefficients(*expected_cut, src_alpha_col, ceps);
+    dt_cut_build += elapsed_s(t_build);
 
+    const auto t_add_row = Clock::now();
     const auto cut_row = src_li.add_row(*expected_cut);
+    dt_add_row += elapsed_s(t_add_row);
 
     // Re-solve src_li only when there is a further backward step that
     // will consume its state.  At src_phase_index == 0 there is no
@@ -156,9 +176,13 @@ auto SDDPMethod::install_aperture_backward_cut(
                                   iteration_index,
                                   scene_uid(scene_index),
                                   phase_uid(src_phase_index)));
+      const auto t_resolve = Clock::now();
       auto r = src_li.resolve(opts);
+      dt_resolve += elapsed_s(t_resolve);
       if (r.has_value() && src_li.is_optimal()) {
+        const auto t_kappa = Clock::now();
         update_max_kappa(scene_index, src_phase_index, src_li, iteration_index);
+        dt_kappa += elapsed_s(t_kappa);
       } else {
         keep_expected_cut = false;
         SPDLOG_WARN(
@@ -173,11 +197,13 @@ auto SDDPMethod::install_aperture_backward_cut(
     }
 
     if (keep_expected_cut) {
+      const auto t_store = Clock::now();
       store_cut(scene_index,
                 src_phase_index,
                 *expected_cut,
                 CutType::Optimality,
                 cut_row);
+      dt_store += elapsed_s(t_store);
       SPDLOG_TRACE("{}: cut for phase {} rhs={:.4f}",
                    sddp_log("Aperture",
                             iteration_index,
@@ -185,6 +211,14 @@ auto SDDPMethod::install_aperture_backward_cut(
                             phase_uid(phase_index)),
                    src_phase_index,
                    expected_cut->lowb);
+
+      auto& sstats = src_li.mutable_solver_stats();
+      ++sstats.bwd_step_count;
+      sstats.bwd_cut_build_s += dt_cut_build;
+      sstats.bwd_add_row_s += dt_add_row;
+      sstats.bwd_resolve_s += dt_resolve;
+      sstats.bwd_kappa_s += dt_kappa;
+      sstats.bwd_store_cut_s += dt_store;
       return 1;
     }
 
@@ -202,6 +236,7 @@ auto SDDPMethod::install_aperture_backward_cut(
   // touched by the backward pass.  A valid Benders underestimator of
   // the future-cost function — adding it to an optimal src_li cannot
   // produce infeasibility.
+  const auto t_build = Clock::now();
   auto fallback_cut = build_benders_cut(src_alpha_col,
                                         src_state.outgoing_links,
                                         target_state.forward_full_obj,
@@ -216,10 +251,16 @@ auto SDDPMethod::install_aperture_backward_cut(
                                                 cut_offset);
   rescale_benders_cut(fallback_cut, src_alpha_col, cmax);
   filter_cut_coefficients(fallback_cut, src_alpha_col, ceps);
+  dt_cut_build += elapsed_s(t_build);
 
+  const auto t_add_row = Clock::now();
   const auto cut_row = src_li.add_row(fallback_cut);
+  dt_add_row += elapsed_s(t_add_row);
+
+  const auto t_store = Clock::now();
   store_cut(
       scene_index, src_phase_index, fallback_cut, CutType::Optimality, cut_row);
+  dt_store += elapsed_s(t_store);
 
   SPDLOG_TRACE("{}: bcut for phase {} rhs={:.4f}",
                sddp_log("Aperture",
@@ -229,6 +270,13 @@ auto SDDPMethod::install_aperture_backward_cut(
                src_phase_index,
                fallback_cut.lowb);
 
+  auto& sstats = src_li.mutable_solver_stats();
+  ++sstats.bwd_step_count;
+  sstats.bwd_cut_build_s += dt_cut_build;
+  sstats.bwd_add_row_s += dt_add_row;
+  sstats.bwd_resolve_s += dt_resolve;
+  sstats.bwd_kappa_s += dt_kappa;
+  sstats.bwd_store_cut_s += dt_store;
   return 1;
 }
 

--- a/source/sddp_iteration.cpp
+++ b/source/sddp_iteration.cpp
@@ -19,6 +19,7 @@
 #include <gtopt/sddp_cut_io.hpp>
 #include <gtopt/sddp_method.hpp>
 #include <gtopt/sddp_pool.hpp>
+#include <gtopt/solver_stats.hpp>
 #include <gtopt/solver_status.hpp>
 #include <gtopt/utils.hpp>
 
@@ -30,6 +31,60 @@
 
 namespace gtopt
 {
+
+namespace
+{
+
+/// Sum `SolverStats` across every `(scene, phase)` LP in the planning
+/// grid.  Used to take a pre/post snapshot around the backward pass so
+/// the per-iteration delta of the `bwd_*_s` timers can be logged.
+[[nodiscard]] SolverStats aggregate_backward_stats(const PlanningLP& planning)
+{
+  SolverStats total {};
+  const auto num_scenes = planning.simulation().scene_count();
+  const auto num_phases = planning.simulation().phase_count();
+  for (const auto si : iota_range<SceneIndex>(0, num_scenes)) {
+    for (const auto pi : iota_range<PhaseIndex>(0, num_phases)) {
+      total += planning.system(si, pi).linear_interface().solver_stats();
+    }
+  }
+  return total;
+}
+
+/// Emit a single INFO line summarising the six backward-step timers for
+/// an iteration.  Shown next to the standard "SDDP Iter [iN]: done ..."
+/// so the per-iteration growth of each stage stays visible alongside the
+/// total backward-pass wall time.
+void log_backward_timing_breakdown(IterationIndex iteration_index,
+                                   const SolverStats& delta)
+{
+  if (delta.bwd_step_count == 0) {
+    return;
+  }
+  const auto n = static_cast<double>(delta.bwd_step_count);
+  const auto to_ms = [n](double s_sum) noexcept { return 1000.0 * s_sum / n; };
+  SPDLOG_INFO(
+      "SDDP Backward [i{}]: step-avg(ms) rebuild={:.2f} build={:.2f} "
+      "add_row={:.2f} store={:.2f} resolve={:.2f} kappa={:.2f} — "
+      "{} step(s), total(s) rebuild={:.2f} build={:.2f} add_row={:.2f} "
+      "store={:.2f} resolve={:.2f} kappa={:.2f}",
+      iteration_index,
+      to_ms(delta.bwd_lp_rebuild_s),
+      to_ms(delta.bwd_cut_build_s),
+      to_ms(delta.bwd_add_row_s),
+      to_ms(delta.bwd_store_cut_s),
+      to_ms(delta.bwd_resolve_s),
+      to_ms(delta.bwd_kappa_s),
+      delta.bwd_step_count,
+      delta.bwd_lp_rebuild_s,
+      delta.bwd_cut_build_s,
+      delta.bwd_add_row_s,
+      delta.bwd_store_cut_s,
+      delta.bwd_resolve_s,
+      delta.bwd_kappa_s);
+}
+
+}  // namespace
 
 auto SDDPMethod::solve(const SolverOptions& lp_opts)
     -> std::expected<std::vector<SDDPIterationResult>, Error>
@@ -182,6 +237,13 @@ auto SDDPMethod::solve(const SolverOptions& lp_opts)
         m_cut_store_.scene_cuts_before()[scene_index] =
             m_cut_store_.scene_cuts()[scene_index].size();
       }
+      // Snapshot aggregate solver stats so the post-pass diff reveals
+      // the six per-step backward-cut timers (rebuild/build/add_row/
+      // store/resolve/kappa).  The cost of the aggregation is a loop
+      // over (scene × phase) LPs — trivial compared to the backward
+      // pass itself.
+      const auto bwd_stats_before = aggregate_backward_stats(planning_lp());
+
       auto bwd = run_backward_pass_all_scenes(
           fwd->scene_feasible, *sddp_pool, bwd_opts, iteration_index);
       ir.cuts_added = bwd.total_cuts;
@@ -200,6 +262,17 @@ auto SDDPMethod::solve(const SolverOptions& lp_opts)
                    iteration_index,
                    bwd.elapsed_s,
                    bwd.total_cuts);
+
+      // Diff the post-pass aggregate against the snapshot so each log
+      // line shows just this iteration's breakdown.  Useful for
+      // tracking how stages scale with the number of cuts installed so
+      // far — the suspected cause of the "later iterations are 10x
+      // slower than early ones" pattern.
+      {
+        auto bwd_delta = aggregate_backward_stats(planning_lp());
+        bwd_delta -= bwd_stats_before;
+        log_backward_timing_breakdown(iteration_index, bwd_delta);
+      }
 
       // ── Cut sharing ──
       if (m_options_.cut_sharing == CutSharingMode::none) {

--- a/source/sddp_method.cpp
+++ b/source/sddp_method.cpp
@@ -832,6 +832,16 @@ auto SDDPMethod::backward_pass_single_phase(SceneIndex scene_index,
                                             IterationIndex iteration_index)
     -> std::expected<int, Error>
 {
+  // Fine-grained stage timing for the backward-cut step.  Each pair of
+  // chrono::steady_clock::now() calls is O(100ns); the stages they
+  // bracket dominate by 3-5 orders of magnitude (LP resolve, kappa
+  // query) so the overhead is irrelevant.  The counters land on the
+  // previous-phase LP's SolverStats so end-of-run aggregation and
+  // per-iteration diffing both fall out of the existing infrastructure.
+  using Clock = std::chrono::steady_clock;
+  const auto elapsed_s = [](Clock::time_point start) noexcept
+  { return std::chrono::duration<double>(Clock::now() - start).count(); };
+
   auto& phase_states = m_scene_phase_states_[scene_index];
   int cuts_added = 0;
 
@@ -843,7 +853,9 @@ auto SDDPMethod::backward_pass_single_phase(SceneIndex scene_index,
   // (mode=off, or a prior task already rebuilt it); otherwise reloads
   // from snapshot (snapshot/compress) or re-flattens from collections
   // (rebuild).
+  const auto t_rebuild = Clock::now();
   src_sys.ensure_lp_built();
+  const auto dt_rebuild = elapsed_s(t_rebuild);
 
   auto& src_li = src_sys.linear_interface();
 
@@ -867,6 +879,7 @@ auto SDDPMethod::backward_pass_single_phase(SceneIndex scene_index,
       : ColIndex {unknown_index};
 
   const auto scale_obj = planning_lp().options().scale_objective();
+  const auto t_build = Clock::now();
   auto cut = build_benders_cut(src_alpha_col,
                                src_state.outgoing_links,
                                target_state.forward_full_obj,
@@ -881,9 +894,16 @@ auto SDDPMethod::backward_pass_single_phase(SceneIndex scene_index,
                                        cut_offset);
   rescale_benders_cut(cut, src_alpha_col, cmax);
   filter_cut_coefficients(cut, src_alpha_col, ceps);
+  const auto dt_build = elapsed_s(t_build);
 
+  const auto t_add_row = Clock::now();
   const auto cut_row = src_li.add_row(cut);
+  const auto dt_add_row = elapsed_s(t_add_row);
+
+  const auto t_store = Clock::now();
   store_cut(scene_index, prev_phase_index, cut, CutType::Optimality, cut_row);
+  const auto dt_store = elapsed_s(t_store);
+
   ++cuts_added;
   m_phase_grid_.record(
       iteration_index, scene_uid(scene_index), phase_index, GridCell::Backward);
@@ -909,14 +929,20 @@ auto SDDPMethod::backward_pass_single_phase(SceneIndex scene_index,
   // solve from a fresh basis.  Mirrors the bcut-path simplification in
   // sddp_aperture_pass.cpp where we removed the corresponding resolve
   // entirely (the bcut path doesn't feed into async LB computation).
+  double dt_resolve = 0.0;
+  double dt_kappa = 0.0;
   if (phase_index) {
     src_li.set_log_tag(sddp_log("Backward",
                                 iteration_index,
                                 scene_uid(scene_index),
                                 phase_uid(prev_phase_index)));
+    const auto t_resolve = Clock::now();
     auto r = src_li.resolve(opts);
+    dt_resolve = elapsed_s(t_resolve);
     if (r.has_value() && src_li.is_optimal()) {
+      const auto t_kappa = Clock::now();
       update_max_kappa(scene_index, prev_phase_index, src_li, iteration_index);
+      dt_kappa = elapsed_s(t_kappa);
     } else {
       SPDLOG_DEBUG(
           "{}: post-cut resolve non-optimal (status {}) — keeping "
@@ -928,6 +954,19 @@ auto SDDPMethod::backward_pass_single_phase(SceneIndex scene_index,
           src_li.get_status());
     }
   }
+
+  // Fold this step's timings into the previous-phase LP's SolverStats.
+  // Single-writer per-LP invariant holds: phase access within a scene
+  // is serial during the backward pass (both the async and
+  // phase-synchronised variants obey this), so no atomics are needed.
+  auto& sstats = src_li.mutable_solver_stats();
+  ++sstats.bwd_step_count;
+  sstats.bwd_lp_rebuild_s += dt_rebuild;
+  sstats.bwd_cut_build_s += dt_build;
+  sstats.bwd_add_row_s += dt_add_row;
+  sstats.bwd_store_cut_s += dt_store;
+  sstats.bwd_resolve_s += dt_resolve;
+  sstats.bwd_kappa_s += dt_kappa;
 
   return cuts_added;
 }

--- a/test/source/test_solver_stats.cpp
+++ b/test/source/test_solver_stats.cpp
@@ -125,6 +125,87 @@ TEST_CASE(
   CHECK(a.max_kappa == doctest::Approx(-1.0));
 }
 
+// ── Backward-step timers: sum and diff ────────────────────────────────
+
+TEST_CASE("SolverStats operator+= sums backward-step timers")  // NOLINT
+{
+  SolverStats a;
+  a.bwd_step_count = 3;
+  a.bwd_lp_rebuild_s = 0.1;
+  a.bwd_cut_build_s = 0.2;
+  a.bwd_add_row_s = 0.3;
+  a.bwd_store_cut_s = 0.4;
+  a.bwd_resolve_s = 0.5;
+  a.bwd_kappa_s = 0.6;
+
+  SolverStats b;
+  b.bwd_step_count = 5;
+  b.bwd_lp_rebuild_s = 1.0;
+  b.bwd_cut_build_s = 2.0;
+  b.bwd_add_row_s = 3.0;
+  b.bwd_store_cut_s = 4.0;
+  b.bwd_resolve_s = 5.0;
+  b.bwd_kappa_s = 6.0;
+
+  a += b;
+
+  CHECK(a.bwd_step_count == 8);
+  CHECK(a.bwd_lp_rebuild_s == doctest::Approx(1.1));
+  CHECK(a.bwd_cut_build_s == doctest::Approx(2.2));
+  CHECK(a.bwd_add_row_s == doctest::Approx(3.3));
+  CHECK(a.bwd_store_cut_s == doctest::Approx(4.4));
+  CHECK(a.bwd_resolve_s == doctest::Approx(5.5));
+  CHECK(a.bwd_kappa_s == doctest::Approx(6.6));
+}
+
+TEST_CASE("SolverStats operator-= diffs backward-step timers")  // NOLINT
+{
+  // Scenario: aggregate at end of iter_N minus aggregate at start of
+  // iter_N should yield the per-iteration delta for the bwd_* fields.
+  SolverStats after;
+  after.bwd_step_count = 10;
+  after.bwd_lp_rebuild_s = 0.8;
+  after.bwd_cut_build_s = 1.6;
+  after.bwd_add_row_s = 2.4;
+  after.bwd_store_cut_s = 3.2;
+  after.bwd_resolve_s = 4.0;
+  after.bwd_kappa_s = 4.8;
+
+  SolverStats before;
+  before.bwd_step_count = 3;
+  before.bwd_lp_rebuild_s = 0.1;
+  before.bwd_cut_build_s = 0.2;
+  before.bwd_add_row_s = 0.3;
+  before.bwd_store_cut_s = 0.4;
+  before.bwd_resolve_s = 0.5;
+  before.bwd_kappa_s = 0.6;
+
+  after -= before;
+
+  CHECK(after.bwd_step_count == 7);
+  CHECK(after.bwd_lp_rebuild_s == doctest::Approx(0.7));
+  CHECK(after.bwd_cut_build_s == doctest::Approx(1.4));
+  CHECK(after.bwd_add_row_s == doctest::Approx(2.1));
+  CHECK(after.bwd_store_cut_s == doctest::Approx(2.8));
+  CHECK(after.bwd_resolve_s == doctest::Approx(3.5));
+  CHECK(after.bwd_kappa_s == doctest::Approx(4.2));
+}
+
+TEST_CASE("SolverStats operator-= does not subtract max_kappa")  // NOLINT
+{
+  // max_kappa is monotonic across iterations; subtraction would
+  // corrupt it, so operator-= leaves it alone.  The `after` snapshot
+  // carries the post-iteration max, which is the right value to log.
+  SolverStats after;
+  after.max_kappa = 1.0e8;
+  SolverStats before;
+  before.max_kappa = 1.0e5;
+
+  after -= before;
+
+  CHECK(after.max_kappa == doctest::Approx(1.0e8));
+}
+
 TEST_CASE("SolverStats operator+ is non-mutating")  // NOLINT
 {
   SolverStats a;


### PR DESCRIPTION
## Summary

Adds fine-grained timers to every SDDP backward-cut installation step, so
per-iteration breakdown of the 0.1 s → 3 s growth pattern we see on big
cases (e.g. juan/iplp) can be attributed to a specific stage.

Six new fields on \`SolverStats\` (wall-clock seconds, summable across
LPs, diff-able between iterations):

- \`bwd_lp_rebuild_s\`  \`ensure_lp_built\` (snapshot/compress reload)
- \`bwd_cut_build_s\`   \`build_benders_cut\` + \`rescale\` + \`filter\`
- \`bwd_add_row_s\`     \`LinearInterface::add_row\`
- \`bwd_store_cut_s\`   \`SDDPCutStore::store_cut\`
- \`bwd_resolve_s\`     post-cut \`LinearInterface::resolve\`
- \`bwd_kappa_s\`       \`update_max_kappa\` (backend kappa query)

Instrumented in both cut paths:
- \`backward_pass_single_phase\` (Benders-only)
- \`install_aperture_backward_cut\` (aperture path + bcut fallback)

\`SolverStats::operator-=\` added so the per-iteration delta falls out of
diffing two aggregated snapshots of the (scene, phase) grid. \`max_kappa\`
is deliberately not subtracted (monotonic; post-iter value is what we
want to log).

After each backward pass, \`sddp_iteration.cpp\` emits one INFO line:

\`\`\`
SDDP Backward [iN]: step-avg(ms) rebuild=… build=… add_row=… store=…
                    resolve=… kappa=… — N step(s), total(s) …
\`\`\`

## Diagnostic outcome on juan/iplp (5 iters)

First-iteration breakdown:
\`\`\`
step-avg(ms) rebuild=0.00 build=0.02 add_row=0.34 store=0.10
             resolve=2194.26 kappa=0.01 — 800 step(s)
\`\`\`
> 99.98 % of per-step wall time is CPLEX resolve. Cut-handling overhead
(add_row + store_cut + build) totals 0.46 ms — irrelevant. Confirms H1
(CPLEX) and rules out H2 (gtopt cut bookkeeping). H3 (numerics) remains
open; the equilibration-for-cuts work (separate PR) targets it.

## Cost of the instrumentation

Six \`chrono::steady_clock::now()\` pairs per backward step (~100 ns each)
vs. the LP resolve they wrap (~1–3 s). Never measurable; not gated on
any flag.

## Test plan

- [x] \`ctest -j20\` — 2579/2579 pass
- [x] New doctest cases: \`operator+=\`, \`operator-=\` on bwd_* fields; \`-=\`
      preserves max_kappa.
- [x] \`clang-tidy\` on both changed .cpp files — clean (only environmental
      PCH-ignored warning).
- [x] \`clang-format\` pre-commit hook — clean.
- [x] End-to-end on support/juan/gtopt_iplp — log line appears correctly
      with 800 steps per iteration.

Depends on #418 (used for \`--set cascade_options.level_array.0.*\` in the
diagnostic run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)