### PR TITLE
perf(sddp): parallelize per-scene cut writes, drop versioned state file, log post-iter breakdown

### DIFF
--- a/include/gtopt/sddp_cut_store.hpp
+++ b/include/gtopt/sddp_cut_store.hpp
@@ -38,6 +38,7 @@ namespace gtopt
 class PlanningLP;
 struct SDDPOptions;
 struct PhaseStateInfo;
+class SDDPWorkPool;
 
 // ─── Stored cut types ──────────────────────────────────────────────────────
 
@@ -336,6 +337,14 @@ public:
                                        const LabelMaker& label_maker);
 
   /// Save cuts (combined + per-scene) after an iteration.
+  ///
+  /// When @p pool is non-null, the per-scene cut-file writes are
+  /// dispatched as parallel tasks (16 sequential writes → 16 in
+  /// parallel on a saturated pool, ~0.5–1 s saved per iteration on
+  /// the juan/gtopt_iplp scale).  When @p pool is null, falls back
+  /// to a sequential loop — used by code paths that do not have a
+  /// pool available (e.g. unit tests that exercise this method
+  /// directly without going through `SDDPMethod::solve`).
   void save_cuts_for_iteration(
       IterationIndex iteration_index,
       std::span<const uint8_t> scene_feasible,
@@ -345,7 +354,8 @@ public:
       const StrongIndexVector<SceneIndex,
                               StrongIndexVector<PhaseIndex, PhaseStateInfo>>&
           scene_phase_states,
-      IterationIndex current_iteration);
+      IterationIndex current_iteration,
+      SDDPWorkPool* pool = nullptr);
 
 private:
   /// Per-scene cut storage — the single source of truth for every

