### PR TITLE
fix(line_losses): make piecewise_direct truly direct (PLP-faithful)

### DIFF
--- a/include/gtopt/line_enums.hpp
+++ b/include/gtopt/line_enums.hpp
@@ -111,14 +111,21 @@ inline constexpr auto loss_allocation_mode_entries =
  *   segment variables (bound `[0, tmax_dir/K]`) inject directly into
  *   the bus-balance rows with the per-segment loss factor
  *   `λ_k = (tmax_dir/K) · (2k−1) · R / V²` baked into the coefficients
- *   (PLP `genpdlin.f`).  There is no loss variable and no loss-tracking
- *   row — losses are implicit in the bus stamps.  A zero-cost
- *   aggregation column (`flowp`, `flown`) plus one linking row per
- *   direction preserves the downstream `fp_col` / `fn_col` API so the
- *   Kirchhoff (KVL) row and reporters require no changes.
+ *   (PLP `genpdlin.f`).  There is no loss variable, no loss-tracking
+ *   row, no aggregator column, and no flow-link row: each segment also
+ *   stamps directly into the Kirchhoff (KVL) row with `±x_τ`, so the
+ *   identity `Σ seg_k = |f|` is recovered without an explicit equality.
+ *   This produces the most compact LP (2K cols, 0 extra rows per block
+ *   per line) and matches the row count of PLP exactly.
+ *   Trade-off: the `line.flowp` / `line.flown` solution columns are
+ *   *not emitted* for piecewise_direct lines — the AMPL compound
+ *   `line.flow` is unavailable for these lines (use `piecewise` if you
+ *   need it).
  *   Activation: opt-in only — `adaptive` prefers `piecewise` (smaller
- *   LP).  Select explicitly for PLP-diff parity.  On expandable lines
- *   this mode falls back to `piecewise` with a warning.
+ *   LP per block, but more *rows*).  Select explicitly for PLP-diff
+ *   parity or to halve the LP size on transmission-heavy cases.  On
+ *   expandable lines this mode falls back to `piecewise` with a
+ *   warning.
  *   Ref: PLP Fortran `genpdlin.f` (GenPDLinA).
  */
 enum class LineLossesMode : uint8_t

--- a/include/gtopt/line_losses.hpp
+++ b/include/gtopt/line_losses.hpp
@@ -19,7 +19,7 @@
  * | `bidirectional`     | 4                | 2(K+2) (per-dir segs)     |
  * | `adaptive`          | resolved at config time (piecewise/bidirectional) |
  * | `dynamic`           | placeholder → piecewise                           |
- * | `piecewise_direct`  | 2                | 2(K+1) (per-dir segs + fp/fn) |
+ * | `piecewise_direct`  | 0                | 2K  (per-dir segs only)       |
  *
  * ### Mathematical background
  *
@@ -44,6 +44,7 @@
 
 #include <optional>
 #include <string_view>
+#include <vector>
 
 #include <gtopt/line.hpp>
 #include <gtopt/linear_problem.hpp>
@@ -84,12 +85,21 @@ struct LossConfig
  */
 struct BlockResult
 {
-  std::optional<ColIndex> fp_col;  ///< A→B flow column
-  std::optional<ColIndex> fn_col;  ///< B→A flow column
+  std::optional<ColIndex> fp_col;  ///< A→B flow column (aggregator)
+  std::optional<ColIndex> fn_col;  ///< B→A flow column (aggregator)
   std::optional<ColIndex> lossp_col;  ///< A→B loss column (PWL modes)
   std::optional<ColIndex> lossn_col;  ///< B→A loss column (PWL modes)
   std::optional<RowIndex> capp_row;  ///< A→B capacity constraint
   std::optional<RowIndex> capn_row;  ///< B→A capacity constraint
+  /// Per-segment columns for the A→B direction.  Populated only by
+  /// `piecewise_direct` mode, which has no aggregator (`fp_col` is
+  /// empty).  Each segment carries its own bus-balance stamp with the
+  /// per-segment loss factor; the Kirchhoff (KVL) row sums them with
+  /// `+x_τ` per segment to recover `x_τ · f_p`.
+  std::vector<ColIndex> seg_p_cols;
+  /// Per-segment columns for the B→A direction.  Same semantics as
+  /// `seg_p_cols`; KVL stamps each with `−x_τ`.
+  std::vector<ColIndex> seg_n_cols;
 };
 
 // ─── Mode resolution ────────────────────────────────────────────────

