### PR TITLE
fix(li): clone_from_flat — gate on flat_lp accessibility, not is_compressed

### DIFF
--- a/source/linear_interface.cpp
+++ b/source/linear_interface.cpp
@@ -919,22 +919,27 @@ LinearInterface LinearInterface::clone_from_flat(CloneKind kind) const
   // Pre-conditions: the manual route reads from
   // `m_snapshot_holder_.snapshot().flat_lp`, which is only populated when
   // `freeze_for_cuts` ran with `LowMemoryMode::compress` (or `snapshot`).
-  // Compressed snapshots are not directly readable here — the SDDP aperture
-  // path decompresses around the backward pass via `DecompressionGuard`
-  // (sddp_aperture_pass.cpp:390, 579), so callers reaching this
-  // method during the aperture window are guaranteed an
-  // uncompressed snapshot.
+  // The SDDP aperture path decompresses around the backward pass via
+  // `DecompressionGuard` (sddp_aperture_pass.cpp:460 / 693), so callers
+  // reaching this method during the aperture window are guaranteed a
+  // hydrated `flat_lp.matbeg` even though the persistent compressed
+  // buffer (`m_snapshot_holder_.is_compressed()`) may still report
+  // ``true`` — the buffer is kept alive as a cache by
+  // `LowMemorySnapshot::decompress` and survives the rehydrate.  The
+  // check below is therefore on the *accessibility* of the flat LP
+  // (matbeg populated), not on the secondary compressed cache.
   if (!m_snapshot_holder_.has_data()) {
     throw std::runtime_error(
         "LinearInterface::clone_from_flat: source has no snapshot — call "
         "freeze_for_cuts(LowMemoryMode::compress) on the source first, or "
         "fall back to clone(kind) which uses the backend's native clone.");
   }
-  if (m_snapshot_holder_.is_compressed()) {
+  if (m_snapshot_holder_.snapshot().flat_lp.matbeg.empty()) {
     throw std::runtime_error(
-        "LinearInterface::clone_from_flat: source snapshot is compressed; "
-        "decompress first (DecompressionGuard) or fall back to "
-        "clone(kind).");
+        "LinearInterface::clone_from_flat: source flat LP is not "
+        "decompressed (matbeg is empty while compressed cache may be "
+        "present); decompress first (DecompressionGuard) or fall back "
+        "to clone(kind).");
   }
 
   // Build the clone via load_flat — no backend.clone() call, no

--- a/test/source/test_clone_via_load_flat.cpp
+++ b/test/source/test_clone_via_load_flat.cpp
@@ -484,6 +484,40 @@ TEST_CASE(  // NOLINT
   CHECK_THROWS_AS(std::ignore = src.clone_from_flat(), std::runtime_error);
 }
 
+TEST_CASE(  // NOLINT
+    "LinearInterface::clone_from_flat — succeeds after DecompressionGuard "
+    "even when persistent compressed buffer is present")
+{
+  // Pin the bug fix where ``clone_from_flat`` previously rejected a
+  // source whose persistent compressed buffer was non-empty, even if
+  // the flat LP itself had been re-hydrated by ``DecompressionGuard``.
+  // The aperture path under ``low_memory_mode=compress`` after PR #465
+  // (eager build-time compression) hits exactly this case: the source
+  // LP is built, compressed, then the aperture pass wraps it in a
+  // ``DecompressionGuard`` before calling ``clone_from_flat`` for each
+  // aperture.  The persistent compressed cache stays alive through the
+  // guard, but the flat LP is fully accessible.
+  auto problem = build_feature_problem();
+  auto flat_for_src = problem.flatten({});
+
+  LinearInterface src;
+  src.set_low_memory(LowMemoryMode::compress);
+  src.load_flat(flat_for_src);
+  src.save_snapshot(std::move(flat_for_src));
+  REQUIRE(src.has_snapshot_data());
+
+  // Compress the snapshot, then decompress (mimicking the
+  // build → release → DecompressionGuard sequence in production).
+  src.enable_compression();
+  src.disable_compression();
+
+  // Even though the persistent compressed cache is still non-empty
+  // (kept by ``LowMemorySnapshot::decompress`` as a one-time-only cache
+  // for future reload cycles), ``clone_from_flat`` must succeed because
+  // ``flat_lp.matbeg`` is now populated.
+  CHECK_NOTHROW(std::ignore = src.clone_from_flat());
+}
+
 // ─── 7. Timing comparison (informational) ───────────────────────────
 
 TEST_CASE(  // NOLINT


### PR DESCRIPTION
## Summary

PR #465 (eager build-time compression) exposed a latent bug: `clone_from_flat`'s pre-condition rejected a source whose **persistent compressed cache** was non-empty, even when the flat LP itself had been re-hydrated by `DecompressionGuard`.

**Symptom on the live juan run** (`compress` + `aperture_use_manual_clone=true`):

```
[critical] Error during LP creation or solving: LinearInterface::clone_from_flat:
  source snapshot is compressed; decompress first (DecompressionGuard)
  or fall back to clone(kind).
```

## Root cause

`LowMemorySnapshot::decompress` re-hydrates `flat_lp` but **keeps** the `compressed_lp` cache alive (it was paid for once at first-compress and is kept forever for future reload cycles). `is_compressed()` returns `!compressed_lp.empty()` — stays `true` after decompress. `DecompressionGuard` correctly populates `flat_lp.matbeg` but cannot make `is_compressed()` flip back to `false` without losing the cache.

## Why latent until #465

Pre-#465 the snapshot only compressed at end of the first backward pass. The very first iteration's aperture pass escaped the false trip because the snapshot was still uncompressed. After #465 the snapshot is compressed from build time onwards, so every aperture call hits the bug from iter 1.

## Fix

Change the pre-condition to test **accessibility of the flat LP** (`flat_lp.matbeg.empty()`) instead of the secondary compressed-cache state. The semantic the caller actually wants is "can I read the flat LP from this snapshot now?" — which `matbeg.empty()` answers correctly.

## Test plan

- [x] New `clone_from_flat — succeeds after DecompressionGuard even when persistent compressed buffer is present` case in `test_clone_via_load_flat.cpp` reproduces the failing sequence (load → save_snapshot → enable_compression → disable_compression → clone_from_flat) and asserts no throw.
- [x] All 3193 unit tests pass under `ctest -j20`, including all 5 `clone_from_flat` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)