### PR TITLE
perf(sddp): default aperture_use_manual_clone=true for all memory modes

### DIFF
--- a/include/gtopt/planning_options_lp.hpp
+++ b/include/gtopt/planning_options_lp.hpp
@@ -637,11 +637,20 @@ public:
   /** @brief Whether aperture clones bypass the backend's native `clone()`
    *         and are built via `LinearInterface::clone_from_flat()` instead
    *         (manual route, no global mutex).
-   * @return false by default (preserve legacy native-clone route).
+   *
+   * @return ``true`` by default — measured ~2-3× speed-up on the
+   *         juan/iplp aperture phase by escaping the global
+   *         ``s_global_clone_mutex`` that serialises ``CPXcloneprob``
+   *         calls across the SDDP work pool.  Safe under all
+   *         ``LowMemoryMode`` settings: the call site falls back to
+   *         the native ``clone()`` route automatically when the source
+   *         has no snapshot (``has_snapshot_data() == false``), which
+   *         is the only condition where the manual route cannot run.
+   *         Set to ``false`` to restore the legacy native-clone path.
    */
   [[nodiscard]] constexpr auto sddp_aperture_use_manual_clone() const
   {
-    return m_options_.sddp_options.aperture_use_manual_clone.value_or(false);
+    return m_options_.sddp_options.aperture_use_manual_clone.value_or(true);
   }
 
   /**

--- a/source/linear_interface.cpp
+++ b/source/linear_interface.cpp
@@ -919,22 +919,27 @@ LinearInterface LinearInterface::clone_from_flat(CloneKind kind) const
   // Pre-conditions: the manual route reads from
   // `m_snapshot_holder_.snapshot().flat_lp`, which is only populated when
   // `freeze_for_cuts` ran with `LowMemoryMode::compress` (or `snapshot`).
-  // Compressed snapshots are not directly readable here — the SDDP aperture
-  // path decompresses around the backward pass via `DecompressionGuard`
-  // (sddp_aperture_pass.cpp:390, 579), so callers reaching this
-  // method during the aperture window are guaranteed an
-  // uncompressed snapshot.
+  // The SDDP aperture path decompresses around the backward pass via
+  // `DecompressionGuard` (sddp_aperture_pass.cpp:460 / 693), so callers
+  // reaching this method during the aperture window are guaranteed a
+  // hydrated `flat_lp.matbeg` even though the persistent compressed
+  // buffer (`m_snapshot_holder_.is_compressed()`) may still report
+  // ``true`` — the buffer is kept alive as a cache by
+  // `LowMemorySnapshot::decompress` and survives the rehydrate.  The
+  // check below is therefore on the *accessibility* of the flat LP
+  // (matbeg populated), not on the secondary compressed cache.
   if (!m_snapshot_holder_.has_data()) {
     throw std::runtime_error(
         "LinearInterface::clone_from_flat: source has no snapshot — call "
         "freeze_for_cuts(LowMemoryMode::compress) on the source first, or "
         "fall back to clone(kind) which uses the backend's native clone.");
   }
-  if (m_snapshot_holder_.is_compressed()) {
+  if (m_snapshot_holder_.snapshot().flat_lp.matbeg.empty()) {
     throw std::runtime_error(
-        "LinearInterface::clone_from_flat: source snapshot is compressed; "
-        "decompress first (DecompressionGuard) or fall back to "
-        "clone(kind).");
+        "LinearInterface::clone_from_flat: source flat LP is not "
+        "decompressed (matbeg is empty while compressed cache may be "
+        "present); decompress first (DecompressionGuard) or fall back "
+        "to clone(kind).");
   }
 
   // Build the clone via load_flat — no backend.clone() call, no

--- a/test/source/test_clone_via_load_flat.cpp
+++ b/test/source/test_clone_via_load_flat.cpp
@@ -484,6 +484,40 @@ TEST_CASE(  // NOLINT
   CHECK_THROWS_AS(std::ignore = src.clone_from_flat(), std::runtime_error);
 }
 
+TEST_CASE(  // NOLINT
+    "LinearInterface::clone_from_flat — succeeds after DecompressionGuard "
+    "even when persistent compressed buffer is present")
+{
+  // Pin the bug fix where ``clone_from_flat`` previously rejected a
+  // source whose persistent compressed buffer was non-empty, even if
+  // the flat LP itself had been re-hydrated by ``DecompressionGuard``.
+  // The aperture path under ``low_memory_mode=compress`` after PR #465
+  // (eager build-time compression) hits exactly this case: the source
+  // LP is built, compressed, then the aperture pass wraps it in a
+  // ``DecompressionGuard`` before calling ``clone_from_flat`` for each
+  // aperture.  The persistent compressed cache stays alive through the
+  // guard, but the flat LP is fully accessible.
+  auto problem = build_feature_problem();
+  auto flat_for_src = problem.flatten({});
+
+  LinearInterface src;
+  src.set_low_memory(LowMemoryMode::compress);
+  src.load_flat(flat_for_src);
+  src.save_snapshot(std::move(flat_for_src));
+  REQUIRE(src.has_snapshot_data());
+
+  // Compress the snapshot, then decompress (mimicking the
+  // build → release → DecompressionGuard sequence in production).
+  src.enable_compression();
+  src.disable_compression();
+
+  // Even though the persistent compressed cache is still non-empty
+  // (kept by ``LowMemorySnapshot::decompress`` as a one-time-only cache
+  // for future reload cycles), ``clone_from_flat`` must succeed because
+  // ``flat_lp.matbeg`` is now populated.
+  CHECK_NOTHROW(std::ignore = src.clone_from_flat());
+}
+
 // ─── 7. Timing comparison (informational) ───────────────────────────
 
 TEST_CASE(  // NOLINT


### PR DESCRIPTION
## Summary

Flip the resolved default of `sddp_options.aperture_use_manual_clone` from `false` to `true` so the SDDP aperture phase escapes the global `s_global_clone_mutex` by default.

## Measured impact (juan/iplp_plain, A/B)

| Run | aperture set per (scene, phase) | parallelism |
|-----|---------------------------------|-------------|
| native clone (`false`) | 17 – 21 s | one `CPXcloneprob` at a time across the whole pool |
| **manual clone (this default)** | **5 – 17 s** | full 75/96 worker concurrency, no global mutex |

**~2-3× speed-up** on the aperture phase, which is the dominant cost of every SDDP backward iteration.

## Safety contract

The manual route only runs when the source has `has_snapshot_data() == true` (precondition checked at the call site in `sddp_aperture.cpp:272`). When the snapshot is unavailable (e.g. `LowMemoryMode::rebuild` after `release_backend()`), the call site silently falls back to the native `clone()` route under `s_global_clone_mutex`. Default flip is therefore safe under all `LowMemoryMode` settings:

| Mode | Behaviour |
|------|-----------|
| `compress` / `snapshot` | manual route (snapshot retained) |
| `off` | manual route (`save_snapshot` keeps an uncompressed snapshot) |
| `rebuild` | falls back to native when snapshot is absent |

After PR #467 ironed out the last precondition bug under PR #465's eager build-time compression, the manual route is the production default with no known issues.

## Test plan

- [x] All 3193 unit tests pass under `ctest -j20`.
- [x] Live juan/iplp_plain run with `aperture_use_manual_clone=true` confirms 2-3× aperture speed-up vs native-clone baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)