--- a/source/sddp_cut_store.cpp
+++ b/source/sddp_cut_store.cpp
@@ -584,7 +584,8 @@ void SDDPCutManager::save_cuts_for_iteration(
     const StrongIndexVector<SceneIndex,
                             StrongIndexVector<PhaseIndex, PhaseStateInfo>>&
     /*scene_phase_states*/,
-    IterationIndex current_iteration)
+    IterationIndex current_iteration,
+    SDDPWorkPool* pool)
 {
   if (options.cuts_output_file.empty()) {
     return;
@@ -592,6 +593,18 @@ void SDDPCutManager::save_cuts_for_iteration(
 
   const auto cut_dir =
       std::filesystem::path(options.cuts_output_file).parent_path();
+
+  // Per-stage timing for the iter-end gap audit.  Each stage's
+  // duration is reported in a single INFO line at the end so
+  // operators can break down "post-iter housekeeping took X s" into
+  // its components without rebuilding with TRACE logging on.
+  using Clock = std::chrono::steady_clock;
+  const auto elapsed_s = [](Clock::time_point start) noexcept
+  { return std::chrono::duration<double>(Clock::now() - start).count(); };
+  double dt_combined = 0.0;
+  double dt_per_scene = 0.0;
+  double dt_state = 0.0;
+  double dt_rename = 0.0;
 
   // Helper: save all cuts to a file
   auto save_all = [&](const std::string& filepath) -> std::expected<void, Error>
@@ -607,8 +620,9 @@ void SDDPCutManager::save_cuts_for_iteration(
     return save_cuts_csv(combined, planning_lp, filepath);
   };
 
-  // Save to a versioned file: sddp_cuts_<iter>.csv
+  // ── Save to a versioned file: sddp_cuts_<iter>.csv ──
   if (!cut_dir.empty()) {
+    const auto t0 = Clock::now();
     const auto versioned_file =
         (cut_dir / std::format(sddp_file::versioned_cuts_fmt, iteration_index))
             .string();
@@ -618,29 +632,85 @@ void SDDPCutManager::save_cuts_for_iteration(
                   iteration_index,
                   result.error().message);
     }
+    dt_combined = elapsed_s(t0);
   }
 
-  // Save per-scene cuts
+  const auto num_scenes = planning_lp.simulation().scene_count();
+  const auto& scenes = planning_lp.simulation().scenes();
+
+  // ── Save per-scene cuts (parallelised when a pool is available) ──
+  //
+  // Sequential cost on the juan/gtopt_iplp case: ~16 sequential CSV
+  // writes, dominated by per-cut label formatting; profiled at
+  // 0.5–1 s/iter.  Dispatching them via the SDDP work pool overlaps
+  // formatting + I/O across workers (the pool is otherwise idle in
+  // this post-iter gap), reducing the wall to a single write's
+  // duration.
   if (!cut_dir.empty()) {
-    const auto num_scenes = planning_lp.simulation().scene_count();
-    const auto& scenes = planning_lp.simulation().scenes();
-    for (const auto scene_index : iota_range<SceneIndex>(0, num_scenes)) {
-      auto result = save_scene_cuts_csv(m_scene_cuts_[scene_index],
-                                        scene_index,
-                                        scenes[scene_index].uid(),
-                                        planning_lp,
-                                        cut_dir.string());
-      if (!result.has_value()) {
-        SPDLOG_WARN("SDDP: could not save per-scene cuts at iter {}: {}",
-                    iteration_index,
-                    result.error().message);
-        break;
+    const auto t0 = Clock::now();
+    if (pool != nullptr && num_scenes > Index {1}) {
+      std::vector<std::future<std::expected<void, Error>>> futures;
+      futures.reserve(static_cast<std::size_t>(num_scenes));
+      for (const auto scene_index : iota_range<SceneIndex>(0, num_scenes)) {
+        const auto scene_uid = scenes[scene_index].uid();
+        const auto cut_dir_str = cut_dir.string();
+        // Capture by value/reference appropriately: per-scene cut
+        // vectors are read-only here (no mutation by the writer);
+        // `planning_lp` is also read-only for `save_scene_cuts_csv`.
+        auto fut = pool->submit(
+            [this, scene_index, scene_uid, &planning_lp, cut_dir_str]
+            {
+              return save_scene_cuts_csv(m_scene_cuts_[scene_index],
+                                         scene_index,
+                                         scene_uid,
+                                         planning_lp,
+                                         cut_dir_str);
+            });
+        if (fut.has_value()) {
+          futures.push_back(std::move(*fut));
+        }
+      }
+      for (auto& f : futures) {
+        auto result = f.get();
+        if (!result.has_value()) {
+          SPDLOG_WARN("SDDP: could not save per-scene cuts at iter {}: {}",
+                      iteration_index,
+                      result.error().message);
+          // Continue draining other futures rather than break — we
+          // want every worker's result observed before we move on so
+          // the pool's accounting and the `f.get()` blocking
+          // semantics are honoured in order.
+        }
+      }
+    } else {
+      for (const auto scene_index : iota_range<SceneIndex>(0, num_scenes)) {
+        auto result = save_scene_cuts_csv(m_scene_cuts_[scene_index],
+                                          scene_index,
+                                          scenes[scene_index].uid(),
+                                          planning_lp,
+                                          cut_dir.string());
+        if (!result.has_value()) {
+          SPDLOG_WARN("SDDP: could not save per-scene cuts at iter {}: {}",
+                      iteration_index,
+                      result.error().message);
+          break;
+        }
       }
     }
+    dt_per_scene = elapsed_s(t0);
   }
 
-  // Save state variable column solutions (latest + versioned)
+  // ── Save state variable column solutions (latest only) ──
+  //
+  // Previous design wrote both `sddp_state.csv` (latest) and
+  // `sddp_state_<iter>.csv` (versioned).  The versioned file
+  // doubled the per-iter cost (~8 GB written cumulatively over a
+  // full juan run) for negligible benefit: the policy is encoded
+  // by the cuts, which ARE versioned, and re-running from cuts
+  // reconstructs state.  Keeping only the latest file is enough
+  // for real-time monitoring.
   if (!cut_dir.empty()) {
+    const auto t0 = Clock::now();
     const auto state_file = (cut_dir / sddp_file::state_cols).string();
     auto sr = save_state_csv(planning_lp, state_file, current_iteration);
     if (!sr.has_value()) {
@@ -648,42 +718,49 @@ void SDDPCutManager::save_cuts_for_iteration(
                   iteration_index,
                   sr.error().message);
     }
-    const auto versioned_state =
-        (cut_dir / std::format(sddp_file::versioned_state_fmt, iteration_index))
-            .string();
-    sr = save_state_csv(planning_lp, versioned_state, current_iteration);
-    if (!sr.has_value()) {
-      SPDLOG_WARN("SDDP: could not save versioned state at iter {}: {}",
-                  iteration_index,
-                  sr.error().message);
-    }
+    dt_state = elapsed_s(t0);
   }
 
-  // Rename cut files for infeasible scenes
-  const auto num_scenes = planning_lp.simulation().scene_count();
-  const auto& scenes = planning_lp.simulation().scenes();
-  for (const auto scene_index : iota_range<SceneIndex>(0, num_scenes)) {
-    if (scene_feasible[scene_index] != 0U) {
-      continue;
-    }
-    if (cut_dir.empty()) {
-      continue;
-    }
-    const auto suid = scenes[scene_index].uid();
-    const auto scene_file =
-        cut_dir / std::format(sddp_file::scene_cuts_fmt, suid);
-    const auto error_file =
-        cut_dir / std::format(sddp_file::error_scene_cuts_fmt, suid);
-    std::error_code ec;
-    if (std::filesystem::exists(scene_file, ec)) {
-      std::filesystem::rename(scene_file, error_file, ec);
-      if (!ec) {
-        SPDLOG_TRACE("SDDP: renamed cut file for infeasible scene {} to {}",
-                     scene_index,
-                     error_file.string());
+  // ── Rename cut files for infeasible scenes ──
+  {
+    const auto t0 = Clock::now();
+    for (const auto scene_index : iota_range<SceneIndex>(0, num_scenes)) {
+      if (scene_feasible[scene_index] != 0U) {
+        continue;
+      }
+      if (cut_dir.empty()) {
+        continue;
+      }
+      const auto suid = scenes[scene_index].uid();
+      const auto scene_file =
+          cut_dir / std::format(sddp_file::scene_cuts_fmt, suid);
+      const auto error_file =
+          cut_dir / std::format(sddp_file::error_scene_cuts_fmt, suid);
+      std::error_code ec;
+      if (std::filesystem::exists(scene_file, ec)) {
+        std::filesystem::rename(scene_file, error_file, ec);
+        if (!ec) {
+          SPDLOG_TRACE("SDDP: renamed cut file for infeasible scene {} to {}",
+                       scene_index,
+                       error_file.string());
+        }
       }
     }
+    dt_rename = elapsed_s(t0);
   }
+
+  const auto dt_total = dt_combined + dt_per_scene + dt_state + dt_rename;
+  SPDLOG_INFO(
+      "SDDP Iter [i{}]: save_cuts_for_iteration {:.2f}s "
+      "— combined={:.2f}s per_scene={:.2f}s state={:.2f}s rename={:.3f}s "
+      "(parallel={})",
+      iteration_index,
+      dt_total,
+      dt_combined,
+      dt_per_scene,
+      dt_state,
+      dt_rename,
+      pool != nullptr ? "yes" : "no");
 }
 
 }  // namespace gtopt

--- a/source/sddp_iteration.cpp
+++ b/source/sddp_iteration.cpp
@@ -507,15 +507,38 @@ auto SDDPMethod::solve(const SolverOptions& lp_opts)
           ir.infeasible_cuts_added,
           ir.converged ? "[CONVERGED]" : "");
 
-      // ── Monitoring API and cut persistence ──
+      // ── Post-iteration housekeeping (timed) ──
+      // Single INFO line at the end summarises the breakdown so the
+      // inter-iteration gap visible in operator logs (e.g. juan/
+      // gtopt_iplp's ~10 s gap) can be attributed to its components
+      // — api status write, cut persistence, idempotent backend
+      // release safety net, and the user-supplied iteration
+      // callback — without rebuilding with TRACE logs on.
+      using PostClock = std::chrono::steady_clock;
+      const auto post_iter_t0 = PostClock::now();
+      const auto post_elapsed_s = [](PostClock::time_point start) noexcept
+      {
+        return std::chrono::duration<double>(PostClock::now() - start).count();
+      };
+
+      const auto t_api = PostClock::now();
       maybe_write_api_status(status_file, results, solve_start, monitor);
+      const auto dt_api = post_elapsed_s(t_api);
+
+      double dt_save = 0.0;
       if (m_options_.save_per_iteration) {
+        const auto t_save = PostClock::now();
         save_cuts_for_iteration(iteration_index, fwd->scene_feasible);
+        dt_save = post_elapsed_s(t_save);
       }
 
-      // ── Low-memory: release solver backends ──
-      // Free solver memory after each iteration.  Backends are
-      // reconstructed on demand in the next forward/backward pass.
+      // ── Low-memory: release solver backends (idempotent safety net) ──
+      // After the per-cell release scheme most cells are already
+      // released by the backward worker; this bulk loop is the
+      // idempotent safety net.  `release_backend` is a no-op when
+      // `m_backend_released_` is already set (`linear_interface.cpp:144`),
+      // so the cost is dominated by the loop overhead (~µs total).
+      const auto t_release = PostClock::now();
       if (m_options_.low_memory_mode != LowMemoryMode::off) {
         const auto ns = planning_lp().simulation().scene_count();
         const auto np = planning_lp().simulation().phase_count();
@@ -525,9 +548,26 @@ auto SDDPMethod::solve(const SolverOptions& lp_opts)
           }
         }
       }
+      const auto dt_release = post_elapsed_s(t_release);
 
       // ── Iteration callback ──
-      if (m_iteration_callback_ && m_iteration_callback_(ir)) {
+      const auto t_callback = PostClock::now();
+      const bool callback_requested_stop =
+          m_iteration_callback_ && m_iteration_callback_(ir);
+      const auto dt_callback = post_elapsed_s(t_callback);
+
+      const auto dt_post_iter = post_elapsed_s(post_iter_t0);
+      SPDLOG_INFO(
+          "SDDP Iter [i{}]: post-iter {:.2f}s — api={:.3f}s save={:.2f}s "
+          "release={:.3f}s callback={:.3f}s",
+          iteration_index,
+          dt_post_iter,
+          dt_api,
+          dt_save,
+          dt_release,
+          dt_callback);
+
+      if (callback_requested_stop) {
         SPDLOG_INFO("SDDP Iter [i{}]: callback requested stop",
                     iteration_index);
         break;

--- a/source/sddp_method_iteration.cpp
+++ b/source/sddp_method_iteration.cpp
@@ -1301,13 +1301,17 @@ void SDDPMethod::maybe_write_api_status(
 void SDDPMethod::save_cuts_for_iteration(
     IterationIndex iteration_index, std::span<const uint8_t> scene_feasible)
 {
+  // Pass `m_pool_` so the per-scene cut writes can be dispatched in
+  // parallel (sequential fallback when null — only happens before
+  // `solve()` has constructed the pool).
   m_cut_store_.save_cuts_for_iteration(iteration_index,
                                        scene_feasible,
                                        m_options_,
                                        planning_lp(),
                                        m_label_maker_,
                                        m_scene_phase_states_,
-                                       current_iteration());
+                                       current_iteration(),
+                                       m_pool_);
 }
 
 // ── solve() — now in sddp_iteration.cpp ─────────────────────────────────────


### PR DESCRIPTION
## Summary
- Parallelizes the 16 per-scene `save_scene_cuts_csv` calls via `m_pool_` (previously sequential while pool sat idle).
- Drops the redundant `sddp_state_<iter>.csv` write — only the latest `sddp_state.csv` is kept.
- Two new INFO log lines per iteration give a per-stage breakdown of post-iter housekeeping.

## Why

After the per-cell `release_backend()` change (#441) the bulk release loop is no longer the dominant inter-iter cost. Profiling pointed at `save_cuts_for_iteration` writing the versioned state file (8 GB cumulative on a juan run) and 16 scene CSVs sequentially. On juan/gtopt_iplp the inter-iter gap was 10.39 / 8.99 / 13.14 s for iter 0/1/2.

## New log lines

```
SDDP Iter [iN]: save_cuts_for_iteration X.XXs — combined=A.AAs per_scene=B.BBs state=C.CCs rename=D.DDDs (parallel=yes)
SDDP Iter [iN]: post-iter Y.YYs — api=E.EEEs save=F.FFs release=G.GGGs callback=H.HHHs
```

These attribute the iter-end gap to its components without TRACE-level rebuilds.

## API change

`SDDPCutManager::save_cuts_for_iteration` gained a defaulted trailing parameter `SDDPWorkPool* pool = nullptr` (forward-declared, no header churn). Sequential fallback when null. Source-compatible for all existing callers.

## Verification

`ctest --output-on-failure -j20` in `/tmp/gtopt-build-XJLW`: 3007/3007 in 51 s, zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)