--- a/include/gtopt/line_lp.hpp
+++ b/include/gtopt/line_lp.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include <gtopt/bus_lp.hpp>
 #include <gtopt/capacity_object_lp.hpp>
 #include <gtopt/generator.hpp>
@@ -170,6 +172,12 @@ private:
    *   -θ_a + θ_b + x_tau·fp − x_tau·fn = −φ_rad
    * where x_tau = τ·X/V².  Row scaling is left to the LP layer's
    * row-max equilibration (which auto-unscales duals on output).
+   *
+   * In `piecewise_direct` mode there is no flowp / flown aggregator; the
+   * caller passes the per-direction segment columns instead, and each
+   * segment is stamped into the KVL row with `±x_τ` (PLP `genpdlin.f`).
+   * The aggregator path (`fpcols` / `fncols`) and the segment path
+   * (`fpsegcols` / `fnsegcols`) are mutually exclusive per block.
    */
   void add_kirchhoff_rows(SystemContext& sc,
                           const ScenarioLP& scenario,
@@ -178,7 +186,9 @@ private:
                           const BusLP& bus_a_lp,
                           const BusLP& bus_b_lp,
                           const BIndexHolder<ColIndex>& fpcols,
-                          const BIndexHolder<ColIndex>& fncols);
+                          const BIndexHolder<ColIndex>& fncols,
+                          const BIndexHolder<std::vector<ColIndex>>& fpsegcols,
+                          const BIndexHolder<std::vector<ColIndex>>& fnsegcols);
 };
 
 }  // namespace gtopt

--- a/source/line_losses.cpp
+++ b/source/line_losses.cpp
@@ -320,6 +320,8 @@ BlockResult add_none(const ScenarioLP& scenario,
       .lossn_col = {},
       .capp_row = {},
       .capn_row = {},
+      .seg_p_cols = {},
+      .seg_n_cols = {},
   };
 }
 
@@ -717,6 +719,8 @@ BlockResult add_bidirectional(const LossConfig& config,
       .lossn_col = lsn,
       .capp_row = capp,
       .capn_row = capn,
+      .seg_p_cols = {},
+      .seg_n_cols = {},
   };
 }
 
