### PR TITLE
perf(sddp): drop primal caches between iters, shrink aperture map, free label meta after write_out

### DIFF
--- a/include/gtopt/linear_interface.hpp
+++ b/include/gtopt/linear_interface.hpp
@@ -352,6 +352,69 @@ public:
    */
   void release_backend() noexcept;
 
+  /// Drop the cached primal vectors (`col_sol`, `col_cost`) but keep
+  /// `row_dual` (and the scalar caches).
+  ///
+  /// `release_backend()` populates three primal/dual snapshots so that
+  /// post-release readers can keep accessing the solution:
+  ///   - `col_sol` and `col_cost` are read by `OutputContext`,
+  ///     `save_state_csv`, and the SDDP state-variable propagation
+  ///     paths during the iteration that produced the solve.
+  ///   - `row_dual` is read **across iterations** by
+  ///     `update_stored_cut_duals` and `prune_inactive_cuts`
+  ///     (`sddp_cut_store.cpp:177, 222`).
+  ///
+  /// On a juan/gtopt_iplp run the col_sol + col_cost vectors carry
+  /// 0.7–2.5 GB across all `(scene, phase)` cells between iterations.
+  /// Once the iteration's state CSV has been written and the backward
+  /// pass has consumed the per-state-variable values via
+  /// `capture_state_variable_values`, neither vector is read again
+  /// until the next solve overwrites it — making them the largest
+  /// "alive but unused" allocation in the SDDP loop.
+  ///
+  /// Call this after `save_cuts_for_iteration` (state CSV) returns
+  /// and before the next iteration's forward pass begins.  Safe under
+  /// `low_memory_mode == off` (no-op since the caches stay empty)
+  /// and idempotent.  Does NOT touch `m_cached_row_dual_`,
+  /// `m_cached_obj_value_`, `m_cached_kappa_`, `m_cached_numrows_`,
+  /// `m_cached_numcols_`, or `m_cached_is_optimal_` — those remain
+  /// available for inter-iteration consumers.
+  void drop_cached_primal_only() noexcept
+  {
+    m_cached_col_sol_.clear();
+    m_cached_col_sol_.shrink_to_fit();
+    m_cached_col_cost_.clear();
+    m_cached_col_cost_.shrink_to_fit();
+  }
+
+  /// Drop the label-metadata buffers (compressed col/row label vectors
+  /// and the string pool that backs the decompressed `string_view`s).
+  ///
+  /// `compress_labels_meta_if_needed()` populates these buffers on
+  /// every `release_backend()` so future readers — `write_lp` (debug
+  /// LP dump), cut JSON / CSV save, `OutputContext::write_out` —
+  /// can resolve LP row / column names without re-flattening from
+  /// `System` collections.  Once a run has completed all of those
+  /// operations, the buffers are dead weight: ~3 MB raw / ~1 MB
+  /// compressed per cell, so on a juan/gtopt_iplp scale (816 cells)
+  /// they total ~800 MB held until process exit.
+  ///
+  /// Call this after the final `PlanningLP::write_out` returns and
+  /// no further label-metadata reads will occur.  Idempotent and
+  /// safe to call on cells that never had label metadata (no-op).
+  /// **Do not call mid-run** — `generate_labels_from_maps` (used by
+  /// every cut JSON save and every `write_lp`) would then throw
+  /// "row N has metadata without a class_name" on the next call.
+  void drop_label_meta_buffers() noexcept
+  {
+    m_col_labels_meta_compressed_ = CompressedBuffer {};
+    m_row_labels_meta_compressed_ = CompressedBuffer {};
+    m_col_labels_meta_count_ = 0;
+    m_row_labels_meta_count_ = 0;
+    m_label_string_pool_.clear();
+    m_label_string_pool_.shrink_to_fit();
+  }
+
   /**
    * @brief Check whether the solver backend is loaded.
    * @return true if load_flat() has been called and release_backend() has not

--- a/source/aperture_data_cache.cpp
+++ b/source/aperture_data_cache.cpp
@@ -215,6 +215,20 @@ ApertureDataCache::ApertureDataCache(const std::filesystem::path& aperture_dir)
     }
   }
 
+  // Phase 4: shrink bucket arrays to the actual entry count.  The
+  // per-file `data.reserve(num_rows * uid_col_count)` at line ~80
+  // over-allocates because `try_emplace` then dedups; the libstdc++
+  // unordered_map keeps the over-allocated bucket array.  Calling
+  // `rehash(0)` (== rehash to the minimum size that keeps the load
+  // factor below `max_load_factor()`) drops the slack.  On the
+  // juan/gtopt_iplp cache (170 k entries across 167 elements) this
+  // saves ~5–10 MB at zero lookup cost — the rehash itself is one-
+  // shot at startup, ~milliseconds, and is read-only thereafter.
+  m_elements_.rehash(0);
+  for (auto& [key, data] : m_elements_) {
+    data.rehash(0);
+  }
+
   const auto load_s = std::chrono::duration<double>(
                           std::chrono::steady_clock::now() - load_start)
                           .count();

--- a/source/planning_lp.cpp
+++ b/source/planning_lp.cpp
@@ -1178,11 +1178,18 @@ void PlanningLP::write_out()
       // Drop XLP collections rebuilt inside — the LinearInterface is
       // already released so this is a no-op on the backend side.
       system.release_backend();
+      // Drop label-metadata buffers: this cell's parquet output is
+      // emitted, no further consumer (cut JSON, debug write_lp,
+      // OutputContext) will need the col / row label metadata.  At
+      // ~1 MB compressed per cell × 816 cells = ~800 MB freed on
+      // juan-scale runs, just before the writer thread exits.
+      system.linear_interface().drop_label_meta_buffers();
       return;
     }
     system.ensure_lp_built();
     system.write_out();
     system.release_backend();
+    system.linear_interface().drop_label_meta_buffers();
   };
 
   for (auto&& [scene_num, phase_systems] : enumerate<SceneIndex>(m_systems_)) {

--- a/source/sddp_iteration.cpp
+++ b/source/sddp_iteration.cpp
@@ -532,19 +532,33 @@ auto SDDPMethod::solve(const SolverOptions& lp_opts)
         dt_save = post_elapsed_s(t_save);
       }
 
-      // ── Low-memory: release solver backends (idempotent safety net) ──
+      // ── Low-memory: release solver backends + drop primal caches ──
       // After the per-cell release scheme most cells are already
       // released by the backward worker; this bulk loop is the
       // idempotent safety net.  `release_backend` is a no-op when
       // `m_backend_released_` is already set (`linear_interface.cpp:144`),
       // so the cost is dominated by the loop overhead (~µs total).
+      //
+      // `drop_cached_primal_only()` additionally clears the per-cell
+      // `col_sol` / `col_cost` snapshots (kept around since the
+      // forward-pass solve so the per-iteration `save_state_csv`
+      // could read them).  By the time we reach this point the state
+      // CSV has been written and the backward pass has consumed the
+      // per-state-variable values via `capture_state_variable_values`
+      // — both vectors sit unused until the next iteration's solve
+      // overwrites them.  On juan/gtopt_iplp this frees ~0.7–2.5 GB
+      // across the 816 cells between iterations.  The retained
+      // `row_dual` cache is still needed by `update_stored_cut_duals`
+      // and `prune_inactive_cuts` next iteration.
       const auto t_release = PostClock::now();
       if (m_options_.low_memory_mode != LowMemoryMode::off) {
         const auto ns = planning_lp().simulation().scene_count();
         const auto np = planning_lp().simulation().phase_count();
         for (const auto si : iota_range<SceneIndex>(0, ns)) {
           for (const auto pi : iota_range<PhaseIndex>(0, np)) {
-            planning_lp().system(si, pi).release_backend();
+            auto& sys = planning_lp().system(si, pi);
+            sys.release_backend();
+            sys.linear_interface().drop_cached_primal_only();
           }
         }
       }


### PR DESCRIPTION
## Summary
Three memory-footprint wins from the post-merge memory review. Net expected: **1–3.5 GB off the 24 GB juan/gtopt_iplp peak**.

| Change | Savings | Risk |
|---|---|---|
| **P0-1**: drop col_sol + col_cost between iters | 0.7–2.5 GB | Low — audited all readers, row_dual retained for inter-iter cut prune/dual update |
| **P0-2**: `rehash(0)` ApertureDataCache after load | 5–10 MB | None — cache is read-only after ctor |
| **P1-2**: drop label-meta buffers after write_out emits | ~800 MB at end | Low — gated to per-cell emit lambda where no further consumer reads metadata |

## P0-1: drop primal caches

`LinearInterface::release_backend()` populates `col_sol`, `col_cost`, `row_dual`. Audit:
- col_sol / col_cost: consumed by OutputContext, save_state_csv, state-var propagation **within the iteration**. Dead between iterations.
- row_dual: consumed across iterations by `update_stored_cut_duals` and `prune_inactive_cuts`. **Must retain.**

New `LinearInterface::drop_cached_primal_only()` clears the first two, keeps row_dual. Called from `sddp_iteration.cpp` post-iter loop.

## P0-2: rehash aperture cache

`ApertureDataCache` per-file `data.reserve(num_rows × uid_col_count)`; `try_emplace` then dedups but libstdc++ keeps the over-allocated buckets. One-shot `rehash(0)` minimises bucket count.

## P1-2: drop label-meta buffers

After `PlanningLP::write_out` emits parquet for a cell, no remaining reader needs the compressed col/row label vectors or the string-pool. New `drop_label_meta_buffers()` resets them. Called from the per-cell emit lambda.

Hazard: must NOT be called mid-run (would throw on next `generate_labels_from_maps`). Restricted to the post-emit point.

## Verification

`ctest --output-on-failure -j20`: **3007/3007 in 84 s**, zero failures. Covers SDDP backward+cut-prune (row_dual survival), multi-iteration low_memory runs (release/reload round-trip), final write_out parquet (label-meta drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)