### PR TITLE
style: auto-apply ruff format wrap on _run_gtopt

### DIFF
--- a/scripts/plp2gtopt/tests/test_integration_case2y.py
+++ b/scripts/plp2gtopt/tests/test_integration_case2y.py
@@ -141,7 +141,9 @@ def _run_gtopt(
         timeout=timeout,
         check=False,
     )
-    return result.returncode, result.stdout + result.stderr + _gather_gtopt_logs(case_dir)
+    return result.returncode, result.stdout + result.stderr + _gather_gtopt_logs(
+        case_dir
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Apply the line-wrap that `ruff format` would produce on
`_run_gtopt`'s return statement in `test_integration_case2y.py`.
The post-PR-#457 file currently has a 90-char line that exceeds
the 88-char limit; the next format-bot pass would emit this wrap
anyway.  Cherry-picked from `61a62a72` (the format-bot's commit
on `master-tracker`) so `master` and `master-tracker` reach
content parity.

## Test plan
- [x] No semantic change — pure format wrap.
- [x] ruff format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)