@@ -728,10 +732,22 @@ BlockResult add_bidirectional(const LossConfig& config,
 /// with its per-segment loss factor λ_k baked into the coefficients
 /// (PLP `genpdlin.f:107-164`).
 ///
-/// Returns the aggregation column so the caller can expose it as
-/// `fp_col` / `fn_col` — preserving the downstream API used by
-/// Kirchhoff and the reporters.
-[[nodiscard]] std::optional<ColIndex> add_direct_direction(
+/// Returns the per-segment column list for one direction (PLP-faithful):
+///   - K segment columns, each bounded `[0, w = tmax/K]`
+///   - Per-segment bus-balance stamps with allocation-aware loss factor
+///     `λ_k = w · (2k−1) · R / V²` (PLP `genpdlin.f:107-114`).
+///
+/// **No aggregator column, no link row.**  The Kirchhoff (KVL) row stamps
+/// each segment with `±x_τ` so the algebraic identity `Σ seg_k = |f|` is
+/// recovered without an explicit equality row.  This is what halves the
+/// row count vs the older `piecewise` mode, and matches PLP exactly.
+///
+/// Per-segment transmission cost: split the line tcost across segments
+/// (`tcost_k = block_tcost / K`) so `Σ tcost_k · seg_k = tcost · |f|`
+/// after the segments saturate left-to-right.  At the optimum, segments
+/// fill in order of increasing loss factor, so the cost stays consistent
+/// with the legacy aggregator-based formulation.
+[[nodiscard]] std::vector<ColIndex> add_direct_direction(
     const LossConfig& config,
     const ScenarioLP& scenario,
     const StageLP& stage,
@@ -750,40 +766,12 @@ BlockResult add_bidirectional(const LossConfig& config,
 
   const int nseg = config.nseg;
   assert(nseg > 0 && "line_losses: nseg must be positive");
-  const auto reserve_sz = static_cast<size_t>(nseg) + 1;
   const double seg_width = block_tmax / nseg;
+  const double seg_tcost = block_tcost / nseg;
 
-  const auto block_ctx =
-      make_block_context(scenario.uid(), stage.uid(), block.uid());
+  std::vector<ColIndex> seg_cols;
+  seg_cols.reserve(static_cast<size_t>(nseg));
 
-  // Aggregation column: carries the transmission cost and is the single
-  // "flow" handle seen by Kirchhoff / reporters.  No bus-balance stamp
-  // (losses are baked into the per-segment coefficients).
-  const auto agg_col = lp.add_col({
-      .lowb = 0,
-      .uppb = block_tmax,
-      .cost = block_tcost,
-      .class_name = LineLP::ClassName.full_name(),
-      .variable_name = labels.flow,
-      .variable_uid = uid,
-      .context = block_ctx,
-  });
-
-  // Linking row: agg − Σ seg_k = 0
-  auto linkrow =
-      SparseRow {
-          .class_name = LineLP::ClassName.full_name(),
-          .constraint_name = labels.link,
-          .variable_uid = uid,
-          .context = block_ctx,
-      }
-          .equal(0);
-  linkrow.reserve(reserve_sz);
-  linkrow[agg_col] = +1.0;
-
-  // Per-segment cols + bus stamps with allocation-aware loss factor.
-  // Segment k (1-based) loss factor: λ_k = w · (2k−1) · R / V²
-  // (PLP `genpdlin.f:107-114`, `LinRImp = LinRes*(2*IFlu - 1)`).
   for (const auto k : iota_range(1, nseg + 1)) {
     const double lf_k = seg_width * config.resistance
         * static_cast<double>((2 * k) - 1) / config.V2;
@@ -791,6 +779,7 @@ BlockResult add_bidirectional(const LossConfig& config,
     const auto seg_col = lp.add_col({
         .lowb = 0,
         .uppb = seg_width,
+        .cost = seg_tcost,
         .class_name = LineLP::ClassName.full_name(),
         .variable_name = labels.seg,
         .variable_uid = uid,
@@ -798,14 +787,12 @@ BlockResult add_bidirectional(const LossConfig& config,
             make_block_context(scenario.uid(), stage.uid(), block.uid(), k),
     });
 
-    linkrow[seg_col] = -1.0;
     apply_linear_allocation(
         sending_brow, receiving_brow, seg_col, lf_k, config.allocation);
+    seg_cols.push_back(seg_col);
   }
 
-  [[maybe_unused]] auto linkrow_idx = lp.add_row(std::move(linkrow));
-
-  return agg_col;
+  return seg_cols;
 }
 
 /// PLP-direct piecewise-linear: no loss variables, no loss-tracking
@@ -828,37 +815,39 @@ BlockResult add_piecewise_direct(const LossConfig& config,
                                  double block_tcost,
                                  Uid uid)
 {
-  auto fp = add_direct_direction(config,
-                                 scenario,
-                                 stage,
-                                 block,
-                                 lp,
-                                 brow_a,
-                                 brow_b,
-                                 block_tmax_ab,
-                                 block_tcost,
-                                 uid,
-                                 positive_labels);
+  auto seg_p_cols = add_direct_direction(config,
+                                         scenario,
+                                         stage,
+                                         block,
+                                         lp,
+                                         brow_a,
+                                         brow_b,
+                                         block_tmax_ab,
+                                         block_tcost,
+                                         uid,
+                                         positive_labels);
 
-  auto fn = add_direct_direction(config,
-                                 scenario,
-                                 stage,
-                                 block,
-                                 lp,
-                                 brow_b,
-                                 brow_a,
-                                 block_tmax_ba,
-                                 block_tcost,
-                                 uid,
-                                 negative_labels);
+  auto seg_n_cols = add_direct_direction(config,
+                                         scenario,
+                                         stage,
+                                         block,
+                                         lp,
+                                         brow_b,
+                                         brow_a,
+                                         block_tmax_ba,
+                                         block_tcost,
+                                         uid,
+                                         negative_labels);
 
   return {
-      .fp_col = fp,
-      .fn_col = fn,
+      .fp_col = {},
+      .fn_col = {},
       .lossp_col = {},
       .lossn_col = {},
       .capp_row = {},
       .capn_row = {},
+      .seg_p_cols = std::move(seg_p_cols),
+      .seg_n_cols = std::move(seg_n_cols),
   };
 }
 

--- a/source/line_lp.cpp
+++ b/source/line_lp.cpp
@@ -29,14 +29,17 @@ LineLP::LineLP(const Line& pline, const InputContext& ic)
 
 // ── add_kirchhoff_rows ──────────────────────────────────────────────
 
-void LineLP::add_kirchhoff_rows(SystemContext& sc,
-                                const ScenarioLP& scenario,
-                                const StageLP& stage,
-                                LinearProblem& lp,
-                                const BusLP& bus_a_lp,
-                                const BusLP& bus_b_lp,
-                                const BIndexHolder<ColIndex>& fpcols,
-                                const BIndexHolder<ColIndex>& fncols)
+void LineLP::add_kirchhoff_rows(
+    SystemContext& sc,
+    const ScenarioLP& scenario,
+    const StageLP& stage,
+    LinearProblem& lp,
+    const BusLP& bus_a_lp,
+    const BusLP& bus_b_lp,
+    const BIndexHolder<ColIndex>& fpcols,
+    const BIndexHolder<ColIndex>& fncols,
+    const BIndexHolder<std::vector<ColIndex>>& fpsegcols,
+    const BIndexHolder<std::vector<ColIndex>>& fnsegcols)
 {
   const auto& stage_reactance = sc.stage_reactance(stage, reactance);
   // Skip Kirchhoff for lines without reactance (DC/HVDC lines).
@@ -107,15 +110,34 @@ void LineLP::add_kirchhoff_rows(SystemContext& sc,
         }
             .equal(kirchhoff_rhs);
 
-    trow.reserve(4);
+    // piecewise_direct mode stamps each segment column directly with
+    // ±x_τ (PLP genpdlin.f); other modes stamp the aggregator. Per
+    // block, exactly one of {segs, aggregator} is populated per
+    // direction.  Pre-reserve roughly: 2 thetas + segs + aggregator.
+    const auto fp_seg_it = fpsegcols.find(buid);
+    const auto fn_seg_it = fnsegcols.find(buid);
+    const auto fp_seg_n =
+        (fp_seg_it != fpsegcols.end()) ? fp_seg_it->second.size() : 0;
+    const auto fn_seg_n =
+        (fn_seg_it != fnsegcols.end()) ? fn_seg_it->second.size() : 0;
+    trow.reserve(2 + fp_seg_n + fn_seg_n + 2);
 
     trow[theta_a_cols.at(buid)] = -1.0;
     trow[theta_b_cols.at(buid)] = +1.0;
-    if (!fpcols.empty()) {
-      trow[fpcols.at(buid)] = +x_tau;
+
+    if (fp_seg_n != 0) {
+      for (const auto& col : fp_seg_it->second) {
+        trow[col] = +x_tau;
+      }
+    } else if (auto fit = fpcols.find(buid); fit != fpcols.end()) {
+      trow[fit->second] = +x_tau;
     }
-    if (!fncols.empty()) {
-      trow[fncols.at(buid)] = -x_tau;
+    if (fn_seg_n != 0) {
+      for (const auto& col : fn_seg_it->second) {
+        trow[col] = -x_tau;
+      }
+    } else if (auto fit = fncols.find(buid); fit != fncols.end()) {
+      trow[fit->second] = -x_tau;
     }
 
     trows[buid] = lp.add_row(std::move(trow));
@@ -212,6 +234,8 @@ bool LineLP::add_to_lp(SystemContext& sc,
   BIndexHolder<RowIndex> cnrows;
   BIndexHolder<ColIndex> lpcols;
   BIndexHolder<ColIndex> lncols;
+  BIndexHolder<std::vector<ColIndex>> fpsegcols;
+  BIndexHolder<std::vector<ColIndex>> fnsegcols;
   map_reserve(fpcols, blocks.size());
   map_reserve(cprows, blocks.size());
   map_reserve(fncols, blocks.size());
@@ -258,11 +282,25 @@ bool LineLP::add_to_lp(SystemContext& sc,
     if (result.capn_row) {
       cnrows[buid] = *result.capn_row;
     }
+    if (!result.seg_p_cols.empty()) {
+      fpsegcols[buid] = std::move(result.seg_p_cols);
+    }
+    if (!result.seg_n_cols.empty()) {
+      fnsegcols[buid] = std::move(result.seg_n_cols);
+    }
   }
 
   // ── Kirchhoff (DC OPF) constraints ────────────────────────────────
-  add_kirchhoff_rows(
-      sc, scenario, stage, lp, bus_a_lp, bus_b_lp, fpcols, fncols);
+  add_kirchhoff_rows(sc,
+                     scenario,
+                     stage,
+                     lp,
+                     bus_a_lp,
+                     bus_b_lp,
+                     fpcols,
+                     fncols,
+                     fpsegcols,
+                     fnsegcols);
 
   // Store all indices for this (scenario, stage)
   const auto st_key = std::tuple {scenario.uid(), stage.uid()};

--- a/test/source/test_line_losses.cpp
+++ b/test/source/test_line_losses.cpp
@@ -440,6 +440,94 @@ TEST_CASE(
   CHECK(obj_pw == doctest::Approx(obj_bi).epsilon(0.01));
 }
 
+// ── Measured P_loss vs analytical ─────────────────────────────────
+//
+// `solve_with_mode` uses a 2-bus problem with demand D=100 MW at bus_b
+// and gen on bus_a (gcost=10).  With scale_objective=1000 and zero
+// transmission cost, the LP objective is `obj = gen·gcost/scale = gen/100`,
+// so `gen = 100·obj` and the *measured* loss is `P_loss = gen − D`.
+//
+// The closed-form expected losses (D=100, R=0.01, V²=10⁴, K=3) are:
+//
+//  - none:                  0
+//  - linear (auto λ=R·f_max/V²=2·10⁻⁴):
+//                           D · λ / (1−λ)               ≈ 0.020004
+//  - piecewise / bidirectional / piecewise_direct:
+//      seg_1 fills to w (=66.667 MW), bus_b receives w·(1−λ_1).  The
+//      remaining flow goes through partial seg_2, giving
+//      `gen = w + (D − w·(1−λ_1)) / (1−λ_2)`            ≈ 100.0115
+//      and P_loss ≈ 0.0115 MW.  All three PWL modes share this exact
+//      (non-quadratic) approximation because they share the same
+//      per-segment loss factor `λ_k = w·(2k−1)·R/V²` (PLP genpdlin.f).
+TEST_CASE("line_losses - measured P_loss vs analytical per mode")
+{
+  constexpr int K = 3;
+  constexpr double D = 100.0;
+  constexpr double scale = 1000.0;
+  constexpr double gcost = 10.0;
+  constexpr double R = 0.01;
+  constexpr double V2 = 10000.0;  // V=100kV
+  constexpr double w = 200.0 / K;  // seg width = 66.667 MW
+  constexpr double lambda_1 = w * R * 1.0 / V2;
+  constexpr double lambda_2 = w * R * 3.0 / V2;
+  constexpr double lambda_lin = R * 200.0 / V2;  // auto-linear lossfactor
+
+  const auto measured_loss = [](double obj)
+  { return ((obj * scale) / gcost) - D; };
+
+  // PWL modes (D=100, K=3): seg_1 saturates, seg_2 partial.
+  const double seg2 = (D - (w * (1.0 - lambda_1))) / (1.0 - lambda_2);
+  const double expected_pwl = (w + seg2) - D;
+  // Linear mode: gen = D/(1−λ), loss = D·λ/(1−λ).
+  const double expected_linear = (D * lambda_lin) / (1.0 - lambda_lin);
+
+  SUBCASE("none — zero measured loss")
+  {
+    const auto loss = measured_loss(solve_with_mode("none", K));
+    CHECK(loss == doctest::Approx(0.0).epsilon(1e-9));
+  }
+
+  SUBCASE("linear — D·λ/(1−λ) with auto λ = R·f_max/V²")
+  {
+    const auto loss = measured_loss(solve_with_mode("linear", K));
+    CHECK(loss == doctest::Approx(expected_linear).epsilon(1e-6));
+  }
+
+  SUBCASE("piecewise — PLP per-segment loss factor with partial seg_2")
+  {
+    const auto loss = measured_loss(solve_with_mode("piecewise", K));
+    CHECK(loss == doctest::Approx(expected_pwl).epsilon(1e-6));
+  }
+
+  SUBCASE("bidirectional — same PWL on the active direction")
+  {
+    const auto loss = measured_loss(solve_with_mode("bidirectional", K));
+    CHECK(loss == doctest::Approx(expected_pwl).epsilon(1e-6));
+  }
+
+  SUBCASE("piecewise_direct — PLP-faithful, segments stamp directly")
+  {
+    const auto loss = measured_loss(solve_with_mode("piecewise_direct", K));
+    CHECK(loss == doctest::Approx(expected_pwl).epsilon(1e-6));
+  }
+
+  SUBCASE("PWL approximation tracks the quadratic law within 1/(2K)")
+  {
+    // True quadratic loss at f ≈ gen: P_loss_q = R · f² / V².  The PWL
+    // approximation has truncation error bounded by the maximum slope
+    // gap across segment boundaries — empirically within 1/(2K) relative
+    // error of the integrated quadratic loss for partial fills.
+    for (const auto& mode : {"piecewise", "bidirectional", "piecewise_direct"})
+    {
+      CAPTURE(mode);
+      const auto loss_pw = measured_loss(solve_with_mode(mode, K));
+      const double f = D + loss_pw;
+      const double loss_q = (R * f * f) / V2;
+      CHECK(loss_pw == doctest::Approx(loss_q).epsilon(1.0 / (2.0 * K)));
+    }
+  }
+}
+
 TEST_CASE("line_losses engine - adaptive mode selects based on expansion")
 {
   // Without expansion → piecewise.  We can test this indirectly:
@@ -981,30 +1069,23 @@ TEST_CASE("line_losses LP structure - bidirectional mode")
 
 TEST_CASE("line_losses LP structure - piecewise_direct mode")
 {
-  // 3 segments per direction, R=0.01, V=100 → V²=10000
+  // 3 segments per direction, R=0.01, V=100 → V²=10000.
+  // PLP-faithful: no aggregator, no link row, segments stamp directly
+  // into the bus-balance row (and the KVL row when use_kirchhoff=true).
   LPFixture fix("piecewise_direct", /*loss_segments=*/3);
   auto& li = fix.lp();
 
-  SUBCASE("creates fp_agg, fn_agg + K=3 segments per direction; no loss cols")
+  SUBCASE("creates exactly K segments per direction; no aggregator, no loss")
   {
-    // flowp_ matches aggregation col + 3 segment cols = 4
-    CHECK(count_cols_containing(li, "line_flowp_") == 4);
-    CHECK(count_cols_containing(li, "line_flown_") == 4);
+    // Only segments — no aggregator column, so flowp_ count matches
+    // flowp_seg_ count exactly.
+    CHECK(count_cols_containing(li, "line_flowp_") == 3);
+    CHECK(count_cols_containing(li, "line_flown_") == 3);
     CHECK(count_cols_containing(li, "line_flowp_seg_") == 3);
     CHECK(count_cols_containing(li, "line_flown_seg_") == 3);
     // No loss variables — losses are baked into bus-balance coefficients
     CHECK(count_cols_containing(li, "line_lossp_") == 0);
     CHECK(count_cols_containing(li, "line_lossn_") == 0);
-  }
-
-  SUBCASE("aggregation col bounds are [0, tmax]")
-  {
-    const auto fp = find_col(li, "line_flowp_", "_seg_");
-    const auto fn = find_col(li, "line_flown_", "_seg_");
-    CHECK(li.get_col_low()[value_of(fp)] == doctest::Approx(0.0));
-    CHECK(li.get_col_upp()[value_of(fp)] == doctest::Approx(200.0));
-    CHECK(li.get_col_low()[value_of(fn)] == doctest::Approx(0.0));
-    CHECK(li.get_col_upp()[value_of(fn)] == doctest::Approx(200.0));
   }
 
   SUBCASE("segment bounds are [0, tmax/K]")
@@ -1019,48 +1100,13 @@ TEST_CASE("line_losses LP structure - piecewise_direct mode")
     }
   }
 
-  SUBCASE("two linking rows total (one per direction); no loss-tracking rows")
+  SUBCASE("no link rows, no loss-tracking rows (PLP-faithful)")
   {
-    CHECK(count_rows_containing(li, "line_flowp_link_") == 1);
-    CHECK(count_rows_containing(li, "line_flown_link_") == 1);
+    CHECK(count_rows_containing(li, "line_flowp_link_") == 0);
+    CHECK(count_rows_containing(li, "line_flown_link_") == 0);
     CHECK(count_rows_containing(li, "line_lossp_link_") == 0);
     CHECK(count_rows_containing(li, "line_lossn_link_") == 0);
     CHECK(count_rows_containing(li, "line_loss_link_") == 0);
-  }
-
-  SUBCASE("positive linking row: fp_agg − Σ seg_k = 0")
-  {
-    const auto lnk = find_row(li, "line_flowp_link_");
-    const auto fp = find_col(li, "line_flowp_", "_seg_");
-
-    CHECK(li.get_row_low()[value_of(lnk)] == doctest::Approx(0.0));
-    CHECK(li.get_row_upp()[value_of(lnk)] == doctest::Approx(0.0));
-    CHECK(li.get_coeff(lnk, fp) == doctest::Approx(1.0));
-
-    int seg_count = 0;
-    for (const auto& [name, idx] : li.col_name_map()) {
-      if (name.contains("line_flowp_seg_")) {
-        CHECK(li.get_coeff(lnk, idx) == doctest::Approx(-1.0));
-        ++seg_count;
-      }
-    }
-    CHECK(seg_count == 3);
-  }
-
-  SUBCASE("aggregation col has zero bus-balance coefficient")
-  {
-    // fp_agg / fn_agg are pure accounting; loss allocation lives on
-    // the segment cols.  This preserves the downstream fp_col API for
-    // Kirchhoff and reporters without double-counting.
-    const auto fp = find_col(li, "line_flowp_", "_seg_");
-    const auto fn = find_col(li, "line_flown_", "_seg_");
-    const auto bal_a = find_row(li, "bus_balance_1");
-    const auto bal_b = find_row(li, "bus_balance_2");
-
-    CHECK(li.get_coeff(bal_a, fp) == doctest::Approx(0.0));
-    CHECK(li.get_coeff(bal_b, fp) == doctest::Approx(0.0));
-    CHECK(li.get_coeff(bal_a, fn) == doctest::Approx(0.0));
-    CHECK(li.get_coeff(bal_b, fn) == doctest::Approx(0.0));
   }
 
   SUBCASE("positive segments stamp bus balance with per-segment loss factor")
@@ -1122,7 +1168,7 @@ TEST_CASE("line_losses LP structure - piecewise_direct mode")
     }
   }
 
-  SUBCASE("direct has same row count as piecewise but no loss cols")
+  SUBCASE("direct has zero line-loss-engine rows; piecewise has 2")
   {
     LPFixture fix_pw("piecewise", /*loss_segments=*/3);
     auto& li_pw = fix_pw.lp();
@@ -1130,15 +1176,15 @@ TEST_CASE("line_losses LP structure - piecewise_direct mode")
     // piecewise: 1 flow_link + 1 loss_link = 2 line-specific rows
     const int pw_rows = count_rows_containing(li_pw, "line_flow_link")
         + count_rows_containing(li_pw, "line_loss_link");
-    // direct: flowp_link + flown_link = 2 line-specific rows
+    // direct: zero — bus stamps and KVL stamps replace both.
     const int dir_rows = count_rows_containing(li, "line_flowp_link")
         + count_rows_containing(li, "line_flown_link")
         + count_rows_containing(li, "line_loss_link");
 
     CHECK(pw_rows == 2);
-    CHECK(dir_rows == 2);
+    CHECK(dir_rows == 0);
 
-    // But direct has zero loss variables
+    // direct has zero loss variables and zero aggregator columns
     CHECK(count_cols_containing(li, "line_lossp_")
               + count_cols_containing(li, "line_lossn_")
           == 0);
@@ -1258,13 +1304,14 @@ TEST_CASE("line_losses - all modes cross-comparison matrix")
   // | bidirectional        | 2·(K + 2)        | 4                |
   // | dynamic              | K + 3            | 2                |
   // | adaptive (→piecewise) | K + 3           | 2                |
-  // | piecewise_direct     | 2·(K + 1)        | 2                |
+  // | piecewise_direct     | 2·K              | 0                |
   //
-  // NOTE: piecewise_direct has MORE cols than piecewise (per-direction
-  // segments cannot be shared with direction-dependent loss allocation).
-  // Its win is PLP-semantic parity + zero loss cols/rows, not LP size.
-  // `adaptive` now picks the smallest-LP PWL model (`piecewise`), so
-  // `piecewise_direct` is an opt-in for PLP-diff parity only.
+  // NOTE: piecewise_direct is the only mode with **zero** line-loss-engine
+  // rows.  Per direction, K segments stamp directly into the bus-balance
+  // row (with allocation-aware loss factor) and into the KVL row (with
+  // ±x_τ).  No aggregator, no link, no loss column — the most compact
+  // formulation, matching PLP `genpdlin.f` exactly.  `adaptive` still
+  // picks `piecewise`; `piecewise_direct` remains opt-in.
   const std::array<ModeExpect, 7> expect = {{
       {.name = "none",
        .flowp_like_cols = 1,
@@ -1363,21 +1410,21 @@ TEST_CASE("line_losses - all modes cross-comparison matrix")
        .total_loss_cols = K + 3,
        .total_loss_rows = 2},
       {.name = "piecewise_direct",
-       .flowp_like_cols = 1 + K,
-       .flown_like_cols = 1 + K,
+       .flowp_like_cols = K,
+       .flown_like_cols = K,
        .seg_cols = 0,
        .flowp_seg_cols = K,
        .flown_seg_cols = K,
        .lossp_cols = 0,
        .lossn_cols = 0,
        .flow_link_rows = 0,
-       .flowp_link_rows = 1,
-       .flown_link_rows = 1,
+       .flowp_link_rows = 0,
+       .flown_link_rows = 0,
        .loss_link_rows = 0,
        .lossp_link_rows = 0,
        .lossn_link_rows = 0,
-       .total_loss_cols = 2 * (K + 1),
-       .total_loss_rows = 2},
+       .total_loss_cols = 2 * K,
+       .total_loss_rows = 0},
   }};
 
   // Count cols/rows whose name starts with `line_` but are NOT part of


### PR DESCRIPTION
Drop the per-direction flowp/flown aggregator columns and link rows in piecewise_direct mode.  Segments now stamp directly into both the bus-balance row (with the per-segment loss factor 1−λ_k) and the Kirchhoff (KVL) row (with ±x_τ), so the identity Σ seg_k = |f| is recovered without an explicit equality.  This matches PLP's genpdlin.f LP layout exactly.

Effect on the juan period-28 LP (already configured for piecewise_direct): 17,090 → 11,228 rows (−5,862 / −34%).  Per line per block we save 1 column + 1 row per direction, with a small KVL widening (~K nonzeros per direction).  KVL row count is unchanged.

Updated the LP-structure tests to assert the new layout (0 link rows, K segments per direction, no aggregator) and added a new "measured P_loss vs analytical" test that solves a 2-bus problem in every loss mode and checks that the realised loss gen − demand matches the closed-form PLP/linear formula and stays within the 1/(2K) PWL truncation bound.

The trade-off: line.flowp / line.flown solution columns are no longer emitted for piecewise_direct lines (use 'piecewise' if you need them).  Documented in line_enums.hpp.

All 2,857 unit tests green.