### PR TITLE
fix(osi): preserve cut-row names in writeLp() so SDDP fcut audits pass under CLP

### DIFF
--- a/plugins/osi/osi_solver_backend.cpp
+++ b/plugins/osi/osi_solver_backend.cpp
@@ -612,27 +612,88 @@ void OsiSolverBackend::clear_log_filename()
   }
 }
 
+namespace
+{
+
+/// CoinLpIO's name validator rejects:
+///   - empty names (gaps in the name vector);
+///   - names with characters outside `[A-Za-z0-9_.]` — notably `-`,
+///     which appears in gtopt's unknown-uid placeholder `_-1_...`.
+/// When *any* name fails validation CoinLpIO discards the *entire*
+/// set and falls back to `R1, R2, ...`, breaking LP-file auditing
+/// and every downstream tool that relies on the generated labels.
+///
+/// `sanitise_lp_name` replaces invalid characters with `_` and
+/// substitutes a positional placeholder (`prefix_<idx>`) for empty
+/// names.  The sanitised form only affects the OSI backend's name
+/// storage; authoritative names on `LinearInterface` are preserved.
+[[nodiscard]] std::string sanitise_lp_name(std::string_view raw,
+                                           std::string_view prefix,
+                                           std::size_t idx)
+{
+  if (raw.empty()) {
+    // Synthesise a deterministic placeholder so CoinLpIO accepts the
+    // full name vector.  Index-based so two gaps can't collide.
+    return std::format("{}{}", prefix, idx);
+  }
+  std::string out;
+  out.reserve(raw.size());
+  for (const char c : raw) {
+    const bool ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+        || (c >= '0' && c <= '9') || c == '_' || c == '.';
+    out.push_back(ok ? c : '_');
+  }
+  return out;
+}
+
+}  // namespace
+
 void OsiSolverBackend::push_names(const std::vector<std::string>& col_names,
                                   const std::vector<std::string>& row_names)
 {
-  // Fast path for CLP: bulk set via ClpModel::copyNames()
-  auto* clp = as_clp(m_solver_.get(), m_type_);
-  if (clp != nullptr) {
-    clp->getModelPtr()->copyNames(row_names, col_names);
-    return;
+  // Two name stores are in play on OsiClpSolverInterface:
+  //   1. ClpModel's own `m_rowNames_` / `m_columnNames_` (CLP-internal
+  //      solver consumers).
+  //   2. OSI's base-class name vectors, gated by `OsiNameDiscipline`
+  //      (what `OsiSolverInterface::writeLp` actually reads from).
+  //
+  // A previous `copyNames`-only fast path populated only (1), so cut
+  // rows added after `load_flat` had their names ignored by the LP
+  // file writer — the generated .lp file carried `R1, R2, ...`
+  // defaults instead of `sddp_fcut_...` / `sddp_bcut_...`.  Always
+  // populate BOTH stores: the CLP bulk copy for solver-internal
+  // consumers, and the OSI per-element path so writeLp() emits real
+  // labels.  Both passes are O(ncols + nrows) and negligible next to
+  // the solve they precede.
+  //
+  // We also sanitise names for the OSI store: CoinLpIO's writeLp
+  // rejects the whole set if any name contains characters it deems
+  // "illegal" (notably `-` in gtopt's `-1_` unknown-uid placeholder),
+  // silently falling back to `R1, R2, ...`.  The sanitised form only
+  // affects what OSI writes to `.lp` files; `LinearInterface`'s own
+  // `m_row_index_to_name_` / `m_col_index_to_name_` maps keep the
+  // original names verbatim.
+  m_safe_col_names_.clear();
+  m_safe_row_names_.clear();
+  m_safe_col_names_.reserve(col_names.size());
+  m_safe_row_names_.reserve(row_names.size());
+  for (std::size_t i = 0; i < col_names.size(); ++i) {
+    m_safe_col_names_.push_back(sanitise_lp_name(col_names[i], "c", i));
+  }
+  for (std::size_t i = 0; i < row_names.size(); ++i) {
+    m_safe_row_names_.push_back(sanitise_lp_name(row_names[i], "r", i));
   }
 
-  // Generic fallback: per-element via OSI
-  m_solver_->setIntParam(OsiNameDiscipline, 2);
-  for (size_t i = 0; i < col_names.size(); ++i) {
-    if (!col_names[i].empty()) {
-      m_solver_->setColName(static_cast<int>(i), col_names[i]);
-    }
+  if (auto* clp = as_clp(m_solver_.get(), m_type_); clp != nullptr) {
+    clp->getModelPtr()->copyNames(m_safe_row_names_, m_safe_col_names_);
   }
-  for (size_t i = 0; i < row_names.size(); ++i) {
-    if (!row_names[i].empty()) {
-      m_solver_->setRowName(static_cast<int>(i), row_names[i]);
-    }
+
+  m_solver_->setIntParam(OsiNameDiscipline, 2);
+  for (std::size_t i = 0; i < m_safe_col_names_.size(); ++i) {
+    m_solver_->setColName(static_cast<int>(i), m_safe_col_names_[i]);
+  }
+  for (std::size_t i = 0; i < m_safe_row_names_.size(); ++i) {
+    m_solver_->setRowName(static_cast<int>(i), m_safe_row_names_[i]);
   }
 }
 

--- a/plugins/osi/osi_solver_backend.hpp
+++ b/plugins/osi/osi_solver_backend.hpp
@@ -187,6 +187,18 @@ private:
   bool m_presolve_ {true};
   int m_log_level_ {0};
 
+  /// Sanitised names cached from the most recent `push_names` call.
+  /// `push_names` populates both the CLP-internal name store
+  /// (`ClpModel::copyNames`) and the OSI base-class name vectors
+  /// (`setColName`/`setRowName` under `OsiNameDiscipline=2`) so that
+  /// `OsiSolverInterface::writeLp` emits real labels — the prior
+  /// CLP-only fast path left the OSI side empty and the writer fell
+  /// back to `R1, R2, ...`.  Sanitisation replaces characters that
+  /// CoinLpIO's validator rejects (notably `-`) and fills empty slots
+  /// with positional placeholders.
+  std::vector<std::string> m_safe_col_names_;
+  std::vector<std::string> m_safe_row_names_;
+
   /// Owned FILE* for set_log_filename; closed in clear_log_filename.
   struct FileCloser
   {


### PR DESCRIPTION
## Summary

Three `test_sddp_fcut_audit.cpp` tests that greps generated .lp files
for `sddp_fcut_*` / `sddp_bcut_*` labels passed locally with CPLEX but
failed on CI with CLP.  The failure was a silent name-propagation gap
in the OSI backend's `push_names`:

- **CLP fast path** used `ClpModel::copyNames` only, populating CLP's
  internal name store but not the OSI base-class name vectors that
  `OsiSolverInterface::writeLp` actually reads from.  Cut rows added
  after `load_flat` therefore kept base-class defaults (`R1, R2, ...`)
  in the .lp output.
- **Generic fallback** skipped empty names, leaving gaps in the OSI
  vector.  CoinLpIO's validator rejects any gap *or* any character
  outside `[A-Za-z0-9_.]` (notably `-` in gtopt's `_-1_` placeholder)
  and silently falls back to the same `R1, R2, ...` defaults.

## Fix

Sanitise every name (replace invalid characters with `_`, substitute
`prefix<idx>` for empty slots) and populate **both** name stores
unconditionally — CLP's internal `copyNames` for solver-internal
consumers, and the OSI per-element `setRowName`/`setColName` path so
`writeLp()` emits real labels.  `LinearInterface`'s own
`m_row_index_to_name_` / `m_col_index_to_name_` maps keep the
unsanitised originals, so in-process name lookups are unaffected.

## Test plan

- [x] `test_sddp_fcut_audit.cpp` 9/9 passes under CLP (the CI config)
- [x] Same 9/9 under CPLEX (regression check)
- [x] Full ctest: 2963/2963 pass under CLP

Known residual: CBC's `setRowName` override doesn't propagate to the
base OSI vectors, so CBC emits `R1, R2, ...` in `.lp` files.  CI pins
`GTOPT_SOLVER=clp` (fix/ci — commit 3e9cadc1), so this does not
affect CI; documenting here for when we revisit OSI-CBC integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)