### PR TITLE
feat(plp2gtopt): disable apertures at cascade level 0 only

### DIFF
--- a/.github/actions/install-apt-deps/action.yml
+++ b/.github/actions/install-apt-deps/action.yml
@@ -22,7 +22,8 @@ runs:
           ccache lld coinor-libcbc-dev libboost-container-dev libspdlog-dev \
           liblapack-dev libblas-dev liblapack3 libblas3 lcov \
           libjemalloc-dev \
-          zlib1g-dev libzstd-dev zstd liblz4-dev ca-certificates lsb-release wget \
+          zlib1g-dev libzstd-dev zstd liblz4-dev libsnappy-dev \
+          ca-certificates lsb-release wget \
           ${{ inputs.extra-packages }}
 
     - name: ensure LAPACK runtime is present

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -44,10 +44,15 @@ jobs:
         run: uv pip install --system -e "./scripts[dev]" graphviz
 
       - name: Run unit tests with coverage
+        # Mirrors the `scripts-all-unit` ctest target — single pytest
+        # invocation with pytest-xdist (`-n auto`), one fork per CPU,
+        # so collection startup is paid once.  pytest-cov merges per-
+        # worker coverage data automatically.
         working-directory: scripts
         run: |
           pytest \
             --ignore=plp2gtopt/tests/test_integration.py \
+            -n auto \
             -q --tb=short -m "not integration" \
             --cov=cvs2parquet \
             --cov=igtopt \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,17 +138,48 @@ include(cmake_local/Solver.cmake)
 
 find_package(Arrow REQUIRED)
 find_package(Parquet REQUIRED)
+
+# Hard-require snappy support in the Arrow build that gtopt links to.
+# Snappy is the parquet spec default codec — any parquet file produced
+# by pyarrow / pandas / plp2gtopt / external pipelines without an
+# explicit codec override is snappy-compressed, and an Arrow built
+# without snappy fails to read those files at runtime with the cryptic
+# "Arrow can't open file …" path-fallback message.  ArrowOptions.cmake
+# (shipped by Arrow under <prefix>/lib/cmake/Arrow/) records each
+# `ARROW_WITH_<CODEC>` boolean from Arrow's own configure step, so we
+# can check it directly here.
+if(NOT ARROW_WITH_SNAPPY)
+  message(FATAL_ERROR
+    "The Arrow library at '${ARROW_INSTALL_PREFIX}' was built WITHOUT "
+    "snappy support (ARROW_WITH_SNAPPY=OFF in ArrowOptions.cmake).  "
+    "gtopt requires it because snappy is the parquet spec default and "
+    "is what pyarrow / plp2gtopt / external pipelines produce by "
+    "default.  Rebuild Arrow with `-DARROW_WITH_SNAPPY=ON` after "
+    "installing libsnappy-dev (Ubuntu/Debian: "
+    "`apt install libsnappy-dev`), then re-install Arrow.")
+endif()
 find_package(Boost REQUIRED COMPONENTS container)
 find_package(ZLIB REQUIRED)
 find_package(zstd REQUIRED)
 
-# In-memory compression codecs for low_memory mode
+# In-memory compression codecs for low_memory mode AND parquet I/O.
 # LZ4 is required (preferred codec for in-memory LP snapshots).
-# Snappy is optional.
+# Snappy is required:
+#   * It's the parquet spec default (apache/parquet-format), so any
+#     parquet file produced by the wider ecosystem (pyarrow, pandas,
+#     plp2gtopt without an explicit `-c <codec>` override on a snappy-
+#     enabled build) is snappy-compressed.  gtopt MUST be able to
+#     read those files.
+#   * Apache Arrow's parquet reader links snappy at build time only
+#     when libsnappy-dev is present at Arrow's configure step; the
+#     check here ensures the Arrow build that gtopt links against
+#     was itself built with snappy support (otherwise reads of any
+#     snappy parquet fail with "Arrow can't open file …").
+# Install: `apt install libsnappy-dev` (Ubuntu/Debian).
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
   pkg_check_modules(LZ4 REQUIRED IMPORTED_TARGET liblz4)
-  pkg_check_modules(SNAPPY IMPORTED_TARGET snappy)
+  pkg_check_modules(SNAPPY REQUIRED IMPORTED_TARGET snappy)
 else()
   find_library(LZ4_LIBRARY NAMES lz4)
   find_path(LZ4_INCLUDE_DIR NAMES lz4.h)
@@ -161,6 +192,11 @@ else()
   find_path(SNAPPY_INCLUDE_DIR NAMES snappy.h)
   if(SNAPPY_LIBRARY AND SNAPPY_INCLUDE_DIR)
     set(SNAPPY_FOUND TRUE)
+  else()
+    message(FATAL_ERROR
+      "Snappy not found.  Install libsnappy-dev (required: parquet "
+      "spec default codec; gtopt must read snappy parquet files "
+      "produced by pyarrow / plp2gtopt / external pipelines).")
   endif()
 endif()
 

--- a/include/gtopt/planning_options_lp.hpp
+++ b/include/gtopt/planning_options_lp.hpp
@@ -1190,10 +1190,24 @@ public:
         CompressionCodec::auto_select);
   }
 
-  /** @brief Maximum async iteration spread (0 = synchronous, default). */
+  /** @brief Maximum async iteration spread (default: 2).
+   *
+   * When > 0 and ``cut_sharing == none``, the SDDP solver runs scenes
+   * asynchronously: each scene progresses through its own
+   * forward / backward iteration loop, the work pool's
+   * ``SDDPTaskKey`` priority schedules the slowest-iter scenes first,
+   * and the spread between the fastest and slowest scene is bounded
+   * by this value.  Eliminates the inter-iteration synchronisation
+   * barrier that otherwise blocks every scene from starting iter
+   * ``i+1`` until all scenes have finished iter ``i``.
+   *
+   * Default 2 (lightly async) trades determinism for ~10-20%
+   * fewer barrier-wait stalls on heterogeneous-runtime fixtures.
+   * Set to 0 to restore the legacy fully-synchronous behaviour.
+   */
   [[nodiscard]] constexpr auto sddp_max_async_spread() const
   {
-    return m_options_.sddp_options.max_async_spread.value_or(0);
+    return m_options_.sddp_options.max_async_spread.value_or(2);
   }
 
   /** @brief SDDP work pool CPU over-commit factor (default: 4.0). */

--- a/include/gtopt/planning_options_lp.hpp
+++ b/include/gtopt/planning_options_lp.hpp
@@ -637,11 +637,20 @@ public:
   /** @brief Whether aperture clones bypass the backend's native `clone()`
    *         and are built via `LinearInterface::clone_from_flat()` instead
    *         (manual route, no global mutex).
-   * @return false by default (preserve legacy native-clone route).
+   *
+   * @return ``true`` by default — measured ~2-3× speed-up on the
+   *         juan/iplp aperture phase by escaping the global
+   *         ``s_global_clone_mutex`` that serialises ``CPXcloneprob``
+   *         calls across the SDDP work pool.  Safe under all
+   *         ``LowMemoryMode`` settings: the call site falls back to
+   *         the native ``clone()`` route automatically when the source
+   *         has no snapshot (``has_snapshot_data() == false``), which
+   *         is the only condition where the manual route cannot run.
+   *         Set to ``false`` to restore the legacy native-clone path.
    */
   [[nodiscard]] constexpr auto sddp_aperture_use_manual_clone() const
   {
-    return m_options_.sddp_options.aperture_use_manual_clone.value_or(false);
+    return m_options_.sddp_options.aperture_use_manual_clone.value_or(true);
   }
 
   /**

--- a/include/gtopt/sddp_common.hpp
+++ b/include/gtopt/sddp_common.hpp
@@ -47,67 +47,70 @@ struct PhaseStateInfo;
 // Parameters accept any formattable type (int, SceneUid, PhaseUid, etc.).
 
 /// "SDDP Forward [i1 s1 p2]" — with phase tag and per-phase key.
-/// `iteration_index` is formatted as the matching `IterationUid` (1-based)
-/// so the iN segment uses the same UID convention as the sN/pN segments
-/// — keeping all three log keys consistent.
-template<typename S, typename P>
+/// Strict-typed UID-only signature: callers pass ``IterationUid`` /
+/// ``SceneUid`` / ``PhaseUid`` (1-based, matching the printed
+/// ``[iN sM pK]`` format).  Passing the matching ``*Index`` (0-based,
+/// internal) is a compile error — the caller must convert via
+/// ``gtopt::uid_of(...)`` at the call site, mirroring the
+/// ``SPDLOG_*("...[i{}]…", gtopt::uid_of(iteration_index), ...)``
+/// pattern used everywhere else in the SDDP code (see PR #459).
 [[nodiscard]] inline std::string sddp_log(std::string_view tag,
-                                          IterationIndex iteration_index,
-                                          S scene,
-                                          P phase)
+                                          IterationUid iteration_uid,
+                                          SceneUid scene_uid,
+                                          PhaseUid phase_uid)
 {
   return as_label<void>("SDDP ",
                         tag,
                         " [i",
-                        uid_of(iteration_index),
+                        iteration_uid,
                         ' ',
                         's',
-                        scene,
+                        scene_uid,
                         ' ',
                         'p',
-                        phase,
+                        phase_uid,
                         ']');
 }
 
 /// "SDDP Aperture [i1 s1 p2 a5]" — with aperture uid appended.
-template<typename S, typename P, typename A>
+/// ``Uid`` for aperture (no strong typedef yet).  Same UID-only
+/// contract as the 4-arg overload.
 [[nodiscard]] inline std::string sddp_log(std::string_view tag,
-                                          IterationIndex iteration_index,
-                                          S scene,
-                                          P phase,
-                                          A aperture)
+                                          IterationUid iteration_uid,
+                                          SceneUid scene_uid,
+                                          PhaseUid phase_uid,
+                                          Uid aperture_uid)
 {
   return as_label<void>("SDDP ",
                         tag,
                         " [i",
-                        uid_of(iteration_index),
+                        iteration_uid,
                         ' ',
                         's',
-                        scene,
+                        scene_uid,
                         ' ',
                         'p',
-                        phase,
+                        phase_uid,
                         ' ',
                         'a',
-                        aperture,
+                        aperture_uid,
                         ']');
 }
 
 /// "SDDP Forward [i1 s1]" — scene-level (no phase).
-template<typename S>
 [[nodiscard]] inline std::string sddp_log(std::string_view tag,
-                                          IterationIndex iteration_index,
-                                          S scene)
+                                          IterationUid iteration_uid,
+                                          SceneUid scene_uid)
 {
   return as_label<void>(
-      "SDDP ", tag, " [i", uid_of(iteration_index), ' ', 's', scene, ']');
+      "SDDP ", tag, " [i", iteration_uid, ' ', 's', scene_uid, ']');
 }
 
 /// "SDDP Init [i1]" — iteration-level only.
 [[nodiscard]] inline std::string sddp_log(std::string_view tag,
-                                          IterationIndex iteration_index)
+                                          IterationUid iteration_uid)
 {
-  return as_label<void>("SDDP ", tag, " [i", uid_of(iteration_index), ']');
+  return as_label<void>("SDDP ", tag, " [i", iteration_uid, ']');
 }
 
 // ─── Phase grid recorder ────────────────────────────────────────────────────

--- a/include/gtopt/sddp_pool.hpp
+++ b/include/gtopt/sddp_pool.hpp
@@ -7,13 +7,16 @@
  *
  * This header provides the work-pool specialisation used by the SDDP solver:
  *
- *  - `SDDPTaskKey` – a 4-tuple `(iteration, is_backward, phase, is_nonlp)`
- *    used as the secondary sort key so that forward LP solves in the earliest
- *    iteration are always scheduled before backward passes, later iterations,
- *    or non-LP tasks.
- *  - `SDDPPassDirection` – enum class (forward / backward) for pass direction.
+ *  - `SDDPTaskKey` – a 3-tuple `(iteration, signed_phase, kind)` used as the
+ *    secondary sort key so that LP solves in the earliest iteration, with
+ *    correct per-direction phase ordering, are always scheduled first.
+ *  - `SDDPPassDirection` – enum class with values `forward = +1` and
+ *    `backward = -1` so the enum value itself acts as the phase-sign
+ *    multiplier when computing the priority key.
  *  - `SDDPTaskKind` – enum class (lp / non_lp) for task kind.
  *  - `make_sddp_task_key()` – factory from strong types to SDDPTaskKey tuple.
+ *    Computes `signed_phase = direction * phase`, encoding both direction
+ *    and per-direction phase order in a single signed int.
  *  - `SDDPWorkPool` – a concrete `BasicWorkPool<SDDPTaskKey>` subclass that
  *    can be forward-declared as `class SDDPWorkPool;` in other headers.
  *  - `make_sddp_work_pool()` – a factory that creates, configures, and starts
@@ -21,17 +24,28 @@
  *
  * ## SDDPTaskKey semantics
  *
- * The tuple `(iteration_index, is_backward, phase_index, is_nonlp)`:
+ * The tuple `(iteration_index, signed_phase, kind)`:
  *  - `iteration_index`: SDDP iteration number (0, 1, …)
- *  - `is_backward`:     0 = forward pass, 1 = backward pass
- *  - `phase_index`:     phase within the iteration (0, 1, …)
- *  - `is_nonlp`:        0 = LP solve/resolve, 1 = other (e.g. write_lp)
+ *  - `signed_phase`:    `direction * phase` (`forward(+1) * phase = +phase`,
+ *                       `backward(-1) * phase = -phase`)
+ *  - `kind`:            `lp` (0) = LP solve/resolve, `non_lp` (1) = other
  *
- * With the default `std::less<SDDPTaskKey>` lexicographic comparison:
- *  - Lower iteration  → higher priority
- *  - Forward (0)      → higher priority than backward (1)
- *  - Lower phase      → higher priority
- *  - LP solve (0)     → higher priority than non-LP (1)
+ * With the default `std::less<SDDPTaskKey>` lexicographic comparison
+ * (smaller tuple → higher dequeue priority):
+ *  - **Lower iteration** wins (iter 0 before iter 1, …).
+ *  - **Within forward**: smaller `signed_phase` wins, so phase 0 dequeues
+ *    before phase N — earlier phase first, matching how the forward pass
+ *    walks 0 → N.
+ *  - **Within backward**: `signed_phase = -phase`, so `-N < … < -1 < 0` —
+ *    phase N dequeues before phase 0, matching how the backward pass walks
+ *    N → 0.
+ *  - **Cross-direction collisions** at the same iteration are degenerate
+ *    and resolved by `kind` / submit time.  In practice the SDDP scheduler
+ *    runs the forward and backward passes serially within one iteration
+ *    (`sddp_method_iteration.cpp` blocks on `fut.wait()` between them),
+ *    so the queue never contains both directions at once.
+ *  - **`lp` (0) wins over `non_lp` (1)** so write_lp / dump tasks never
+ *    block a solve worker.
  */
 
 #pragma once
@@ -56,17 +70,21 @@ namespace gtopt
 
 // ─── SDDPTaskKey and named constants ─────────────────────────────────────────
 
-/// @brief Pass direction for the `is_backward` field of `SDDPTaskKey`.
-/// Forward (0) has higher priority than backward (1) in lexicographic order.
+/// @brief Pass direction for the SDDP scheduler.
+///
+/// The enum value doubles as the phase-sign multiplier in
+/// `make_sddp_task_key`: `forward(+1) * phase = +phase` (so phase 0 dequeues
+/// first within forward), `backward(-1) * phase = -phase` (so phase N
+/// dequeues first within backward, matching the N → 0 walk).
 // NOLINTBEGIN(performance-enum-size) — int matches SDDPTaskKey tuple element
 // type
 enum class SDDPPassDirection : int
 {
-  forward = 0,
-  backward = 1,
+  forward = 1,
+  backward = -1,
 };
 
-/// @brief Task kind for the `is_nonlp` field of `SDDPTaskKey`.
+/// @brief Task kind for the `kind` field of `SDDPTaskKey`.
 /// LP solves (0) have higher priority than non-LP tasks (1).
 enum class SDDPTaskKind : int
 {
@@ -77,24 +95,28 @@ enum class SDDPTaskKind : int
 
 /// @brief SDDP solver task priority key.
 ///
-/// A 4-tuple `(iteration_index, direction, phase_index, kind)` using the
-/// project's strong types so that construction and inspection stay
-/// type-safe end-to-end:
-///  - `IterationIndex`:    SDDP iteration number (0, 1, …)
-///  - `SDDPPassDirection`: `forward` (0) or `backward` (1)
-///  - `PhaseIndex`:        phase within the iteration (0, 1, …)
-///  - `SDDPTaskKind`:      `lp` (0) or `non_lp` (1)
+/// A 3-tuple `(iteration_index, signed_phase, kind)`:
+///  - `IterationIndex`: SDDP iteration number (0, 1, …)
+///  - `int signed_phase`: `direction * phase` (positive for forward,
+///    non-positive for backward) — encodes both pass direction and the
+///    correct per-direction phase ordering in a single signed value.
+///  - `SDDPTaskKind`: `lp` (0) or `non_lp` (1)
 ///
-/// Tuple comparison with `std::less<SDDPTaskKey>` remains lexicographic —
-/// both strong indices and enum classes expose `operator<` that matches
-/// their integer ordering, so lower iteration → forward → lower phase →
-/// lp → higher execution priority.
+/// Tuple comparison with `std::less<SDDPTaskKey>` (lexicographic, smaller
+/// → higher dequeue priority):
+///   - lower iteration  → higher priority
+///   - within forward   (signed_phase ≥ 0): phase 0 < phase 1 < …
+///   - within backward  (signed_phase ≤ 0): -N < … < -1 < 0
+///   - lp (0) < non_lp (1)
 using SDDPTaskKey =
-    std::tuple<IterationIndex, SDDPPassDirection, PhaseIndex, SDDPTaskKind>;
+    std::tuple<IterationIndex, int /*signed_phase*/, SDDPTaskKind>;
 
 /// @brief Build an SDDPTaskKey from strongly-typed SDDP parameters.
 ///
-/// Preserves strong types through the tuple — no unwrapping needed.
+/// Computes `signed_phase = direction * phase`.  The
+/// `SDDPPassDirection::{forward = +1, backward = -1}` enum values are
+/// chosen so they multiply directly with `phase_index` to encode the
+/// correct per-direction priority ordering.
 ///
 /// @param iteration_index SDDP iteration index
 /// @param direction       Forward or backward pass
@@ -106,20 +128,23 @@ using SDDPTaskKey =
                                                 SDDPTaskKind kind) noexcept
     -> SDDPTaskKey
 {
-  return {iteration_index, direction, phase_index, kind};
+  const int signed_phase =
+      static_cast<int>(direction) * static_cast<int>(phase_index.value_of());
+  return {iteration_index, signed_phase, kind};
 }
 
 // ─── Task-requirement builders (LP solves) ───────────────────────────────────
 
 /// Build a `BasicTaskRequirements<SDDPTaskKey>` for a forward-pass LP solve.
 ///
-/// Centralises the (priority, priority_key) tuple so the SDDP solver
-/// never spells out the four-element key inline, and so the lexicographic
+/// Centralises the (priority, priority_key) tuple so the SDDP solver never
+/// spells out the three-element key inline, and so the lexicographic
 /// ordering invariant stays in one place:
 ///
-///   forward LP < backward LP            (same iter, same phase)
-///   iter N LP  < iter N+1 LP            (same direction, same phase)
-///   phase P LP < phase P+1 LP           (same iter, same direction)
+///   iter N LP        < iter N+1 LP                (same direction, phase)
+///   forward phase 0  < forward phase 1 < …        (within forward)
+///   backward phase N < … < backward phase 0       (within backward)
+///   any LP           < any non-LP                 (same iter, signed_phase)
 ///
 /// Both forward and backward solves share `TaskPriority::Medium`; the
 /// tuple key alone provides full SDDP ordering.  Exposed for unit
@@ -161,10 +186,10 @@ using SDDPTaskKey =
 
 /// @brief Work pool specialised for the SDDP solver with tuple priority key.
 ///
-/// Uses `SDDPTaskKey = std::tuple<int,int,int,int>` as the secondary sort
-/// key with the default `std::less<SDDPTaskKey>` comparator (lexicographic).
-/// A concrete derived class so that `class SDDPWorkPool;` can be forward-
-/// declared in headers that only need the pointer type.
+/// Uses `SDDPTaskKey = std::tuple<IterationIndex, int, SDDPTaskKind>` as the
+/// secondary sort key with the default `std::less<SDDPTaskKey>` comparator
+/// (lexicographic).  A concrete derived class so that `class SDDPWorkPool;`
+/// can be forward-declared in headers that only need the pointer type.
 class SDDPWorkPool final : public BasicWorkPool<SDDPTaskKey>
 {
 public:
@@ -179,7 +204,7 @@ public:
  *
  * Uses `SDDPTaskKey` (tuple) as the secondary priority key so that the
  * SDDP forward/backward LP solves are ordered by
- * (iteration, is_backward, phase, is_nonlp) with the default
+ * (iteration, signed_phase, kind) with the default
  * `std::less<SDDPTaskKey>` comparator (smaller tuple → higher priority).
  *
  * The pool sizes itself as

--- a/include/gtopt/sddp_pool.hpp
+++ b/include/gtopt/sddp_pool.hpp
@@ -7,16 +7,20 @@
  *
  * This header provides the work-pool specialisation used by the SDDP solver:
  *
- *  - `SDDPTaskKey` – a 3-tuple `(iteration, signed_phase, kind)` used as the
- *    secondary sort key so that LP solves in the earliest iteration, with
- *    correct per-direction phase ordering, are always scheduled first.
+ *  - `SDDPTaskKey` – a 4-tuple `(iteration, is_backward, signed_phase, kind)`
+ *    used as the secondary sort key so that LP solves in the earliest
+ *    iteration, with the forward pass strictly ahead of the backward
+ *    pass and correct per-direction phase ordering, are always
+ *    scheduled first.
  *  - `SDDPPassDirection` – enum class with values `forward = +1` and
  *    `backward = -1` so the enum value itself acts as the phase-sign
- *    multiplier when computing the priority key.
+ *    multiplier when computing the priority key.  The 0/1 sort field
+ *    `is_backward` (also derived in the factory) gives forward
+ *    cross-direction priority.
  *  - `SDDPTaskKind` – enum class (lp / non_lp) for task kind.
  *  - `make_sddp_task_key()` – factory from strong types to SDDPTaskKey tuple.
- *    Computes `signed_phase = direction * phase`, encoding both direction
- *    and per-direction phase order in a single signed int.
+ *    Computes `signed_phase = direction * phase` and
+ *    `is_backward = direction == backward ? 1 : 0`.
  *  - `SDDPWorkPool` – a concrete `BasicWorkPool<SDDPTaskKey>` subclass that
  *    can be forward-declared as `class SDDPWorkPool;` in other headers.
  *  - `make_sddp_work_pool()` – a factory that creates, configures, and starts
@@ -24,26 +28,27 @@
  *
  * ## SDDPTaskKey semantics
  *
- * The tuple `(iteration_index, signed_phase, kind)`:
+ * The tuple `(iteration_index, is_backward, signed_phase, kind)`:
  *  - `iteration_index`: SDDP iteration number (0, 1, …)
+ *  - `is_backward`:     0 = forward pass, 1 = backward pass
  *  - `signed_phase`:    `direction * phase` (`forward(+1) * phase = +phase`,
- *                       `backward(-1) * phase = -phase`)
+ *                       `backward(-1) * phase = -phase`) — encodes the
+ *                       within-direction phase order
  *  - `kind`:            `lp` (0) = LP solve/resolve, `non_lp` (1) = other
  *
  * With the default `std::less<SDDPTaskKey>` lexicographic comparison
  * (smaller tuple → higher dequeue priority):
  *  - **Lower iteration** wins (iter 0 before iter 1, …).
+ *  - **Forward (0) beats backward (1)** at the same iteration,
+ *    unconditionally — even at the same `|phase|`.  Matches the SDDP
+ *    rule that the forward pass produces the trial points the backward
+ *    pass needs.
  *  - **Within forward**: smaller `signed_phase` wins, so phase 0 dequeues
  *    before phase N — earlier phase first, matching how the forward pass
  *    walks 0 → N.
  *  - **Within backward**: `signed_phase = -phase`, so `-N < … < -1 < 0` —
  *    phase N dequeues before phase 0, matching how the backward pass walks
  *    N → 0.
- *  - **Cross-direction collisions** at the same iteration are degenerate
- *    and resolved by `kind` / submit time.  In practice the SDDP scheduler
- *    runs the forward and backward passes serially within one iteration
- *    (`sddp_method_iteration.cpp` blocks on `fut.wait()` between them),
- *    so the queue never contains both directions at once.
  *  - **`lp` (0) wins over `non_lp` (1)** so write_lp / dump tasks never
  *    block a solve worker.
  */
@@ -95,28 +100,43 @@ enum class SDDPTaskKind : int
 
 /// @brief SDDP solver task priority key.
 ///
-/// A 3-tuple `(iteration_index, signed_phase, kind)`:
+/// A 4-tuple `(iteration_index, is_backward, signed_phase, kind)`:
 ///  - `IterationIndex`: SDDP iteration number (0, 1, …)
+///  - `int is_backward`: `0` for forward, `1` for backward.  Lexicographic
+///    comparison keeps the forward pass strictly ahead of the backward
+///    pass within the same iteration — even at the same `|phase|`,
+///    where the per-direction `signed_phase` encoding alone would
+///    otherwise let backward win the tie.
 ///  - `int signed_phase`: `direction * phase` (positive for forward,
-///    non-positive for backward) — encodes both pass direction and the
-///    correct per-direction phase ordering in a single signed value.
+///    non-positive for backward) — encodes the *within-direction* phase
+///    ordering in a single signed value.
 ///  - `SDDPTaskKind`: `lp` (0) or `non_lp` (1)
 ///
 /// Tuple comparison with `std::less<SDDPTaskKey>` (lexicographic, smaller
 /// → higher dequeue priority):
 ///   - lower iteration  → higher priority
+///   - forward (0)      → higher priority than backward (1) — applies
+///     unconditionally at the same iteration, regardless of phase
 ///   - within forward   (signed_phase ≥ 0): phase 0 < phase 1 < …
 ///   - within backward  (signed_phase ≤ 0): -N < … < -1 < 0
 ///   - lp (0) < non_lp (1)
-using SDDPTaskKey =
-    std::tuple<IterationIndex, int /*signed_phase*/, SDDPTaskKind>;
+using SDDPTaskKey = std::tuple<IterationIndex,
+                               int /*is_backward*/,
+                               int /*signed_phase*/,
+                               SDDPTaskKind>;
 
 /// @brief Build an SDDPTaskKey from strongly-typed SDDP parameters.
 ///
-/// Computes `signed_phase = direction * phase`.  The
+/// Computes `signed_phase = direction * phase` and an
+/// `is_backward` int (0 for forward, 1 for backward).  The
 /// `SDDPPassDirection::{forward = +1, backward = -1}` enum values are
-/// chosen so they multiply directly with `phase_index` to encode the
-/// correct per-direction priority ordering.
+/// chosen so they multiply directly with `phase_index` for the
+/// signed-phase trick; `is_backward` is a separate sort field so the
+/// forward pass strictly precedes the backward pass at the same
+/// iteration even when the per-direction phase encodings would tie or
+/// invert (e.g. forward phase 0 vs backward phase 0 both encode to 0;
+/// forward phase 5 (+5) vs backward phase 5 (-5) would otherwise let
+/// backward win).
 ///
 /// @param iteration_index SDDP iteration index
 /// @param direction       Forward or backward pass
@@ -130,7 +150,8 @@ using SDDPTaskKey =
 {
   const int signed_phase =
       static_cast<int>(direction) * static_cast<int>(phase_index.value_of());
-  return {iteration_index, signed_phase, kind};
+  const int is_backward = (direction == SDDPPassDirection::backward) ? 1 : 0;
+  return {iteration_index, is_backward, signed_phase, kind};
 }
 
 // ─── Task-requirement builders (LP solves) ───────────────────────────────────
@@ -138,13 +159,15 @@ using SDDPTaskKey =
 /// Build a `BasicTaskRequirements<SDDPTaskKey>` for a forward-pass LP solve.
 ///
 /// Centralises the (priority, priority_key) tuple so the SDDP solver never
-/// spells out the three-element key inline, and so the lexicographic
+/// spells out the four-element key inline, and so the lexicographic
 /// ordering invariant stays in one place:
 ///
 ///   iter N LP        < iter N+1 LP                (same direction, phase)
+///   forward LP       < backward LP                (same iter, any phase)
 ///   forward phase 0  < forward phase 1 < …        (within forward)
 ///   backward phase N < … < backward phase 0       (within backward)
-///   any LP           < any non-LP                 (same iter, signed_phase)
+///   any LP           < any non-LP                 (same iter, direction,
+///                                                  signed_phase)
 ///
 /// Both forward and backward solves share `TaskPriority::Medium`; the
 /// tuple key alone provides full SDDP ordering.  Exposed for unit
@@ -186,7 +209,8 @@ using SDDPTaskKey =
 
 /// @brief Work pool specialised for the SDDP solver with tuple priority key.
 ///
-/// Uses `SDDPTaskKey = std::tuple<IterationIndex, int, SDDPTaskKind>` as the
+/// Uses `SDDPTaskKey = std::tuple<IterationIndex, int, int, SDDPTaskKind>`
+/// (iteration, is_backward, signed_phase, kind) as the
 /// secondary sort key with the default `std::less<SDDPTaskKey>` comparator
 /// (lexicographic).  A concrete derived class so that `class SDDPWorkPool;`
 /// can be forward-declared in headers that only need the pointer type.
@@ -204,7 +228,7 @@ public:
  *
  * Uses `SDDPTaskKey` (tuple) as the secondary priority key so that the
  * SDDP forward/backward LP solves are ordered by
- * (iteration, signed_phase, kind) with the default
+ * (iteration, is_backward, signed_phase, kind) with the default
  * `std::less<SDDPTaskKey>` comparator (smaller tuple → higher priority).
  *
  * The pool sizes itself as

--- a/plugins/cplex/cplex_solver_backend.cpp
+++ b/plugins/cplex/cplex_solver_backend.cpp
@@ -117,6 +117,19 @@ void apply_options_to_env(cpxenv* env, const SolverOptions& opts)
     CPXsetintparam(env, CPX_PARAM_THREADS, opts.threads);
   }
 
+  // Force opportunistic parallel mode (-1, ``CPX_PARALLEL_OPPORTUNISTIC``)
+  // by default.  Per the GTEP LP benchmark
+  // (``docs/analysis/cplex-benchmark-results.md``) this is "the single
+  // best option: 733ms median, tightest range (718-805ms), lowest ticks
+  // (1,150).  Free ~3% speedup."  CPLEX's own default is deterministic
+  // (``+1``) which serialises some internal phases for run-to-run
+  // reproducibility — opportunistic relaxes that and can produce
+  // slightly different floating-point results between runs but
+  // converges to the same optimum within tolerance.  Acceptable for
+  // SDDP because individual cell solves are themselves wrapped in a
+  // tolerance-based convergence test, not a bit-exact compare.
+  CPXsetintparam(env, CPX_PARAM_PARALLELMODE, -1);
+
   CPXsetintparam(env, CPX_PARAM_PREIND, opts.presolve ? CPX_ON : CPX_OFF);
 
   if (opts.scaling.has_value()) {

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -376,6 +376,45 @@ add_pytest_unit_test(
   FIXTURE_REQUIRED scripts-deps
 )
 
+# ── Consolidated unit-test runner ────────────────────────────────────────
+#
+# `scripts-all-unit` runs every package's unit tests in a SINGLE pytest
+# invocation with pytest-xdist (`-n auto`).  Compared with the per-package
+# `scripts-<pkg>-unit` cases above, it pays the Python interpreter +
+# pytest-collection startup cost ONCE instead of N times (≈ 5 s saved
+# wall, ≈ 1 GB peak RSS reduced under `ctest -j20`).  Same parallelism
+# (xdist forks one worker per CPU) but inside a single process tree.
+#
+# Trade-off: failure isolation is weaker — a regression buries all 3500+
+# results under one heading instead of a per-package summary.  Both
+# layouts coexist; pick whichever fits the use case:
+#
+#   * Local "did I break anything?"   → ctest -L aggregate
+#                                       (or: ctest -R '^scripts-all-unit$')
+#   * CI / per-package triage         → default ctest run (per-package
+#                                       tests labelled `unit`; this one
+#                                       is NOT labelled `unit`, so it
+#                                       does NOT double-run by default)
+#
+# Carries ONLY the `aggregate` label so default `ctest` / `ctest -L unit`
+# never picks it up — opt-in only.  This keeps CI from running every
+# Python test twice.
+add_test(
+  NAME scripts-all-unit
+  COMMAND "${PYTHON_EXECUTABLE}" -m pytest
+    "${SCRIPTS_DIR}"
+    -m "not integration"
+    -n auto
+    -q --tb=short
+    --ignore=${SCRIPTS_DIR}/plp2gtopt/tests/test_integration.py
+  WORKING_DIRECTORY "${SCRIPTS_DIR}"
+)
+set_tests_properties(scripts-all-unit PROPERTIES
+  COST 60
+  LABELS "aggregate"
+  FIXTURES_REQUIRED scripts-deps
+)
+
 # ---- plp2gtopt integration tests (one CTest test per case group) ----
 # Each test runs the subset of @pytest.mark.integration tests matching the
 # given -k keyword.  Tests are independent and run in parallel via CTest.

--- a/scripts/gtopt_check_json/_checks.py
+++ b/scripts/gtopt_check_json/_checks.py
@@ -60,6 +60,11 @@ from gtopt_check_json._reference_checks import (
     check_element_references,
 )
 
+# -- Re-export engine-side validation (delegates to gtopt --lp-only) --------
+from gtopt_check_json._engine_validate import (
+    check_engine_validate,
+)
+
 # -- Re-export topology checks ----------------------------------------------
 from gtopt_check_json._topology_checks import (
     IslandInfo,
@@ -91,6 +96,7 @@ _CHECK_REGISTRY: list[tuple[str, Any, bool]] = [
     ("sddp_options", check_sddp_options, False),
     ("cascade_solver_type", check_cascade_solver_type, False),
     ("boundary_cuts", check_boundary_cuts, False),
+    ("engine_validate", check_engine_validate, False),
     ("ai_system_analysis", check_ai_system_analysis, True),
 ]
 
@@ -100,6 +106,7 @@ def run_all_checks(
     enabled_checks: set[str] | None = None,
     ai_options: Any = None,
     base_dir: str = "",
+    json_paths: list[str] | None = None,
 ) -> list[Finding]:
     """Run all enabled checks and return combined findings.
 
@@ -113,17 +120,26 @@ def run_all_checks(
         AI options for the AI system analysis check.  ``None`` disables it.
     base_dir:
         Case directory for resolving relative file paths.
+    json_paths:
+        Original JSON paths the user passed; needed by ``engine_validate``
+        to invoke the gtopt binary on the same inputs.
     """
     findings: list[Finding] = []
 
     # Checks that accept a base_dir keyword argument.
     _NEEDS_BASE_DIR = {"boundary_cuts"}
+    # Checks that accept a json_paths keyword argument.
+    _NEEDS_JSON_PATHS = {"engine_validate"}
 
     for check_id, check_fn, needs_ai in _CHECK_REGISTRY:
         if enabled_checks is not None and check_id not in enabled_checks:
             continue
         if needs_ai:
             findings.extend(check_fn(planning, ai_options=ai_options))
+        elif check_id in _NEEDS_JSON_PATHS:
+            findings.extend(
+                check_fn(planning, json_paths=json_paths, base_dir=base_dir)
+            )
         elif check_id in _NEEDS_BASE_DIR:
             findings.extend(check_fn(planning, base_dir=base_dir))
         else:
@@ -161,6 +177,7 @@ __all__ = [
     "check_cascade_solver_type",
     "check_demand_lmax_nonneg",
     "check_element_references",
+    "check_engine_validate",
     "check_name_uniqueness",
     "check_sddp_options",
     "check_seepage_at_vmin",

--- a/scripts/gtopt_check_json/_config.py
+++ b/scripts/gtopt_check_json/_config.py
@@ -45,6 +45,14 @@ CHECK_DEFAULTS: dict[str, str] = {
     "sddp_options": "true",
     "cascade_solver_type": "true",
     "boundary_cuts": "true",
+    # Engine-side validation: shells out to `gtopt --lp-only` and harvests
+    # the C++-side `Validation: …` log lines.  Enabled by default — picks
+    # up every C++ validator (referential integrity, positivity,
+    # piecewise feasibility, aperture refs, completeness, scenario
+    # probability rescale, …) automatically with zero drift.  Set to
+    # "false" if you don't have the gtopt binary handy or want a
+    # JSON-only static check.
+    "engine_validate": "true",
     "ai_system_analysis": "false",
 }
 

--- a/scripts/gtopt_check_json/_engine_validate.py
+++ b/scripts/gtopt_check_json/_engine_validate.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""Engine-side validation check — shells out to ``gtopt --lp-only`` and
+harvests the C++-side ``Validation: …`` warnings / errors as Findings.
+
+This avoids re-implementing every C++ validator (`check_referential_integrity`,
+`check_positivity`, `check_piecewise_feasibility`, `check_aperture_references`,
+`check_completeness`, `check_scenario_probabilities`, …) in Python: instead
+we ask the canonical authority — the gtopt engine itself — to validate the
+case and surface its findings as `gtopt_check_json` `Finding`s.
+
+Picks up *every* future C++ validator automatically with zero drift.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from gtopt_check_json._checks_common import Finding, Severity
+
+
+# ── Binary discovery (mirrors gtopt_check_solvers/_binary.py) ─────────────
+
+
+def _standard_build_paths() -> list[Path]:
+    """Return the standard build paths relative to the repo root."""
+    repo = Path(__file__).resolve().parent.parent.parent
+    return [
+        repo / "build" / "standalone" / "gtopt",
+        repo / "build" / "test" / "_deps" / "gtopt-build" / "standalone" / "gtopt",
+        Path("/tmp/gtopt-ci-bin/gtopt"),
+    ]
+
+
+def _find_gtopt_binary() -> str | None:
+    """Locate the gtopt binary.
+
+    Search order: ``GTOPT_BIN`` env var → ``gtopt`` on ``PATH`` → standard
+    build directories.  Returns ``None`` if no binary is found.
+    """
+    env_bin = os.environ.get("GTOPT_BIN")
+    if env_bin and Path(env_bin).is_file():
+        return env_bin
+
+    on_path = shutil.which("gtopt")
+    if on_path:
+        return on_path
+
+    for candidate in _standard_build_paths():
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+
+    return None
+
+
+# ── Output parsing ────────────────────────────────────────────────────────
+
+# Matches a single `[ts] [warning] Validation: <msg>` or
+#                  `[ts] [error]   Validation: <msg>` line written by
+# `validate_planning.cpp` via `spdlog::warn("Validation: {}", …)` /
+# `spdlog::error("Validation: {}", …)`.  We tolerate optional source-file
+# prefix (`[file.cpp:LINE]`) inserted by some spdlog patterns.
+_VALIDATION_RE = re.compile(
+    r"\[(?P<level>warning|error)\]\s*"
+    r"(?:\[[^\]]*\]\s*)?"
+    r"Validation:\s*(?P<msg>.+?)\s*$"
+)
+
+
+def _parse_log_lines(log_text: str) -> list[Finding]:
+    """Convert ``Validation: …`` lines from a gtopt log into Findings."""
+    findings: list[Finding] = []
+    for raw_line in log_text.splitlines():
+        m = _VALIDATION_RE.search(raw_line)
+        if m is None:
+            continue
+        level = m.group("level")
+        msg = m.group("msg")
+        sev = Severity.CRITICAL if level == "error" else Severity.WARNING
+        findings.append(
+            Finding(
+                check_id="engine_validate",
+                severity=sev,
+                message=msg,
+            )
+        )
+    return findings
+
+
+# ── Check entry point ─────────────────────────────────────────────────────
+
+
+def check_engine_validate(
+    planning: dict[str, Any],
+    json_paths: list[str] | None = None,
+    base_dir: str = "",
+) -> list[Finding]:
+    """Run ``gtopt --lp-only`` on the same JSON inputs and harvest the
+    C++ ``Validation: …`` log lines as Findings.
+
+    Parameters
+    ----------
+    planning
+        The merged planning dict.  Unused — the gtopt binary parses the
+        original JSON files directly so JSON-merge precedence is exactly
+        what gtopt itself sees.
+    json_paths
+        Original JSON file paths the user passed to ``gtopt_check_json``.
+    base_dir
+        Case directory (unused for this check).
+    """
+    # Silence unused-parameter linters — kept in the signature for the
+    # uniform check-function contract.
+    _ = planning, base_dir
+
+    if not json_paths:
+        return []
+
+    binary = _find_gtopt_binary()
+    if binary is None:
+        return [
+            Finding(
+                check_id="engine_validate",
+                severity=Severity.NOTE,
+                message=(
+                    "skipped: gtopt binary not found "
+                    "(set GTOPT_BIN, add gtopt to PATH, or build the standalone)"
+                ),
+            )
+        ]
+
+    # Run gtopt with --lp-only so it parses + validates + builds LP and
+    # exits before solving.  --output-directory + --log-directory point
+    # both at a single tempdir we control, so the validation messages
+    # land in `<tmpdir>/gtopt_*.log` (per the non-TTY logging convention).
+    with tempfile.TemporaryDirectory(prefix="gtopt_check_lp_") as tmpdir:
+        tmp = Path(tmpdir)
+        cmd: list[str] = [
+            binary,
+            *json_paths,
+            "--lp-only",
+            "--set",
+            f"output_directory={tmp}",
+            "--set",
+            f"log_directory={tmp}",
+        ]
+        try:
+            subprocess.run(  # noqa: S603
+                cmd,
+                check=False,  # exit-1 on validation error is expected
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=120,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return [
+                Finding(
+                    check_id="engine_validate",
+                    severity=Severity.NOTE,
+                    message=f"skipped: gtopt invocation failed: {exc}",
+                )
+            ]
+
+        log_files = sorted(tmp.glob("gtopt_*.log"))
+        if not log_files:
+            return [
+                Finding(
+                    check_id="engine_validate",
+                    severity=Severity.NOTE,
+                    message=(
+                        "skipped: gtopt produced no log file "
+                        f"(checked {tmp}); the binary may be older than "
+                        "the per-run gtopt_N.log convention"
+                    ),
+                )
+            ]
+
+        log_text = log_files[-1].read_text(encoding="utf-8", errors="replace")
+
+    return _parse_log_lines(log_text)

--- a/scripts/gtopt_check_json/gtopt_check_json.py
+++ b/scripts/gtopt_check_json/gtopt_check_json.py
@@ -188,6 +188,7 @@ def check_json(
         enabled_checks=enabled,
         ai_options=ai_options,
         base_dir=_case_dir,
+        json_paths=json_paths,
     )
 
     # Connectivity table (replaces verbose bus_connectivity findings)

--- a/scripts/gtopt_check_json/tests/test_engine_validate.py
+++ b/scripts/gtopt_check_json/tests/test_engine_validate.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""Unit tests for the engine_validate check.
+
+Two layers of testing:
+
+* Parser tests (`_parse_log_lines`) — pure-function, no subprocess.
+* Integration test (`check_engine_validate`) — invokes the actual gtopt
+  binary; skipped when no binary is found.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from gtopt_check_json._checks_common import Severity
+from gtopt_check_json._engine_validate import (
+    _find_gtopt_binary,
+    _parse_log_lines,
+    check_engine_validate,
+)
+
+
+# ── Parser ────────────────────────────────────────────────────────────────
+
+
+def test_parse_log_lines_warning_and_error():
+    """Both `[warning] Validation:` and `[error] Validation:` are picked up."""
+    log = textwrap.dedent(
+        """\
+        [22:24:31.684] [info] starting gtopt 1.0
+        [22:24:31.700] [warning] Validation: Reservoir 'R1' segment 2 produces qfilt below fmin
+        [22:24:31.701] [error] Validation: Aperture uid 99 not found in scenario_array
+        [22:24:31.702] [info] Planning validation passed
+        """
+    )
+    findings = _parse_log_lines(log)
+    assert len(findings) == 2
+    assert findings[0].severity == Severity.WARNING
+    assert findings[0].check_id == "engine_validate"
+    assert "Reservoir 'R1' segment 2" in findings[0].message
+    assert findings[1].severity == Severity.CRITICAL
+    assert "Aperture uid 99" in findings[1].message
+
+
+def test_parse_log_lines_ignores_non_validation_warnings():
+    """Lines without `Validation:` prefix are skipped (e.g. deprecations)."""
+    log = textwrap.dedent(
+        """\
+        [22:24:31.684] [warning] deprecated option 'use_single_bus': use
+        [22:24:31.685] [warning] --output-directory is deprecated
+        [22:24:31.690] [info] starting gtopt 1.0
+        """
+    )
+    assert not _parse_log_lines(log)
+
+
+def test_parse_log_lines_handles_source_prefix():
+    """`[file.cpp:LINE]` source-prefixed lines are still matched."""
+    log = (
+        "[22:24:31.700] [warning] [validate_planning.cpp:974] "
+        "Validation: Demand 'D1' lmax is negative\n"
+    )
+    findings = _parse_log_lines(log)
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.WARNING
+    assert findings[0].message == "Demand 'D1' lmax is negative"
+
+
+def test_parse_log_lines_empty():
+    """Empty input → no findings."""
+    assert not _parse_log_lines("")
+
+
+# ── Integration (skipped without binary) ──────────────────────────────────
+
+
+def _resolve_binary() -> str | None:
+    """Locate gtopt for the integration test, including the dev tree."""
+    # Honour the test's own GTOPT_BIN; fall back to the helper.
+    return os.environ.get("GTOPT_BIN") or _find_gtopt_binary()
+
+
+_GTOPT_BIN = _resolve_binary()
+
+
+@pytest.mark.skipif(
+    _GTOPT_BIN is None or shutil.which(_GTOPT_BIN) is None,
+    reason="gtopt binary not available",
+)
+def test_check_engine_validate_clean_case():
+    """Running the engine on a known-clean case yields zero findings."""
+    repo = Path(__file__).resolve().parents[3]
+    case = repo / "cases" / "c0" / "system_c0.json"
+    if not case.is_file():
+        pytest.skip(f"canonical case not present: {case}")
+
+    findings = check_engine_validate({}, json_paths=[str(case)])
+    # c0 has no `Validation:` lines (deprecation warnings are ignored).
+    crit_warns = [f for f in findings if f.severity != Severity.NOTE]
+    assert crit_warns == [], (
+        "expected no validation findings on clean case c0; got: "
+        f"{[(f.severity.name, f.message) for f in crit_warns]}"
+    )
+
+
+def test_check_engine_validate_no_binary(monkeypatch):
+    """When the binary is unreachable, return a single NOTE finding."""
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setenv("GTOPT_BIN", "/nonexistent/gtopt")
+    findings = check_engine_validate({}, json_paths=["/tmp/dummy.json"])
+    # Either: env_bin path is invalid → falls through to PATH (empty) →
+    # tries standard build dirs.  If none exist, returns a single NOTE.
+    # If one *does* happen to exist on this dev box, the test still
+    # passes when no Validation messages fire on a missing JSON path
+    # (binary reports a parse error, no `Validation:` lines).
+    notes = [f for f in findings if f.severity == Severity.NOTE]
+    crits = [f for f in findings if f.severity == Severity.CRITICAL]
+    assert notes or crits or not findings
+
+
+def test_check_engine_validate_no_paths():
+    """Empty json_paths → no work, no findings."""
+    assert not check_engine_validate({}, json_paths=None)
+    assert not check_engine_validate({}, json_paths=[])

--- a/scripts/plp2gtopt/_parsers.py
+++ b/scripts/plp2gtopt/_parsers.py
@@ -377,19 +377,23 @@ def add_solver_arguments(parser: argparse.ArgumentParser, conf: dict[str, str]) 
         "--cut-sharing-mode",
         dest="cut_sharing_mode",
         metavar="MODE",
-        default="max",
+        default="none",
         choices=["none", "expected", "accumulate", "max"],
         help=(
             "SDDP cut sharing mode: "
-            "'none' keeps cuts in their originating scene; "
+            "'none' keeps cuts in their originating scene "
+            "(default — the only mathematically safe mode for "
+            "heterogeneous-realisation runs; see "
+            "docs/analysis/investigations/sddp/sddp_cut_sharing_fix_plan_2026-04-30.md); "
             "'expected' computes a probability-weighted average cut; "
             "'accumulate' sums all cuts directly (correct when LP "
             "objectives include probability factors); "
             "'max' shares all cuts from all scenes to all scenes "
             "(PLP-legacy behaviour — every per-scenario cut is "
             "broadcast verbatim, matching `plp-agrespd.f::AgrResPD` "
-            "DO II=IBeg,IEnd). "
-            "(default: max)"
+            "DO II=IBeg,IEnd; valid only when scenes share IDENTICAL "
+            "sample-path realisations at every phase and block). "
+            "(default: none)"
         ),
     )
     parser.add_argument(

--- a/scripts/plp2gtopt/_parsers.py
+++ b/scripts/plp2gtopt/_parsers.py
@@ -535,7 +535,7 @@ def add_solver_arguments(parser: argparse.ArgumentParser, conf: dict[str, str]) 
             "is at or above G, neither stationary nor CI convergence will "
             "fire — only the primary `convergence_tol` test can declare "
             "convergence.  Defends against heterogeneous-scene σ explosion "
-            "(juan run 2026-05-02 converged at iter 2 with gap=25 % via the "
+            "(juan run 2026-05-02 converged at iter 2 with gap=25%% via the "
             "CI test because σ=77 M dominated the 38 M absolute gap).  "
             "Use 1.0 to disable the ceiling.  "
             "(default: emit 0.05 when not set; gtopt's own default is 0.5)"

--- a/scripts/plp2gtopt/gtopt_writer.py
+++ b/scripts/plp2gtopt/gtopt_writer.py
@@ -87,6 +87,15 @@ def _validate_piecewise_segments(planning: Dict) -> list[str]:
       ``min(f(V_low), f(V_high)) < fmin``  OR
       ``max(f(V_low), f(V_high)) > fmax``.
 
+      Also warn when the **first segment** evaluated at ``efin = emin``
+      gives a non-zero qfilt (tolerance 1e-3 m³/s).  PLP filtration
+      curves are physically expected to drop to zero at the lower
+      operating volume; ``junction_writer._fix_first_seepage_segment``
+      anchors q(vmin)=0 by default, so a violation here means the
+      input bypassed that fix (``--plp-legacy``, single-segment
+      curves, or hand-edited JSON) — the LP will be forced to
+      discharge water that isn't physically in storage near vmin.
+
     * ReservoirDischargeLimit row is the inequality
       ``qeh ≤ intercept + slope · efin`` with ``qeh ≥ 0``.  Warn when
       ``min(f(V_low), f(V_high)) < 0``.
@@ -122,6 +131,66 @@ def _validate_piecewise_segments(planning: Dict) -> list[str]:
         fmax_val = _try_scalar(ww.get("fmax"))
         fmin_val = 0.0 if fmin_val is None else fmin_val
         fmax_val = float("inf") if fmax_val is None else fmax_val
+
+        # First-segment q(emin) physical-zero check + auto-fix.  Mirrors
+        # `junction_writer._fix_first_seepage_segment` (which runs on
+        # the way OUT of plp2gtopt for the standard path) so cases that
+        # bypassed it — hand-edited JSON, --plp-legacy, single-segment
+        # curves — still get anchored at q(emin)=0 with the same
+        # 2-point algorithm: anchor (emin, 0) plus continuity at
+        # segment-2's start volume.  A warning fires unconditionally
+        # so the operator sees the (auto-)correction in the log.
+        first = segments[0]
+        first_slope = float(first.get("slope", 0.0))
+        first_constant = float(first.get("constant", 0.0))
+        q_at_emin = first_constant + first_slope * emin
+        if abs(q_at_emin) > 1e-3:
+            seep_name = seep.get("name")
+            rsv_name = rsv.get("name")
+            ww_name = ww.get("name")
+            if len(segments) >= 2:
+                seg2_vol = float(segments[1].get("volume", 0.0))
+            else:
+                seg2_vol = float("nan")
+            if len(segments) >= 2 and seg2_vol > emin:
+                # Anchor: q(emin)=0 and q(seg2_vol) preserved
+                # (continuity with the rest of the curve).
+                q_at_seg2 = first_constant + first_slope * seg2_vol
+                new_slope = q_at_seg2 / (seg2_vol - emin)
+                new_constant = -new_slope * emin
+                # In-place mutation of the planning dict — caller's
+                # reference sees the corrected coefficients.
+                segments[0]["slope"] = new_slope
+                segments[0]["constant"] = new_constant
+                warnings.append(
+                    f"ReservoirSeepage '{seep_name}' (reservoir "
+                    f"'{rsv_name}', waterway '{ww_name}'): first "
+                    f"segment qfilt(efin=emin={emin:.4g}) = "
+                    f"{q_at_emin:.4g} → 0 (auto-anchored: slope "
+                    f"{first_slope:.6g}→{new_slope:.6g}, constant "
+                    f"{first_constant:.6g}→{new_constant:.6g}, "
+                    f"continuity at vol={seg2_vol:.4g} with "
+                    f"q={q_at_seg2:.4g})."
+                )
+            else:
+                # Single segment, or seg2 starts at/below emin —
+                # cannot anchor cleanly without losing physical
+                # meaning; warn only.
+                reason = (
+                    "single segment"
+                    if len(segments) < 2
+                    else f"second segment vol={seg2_vol:.4g} ≤ emin={emin:.4g}"
+                )
+                warnings.append(
+                    f"ReservoirSeepage '{seep_name}' (reservoir "
+                    f"'{rsv_name}', waterway '{ww_name}'): first "
+                    f"segment qfilt(efin=emin={emin:.4g}) = "
+                    f"{q_at_emin:.4g} (slope={first_slope:.6g}, "
+                    f"constant={first_constant:.6g}); cannot "
+                    f"auto-anchor ({reason}) — fix the segment "
+                    f"data manually so that constant + slope * emin "
+                    f"= 0."
+                )
 
         for k, seg in enumerate(segments):
             slope = float(seg.get("slope", 0.0))

--- a/scripts/plp2gtopt/gtopt_writer.py
+++ b/scripts/plp2gtopt/gtopt_writer.py
@@ -448,6 +448,18 @@ class GTOptWriter(
         # cut_coeff_eps: drop coefficients with |value| < eps (default 1e-8).
         sddp_opts["cut_coeff_eps"] = options.get("cut_coeff_eps", 1e-8)
 
+        # Pin the SDDP backward-pass solver to a single thread.  Per-stage
+        # backward LPs are small (hundreds-to-thousands of vars) and the
+        # parallel-simplex / parallel-barrier overhead in CPLEX/HiGHS hurts
+        # more than it helps; one-thread-per-LP also avoids oversubscribing
+        # the host when the SDDP scheduler already runs many backward LPs
+        # concurrently across (scene × phase) cells.  C++ default is 2; this
+        # block keeps the JSON intentional and CLI-overridable via
+        # `--set sddp_options.backward_solver_options.threads=N`.
+        sddp_opts["backward_solver_options"] = {
+            "threads": options.get("backward_solver_threads", 1),
+        }
+
         # When the JSON file lives inside the output directory (the default),
         # input_directory is "." so paths are relative to the JSON location.
         # When -f places the JSON elsewhere, use the full output_dir path.

--- a/scripts/plp2gtopt/gtopt_writer.py
+++ b/scripts/plp2gtopt/gtopt_writer.py
@@ -365,6 +365,14 @@ class GTOptWriter(
                 "sddp_options": {
                     "max_iterations": l0_iter,
                     "convergence_tol": convergence_tol,
+                    # Level 0 (uninodal) is a pure-Benders relaxation:
+                    # the single-bus problem converges much faster
+                    # without the per-aperture solve overhead, and the
+                    # state-variable targets it inherits to level 1
+                    # are unaffected by aperture quality at level 0.
+                    # Empty array overrides the per-phase
+                    # ``Phase::apertures`` default.
+                    "apertures": [],
                 },
             },
             {
@@ -378,6 +386,19 @@ class GTOptWriter(
                 "sddp_options": {
                     "max_iterations": l1_iter,
                     "convergence_tol": convergence_tol,
+                    # ``apertures`` deliberately omitted from level 1
+                    # onward.  The C++ cascade-level merge in
+                    # ``cascade_method.cpp::build_level_sddp_opts``
+                    # only overrides ``opts.apertures`` when
+                    # ``level_solver->apertures.has_value()``; an
+                    # absent key serialises to ``nullopt`` which
+                    # resolves at runtime to "use per-phase
+                    # ``Phase::apertures`` (= the global
+                    # ``aperture_array`` when ``Phase.apertures`` is
+                    # empty)".  This re-enables apertures at level 1
+                    # without polluting the JSON with a
+                    # ``"apertures": null`` line that reads literally
+                    # as "no apertures".
                 },
                 "transition": transition,
             },
@@ -408,6 +429,7 @@ class GTOptWriter(
                 "sddp_options": {
                     "max_iterations": l2_iter,
                     "convergence_tol": convergence_tol,
+                    # ``apertures`` omitted (see level-1 comment).
                 },
                 "transition": transition,
             },

--- a/scripts/plp2gtopt/planos_parser.py
+++ b/scripts/plp2gtopt/planos_parser.py
@@ -40,9 +40,19 @@ intermediate stages.
 The gradient coefficients ``GradX`` correspond to the reservoir volumes
 (state variables) identified by the name mapping in file 1.
 
-The resulting ``varphi`` (φ) variable satisfies::
+The resulting ``varphi`` (φ) variable satisfies the PLP-canonical cut::
 
-    φ ≥ -LDPhiPrv + Σ_i GradX_i · Vol_i
+    φ ≥ +LDPhiPrv + Σ_i GradX_i · Vol_i
+
+where ``LDPhiPrv = E[Z(v_trial)]`` is the **positive** expected future
+operating cost from the next stage onwards (verified against real PLP
+``plpplem2.dat`` output: every row has ``LDPhiPrv > 0``), and
+``GradX_i = ∂E[Z]/∂v_i`` is the **negative** marginal water value (more
+water → less future cost).  The CSV ``rhs`` column carries
+``+LDPhiPrv`` directly, with no sign flip — matching PLP's
+``plp-agrespd.f::AgrResPDi`` which builds the LP row as
+``rowlb = +LDPhiPrv/ScalePhi`` for the constraint
+``α + Σ(-GradX/ScalePhi)·v ≥ +LDPhiPrv/ScalePhi``.
 """
 
 import logging
@@ -228,7 +238,11 @@ class PlanosParser(BaseParser):
             iter_num = int(fields[0])  # IPDNumIte
             stage = int(fields[1])  # IEtapa (1-based)
             scenario = int(fields[2])  # ISimul (1-based)
-            ld_phi_prv = float(fields[3])  # LDPhiPrv (intercept, negated)
+            # LDPhiPrv = E[Z(v_trial)] from PLP backward pass — positive
+            # expected future operating cost (set by `plp-espercnd.f:54`
+            # as `LDPhiPrv = PromedioZ`).  Written verbatim by
+            # `plp-gdbdple.f:42` and `plp-gdbdple2.f:93`.
+            ld_phi_prv = float(fields[3])
 
             coefficients: Dict[str, float] = {}
             for ri, rname in enumerate(self.reservoir_names):
@@ -241,7 +255,17 @@ class PlanosParser(BaseParser):
                 "iteration": iter_num,
                 "stage": stage,
                 "scene": scenario,  # PLP ISimul maps to scene UID
-                "rhs": -ld_phi_prv,  # PLP stores negative intercept
+                # rhs = +LDPhiPrv (no sign flip).  PLP's LP cut at row
+                # construction time (`plp-agrespd.f:194,203`) sets
+                # rowlb = +LDPhiPrv/ScalePhi for the row
+                # `α + Σ(-GradX/ScalePhi)·v ≥ rowlb`.  gtopt's loader at
+                # `source/sddp_boundary_cuts.cpp:418` consumes
+                # `rc.rhs` directly as `lowb`, so the CSV must carry
+                # the positive intercept.  An earlier version negated
+                # this on emit, producing α ≈ -LDPhiPrv at the last
+                # phase — verified against PLP source 2026-05-05 and
+                # corrected.
+                "rhs": ld_phi_prv,
                 "coefficients": coefficients,
             }
             self.all_cuts.append(cut)

--- a/scripts/plp2gtopt/tests/test_gtopt_writer.py
+++ b/scripts/plp2gtopt/tests/test_gtopt_writer.py
@@ -1149,7 +1149,9 @@ class TestValidatePiecewiseSegments:
     def test_seepage_below_fmin_warns(self):
         from plp2gtopt.gtopt_writer import _validate_piecewise_segments
 
-        # f(100) = -5 + 0.01·100 = -4 < fmin=0
+        # f(100) = -5 + 0.01·100 = -4 < fmin=0.  The same input also
+        # fails the q(emin)=0 check (q(100) = -4 ≠ 0), so two warnings
+        # fire; assert that the fmin one is among them.
         planning = self._planning_with(
             seepages=[
                 {
@@ -1163,18 +1165,18 @@ class TestValidatePiecewiseSegments:
             ],
         )
         warns = _validate_piecewise_segments(planning)
-        assert len(warns) == 1
-        assert "seep1" in warns[0]
-        assert "fmin" in warns[0]
-        assert "segment 0" in warns[0]
+        fmin_warns = [w for w in warns if "fmin" in w and "segment 0" in w]
+        assert len(fmin_warns) == 1
+        assert "seep1" in fmin_warns[0]
 
     def test_seepage_above_fmax_warns(self):
         from plp2gtopt.gtopt_writer import _validate_piecewise_segments
 
         # f(100) = 10 + 0.2·100 = 30 ∈ [0, 100] ✓ (lower bound ok)
         # f(1000) = 10 + 0.2·1000 = 210 > fmax=100 ✗
-        # Only the upper-bound violation fires; the lower endpoint
-        # is inside [fmin, fmax] so no fmin warning.
+        # The same input also fails the q(emin)=0 check (q(100) = 30 ≠
+        # 0), so two warnings fire; assert that the fmax one is among
+        # them.
         planning = self._planning_with(
             seepages=[
                 {
@@ -1188,9 +1190,91 @@ class TestValidatePiecewiseSegments:
             ],
         )
         warns = _validate_piecewise_segments(planning)
-        assert len(warns) == 1
-        assert "seep1" in warns[0]
-        assert "fmax" in warns[0]
+        fmax_warns = [w for w in warns if "fmax" in w]
+        assert len(fmax_warns) == 1
+        assert "seep1" in fmax_warns[0]
+
+    def test_seepage_q_at_emin_nonzero_single_segment_warns_no_fix(self):
+        from plp2gtopt.gtopt_writer import _validate_piecewise_segments
+
+        # Single segment with q(efin=100) = -0.5 + 0.01·100 = 0.5 m³/s.
+        # The validator can't auto-anchor (no second segment to preserve
+        # continuity with), so it emits a "cannot auto-anchor (single
+        # segment)" warning and leaves the data unchanged.
+        planning = self._planning_with(
+            seepages=[
+                {
+                    "name": "seep1",
+                    "reservoir": 1,
+                    "waterway": 10,
+                    "segments": [
+                        {"volume": 100, "slope": 0.01, "constant": -0.5},
+                    ],
+                },
+            ],
+        )
+        warns = _validate_piecewise_segments(planning)
+        anchor_warns = [w for w in warns if "qfilt(efin=emin" in w]
+        assert len(anchor_warns) == 1
+        assert "single segment" in anchor_warns[0]
+        # Coefficients are NOT mutated when auto-anchor is impossible.
+        seg = planning["system"]["reservoir_seepage_array"][0]["segments"][0]
+        assert seg["slope"] == 0.01
+        assert seg["constant"] == -0.5
+
+    def test_seepage_q_at_emin_nonzero_two_segments_auto_anchored(self):
+        from plp2gtopt.gtopt_writer import _validate_piecewise_segments
+
+        # First segment: q(emin=100) = 2 + 0.05·100 = 7 m³/s ≠ 0.
+        # Second segment starts at vol=500 → continuity anchor point.
+        # Auto-anchor target:
+        #   q_at_seg2 = 2 + 0.05·500 = 27
+        #   new_slope = 27 / (500 - 100) = 0.0675
+        #   new_constant = -0.0675 · 100 = -6.75
+        planning = self._planning_with(
+            seepages=[
+                {
+                    "name": "seep1",
+                    "reservoir": 1,
+                    "waterway": 10,
+                    "segments": [
+                        {"volume": 100, "slope": 0.05, "constant": 2.0},
+                        {"volume": 500, "slope": 0.10, "constant": -20.0},
+                    ],
+                },
+            ],
+        )
+        warns = _validate_piecewise_segments(planning)
+        anchor_warns = [w for w in warns if "auto-anchored" in w]
+        assert len(anchor_warns) == 1
+        assert "seep1" in anchor_warns[0]
+        # Segments mutated in place — verify the fixed coefficients.
+        seg0 = planning["system"]["reservoir_seepage_array"][0]["segments"][0]
+        assert seg0["slope"] == pytest.approx(0.0675)
+        assert seg0["constant"] == pytest.approx(-6.75)
+        # Sanity: the rebuilt curve now yields q(emin=100) ≈ 0
+        assert seg0["constant"] + seg0["slope"] * 100 == pytest.approx(0.0, abs=1e-12)
+
+    def test_seepage_q_at_emin_zero_emits_no_warning(self):
+        from plp2gtopt.gtopt_writer import _validate_piecewise_segments
+
+        # First segment perfectly anchored at q(emin=100) = 0:
+        # constant + slope·100 = -1 + 0.01·100 = 0.0 ✓
+        # No warnings should fire (this also exercises the path that
+        # CIPRESES auto-rebuild produces).
+        planning = self._planning_with(
+            seepages=[
+                {
+                    "name": "seep1",
+                    "reservoir": 1,
+                    "waterway": 10,
+                    "segments": [
+                        {"volume": 100, "slope": 0.01, "constant": -1.0},
+                    ],
+                },
+            ],
+        )
+        assert not _validate_piecewise_segments(planning)
 
     def test_clean_discharge_limit_emits_no_warning(self):
         from plp2gtopt.gtopt_writer import _validate_piecewise_segments

--- a/scripts/plp2gtopt/tests/test_gtopt_writer_coverage.py
+++ b/scripts/plp2gtopt/tests/test_gtopt_writer_coverage.py
@@ -54,6 +54,26 @@ class TestProcessOptions:
         sddp = writer.planning["options"].get("sddp_options", {})
         assert sddp.get("cut_sharing_mode") == "shared"
 
+    def test_process_options_backward_solver_threads_default(self, tmp_path):
+        """process_options always emits backward_solver_options.threads=1."""
+        parser = PLPParser({"input_dir": _PLPMin1Bus})
+        parser.parse_all()
+        writer = GTOptWriter(parser)
+        writer.process_options(_make_opts(tmp_path))
+        sddp = writer.planning["options"]["sddp_options"]
+        assert sddp["backward_solver_options"] == {"threads": 1}
+
+    def test_process_options_backward_solver_threads_override(self, tmp_path):
+        """`backward_solver_threads` option overrides the default."""
+        parser = PLPParser({"input_dir": _PLPMin1Bus})
+        parser.parse_all()
+        writer = GTOptWriter(parser)
+        opts = _make_opts(tmp_path)
+        opts["backward_solver_threads"] = 4
+        writer.process_options(opts)
+        sddp = writer.planning["options"]["sddp_options"]
+        assert sddp["backward_solver_options"] == {"threads": 4}
+
 
 # ---------------------------------------------------------------------------
 # _load_variable_scales_file (lines 1119-1156)

--- a/scripts/plp2gtopt/tests/test_planos.py
+++ b/scripts/plp2gtopt/tests/test_planos.py
@@ -27,15 +27,18 @@ def planos_files(tmp_path: Path):
         "2 'Colbun'\n"
     )
 
-    # plpplaem2.dat — 3 cuts, boundary stage = 5
+    # plpplaem2.dat — 3 cuts, boundary stage = 5.
     # Fields: IPDNumIte  IEtapa  ISimul  LDPhiPrv  GradX(1)  GradX(2)
+    # LDPhiPrv values are POSITIVE (real PLP output), matching
+    # `plp-espercnd.f:54` (`LDPhiPrv = PromedioZ` — averaged LP obj
+    # across apertures, always positive for cost-minimization SDDP).
     plaem2.write_text(
         "5\n"  # boundary stage
-        "1  5  1  -1000.5  0.25  0.75\n"
-        "1  5  2  -2000.3  0.50  0.60\n"
-        "2  5  1  -1500.0  0.35  0.80\n"
+        "1  5  1  1000.5  0.25  0.75\n"
+        "1  5  2  2000.3  0.50  0.60\n"
+        "2  5  1  1500.0  0.35  0.80\n"
         # This cut is for stage 3 (not boundary stage 5) — should be skipped
-        "2  3  1  -9999.0  0.99  0.99\n"
+        "2  3  1  9999.0  0.99  0.99\n"
     )
 
     return plaem1, plaem2

--- a/scripts/tests/test_cli_help.py
+++ b/scripts/tests/test_cli_help.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""Smoke-tests for every CLI script's ``--help`` output.
+
+These tests exist to catch a specific class of bug that's silent until
+a user actually types ``-h``:
+
+* argparse's ``_expand_help`` runs ``help_string % params`` on each
+  option's help text, where ``params`` carries the standard
+  ``%(default)s``, ``%(prog)s`` etc. tokens.  A **bare** ``%`` in the
+  help text — e.g. ``"converged at gap=25 % via the CI test"`` — is
+  interpreted as a format placeholder, and argparse raises
+  ``ValueError: unsupported format character '<X>'`` only at
+  ``--help`` invocation time.  None of the unit tests catch this
+  because they never call ``parser.format_help()``.
+
+* Module-import errors at the entry-point: a missing dependency, a
+  circular import, or a top-level ``raise`` in a renamed helper
+  surface here as ``ImportError`` / ``ModuleNotFoundError`` and a red
+  test, instead of a confusing traceback the first time a user runs
+  ``<script> --help``.
+
+The test mirrors ``[project.scripts]`` in ``scripts/pyproject.toml`` —
+keep the two in sync when adding a new CLI.  Each parametrisation
+imports the entry-point function and invokes it with
+``sys.argv = [<script>, "--help"]``; argparse short-circuits with
+``SystemExit(0)`` after printing the help text.
+"""
+
+from __future__ import annotations
+
+import importlib
+import io
+from contextlib import redirect_stderr, redirect_stdout
+
+import pytest
+
+# (script_name, dotted_module, function_name).  Mirrors
+# ``[project.scripts]`` in ``scripts/pyproject.toml``.  When adding a
+# new CLI to that table, append a row here too.
+ENTRY_POINTS: list[tuple[str, str, str]] = [
+    ("plp2gtopt", "plp2gtopt.main", "main"),
+    ("pp2gtopt", "pp2gtopt.main", "main"),
+    ("ts2gtopt", "ts2gtopt.main", "main"),
+    ("sddp2gtopt", "sddp2gtopt.main", "main"),
+    ("gtopt2pp", "gtopt2pp.main", "main"),
+    ("gtopt_compare", "gtopt_compare.main", "main"),
+    ("gtopt_check_lp", "gtopt_check_lp.gtopt_check_lp", "main"),
+    ("gtopt_check_json", "gtopt_check_json.gtopt_check_json", "main"),
+    ("gtopt_check_output", "gtopt_check_output.main", "main"),
+    ("gtopt_check_solvers", "gtopt_check_solvers.gtopt_check_solvers", "main"),
+    ("gtopt_check_pampl", "gtopt_check_pampl.gtopt_check_pampl", "main"),
+    ("gtopt_check_fingerprint", "gtopt_check_fingerprint._cli", "main"),
+    ("gtopt_compress_lp", "gtopt_compress_lp.gtopt_compress_lp", "main"),
+    ("gtopt_field_extractor", "gtopt_field_extractor", "main"),
+    ("gtopt_diagram", "gtopt_diagram", "main"),
+    ("gtopt_expand", "gtopt_expand.cli", "main"),
+    ("gtopt_monitor", "gtopt_monitor", "main"),
+    ("cvs2parquet", "cvs2parquet.cvs2parquet", "main"),
+    ("igtopt", "igtopt.igtopt", "main"),
+    ("run_gtopt", "run_gtopt.main", "main"),
+    ("plp_compress_case", "plp_compress_case.main", "main"),
+    ("cen_demanda", "cen_demanda.main", "main"),
+    ("gtopt_results_summary", "gtopt_results_summary.main", "main"),
+    ("gtopt_timeseries_export", "gtopt_timeseries_export.main", "main"),
+]
+
+
+@pytest.mark.parametrize(
+    "script_name,module_path,func_name",
+    ENTRY_POINTS,
+    ids=[name for name, _, _ in ENTRY_POINTS],
+)
+def test_help_renders_without_error(
+    script_name: str, module_path: str, func_name: str, monkeypatch
+) -> None:
+    """``<script> --help`` must complete without raising.
+
+    Specifically catches:
+    * ``ValueError`` from argparse percent-formatting on bare ``%``
+      characters in help strings.
+    * ``ModuleNotFoundError`` / import-time errors at the entry-point.
+    * Missing/renamed entry-point functions (would raise
+      ``AttributeError``).
+
+    Asserts:
+    * Exit is via ``SystemExit(0)`` (argparse's --help convention).
+    * Stdout contains a recognisable usage line so we know the help
+      text actually rendered (and didn't, say, crash inside a
+      formatter mid-write).
+    """
+    try:
+        mod = importlib.import_module(module_path)
+    except ImportError as exc:
+        pytest.fail(
+            f"{script_name}: cannot import entry-point module '{module_path}': {exc}"
+        )
+
+    main_fn = getattr(mod, func_name, None)
+    if main_fn is None:
+        pytest.fail(
+            f"{script_name}: entry-point function '{func_name}' "
+            f"not found in module '{module_path}'"
+        )
+
+    monkeypatch.setattr("sys.argv", [script_name, "--help"])
+
+    out_buf = io.StringIO()
+    err_buf = io.StringIO()
+    try:
+        with redirect_stdout(out_buf), redirect_stderr(err_buf):
+            with pytest.raises(SystemExit) as exc_info:
+                main_fn()
+    except ValueError as exc:
+        pytest.fail(
+            f"{script_name} --help raised ValueError "
+            f"(likely a bare '%' in help text): {exc}"
+        )
+
+    assert exc_info.value.code in (0, None), (
+        f"{script_name} --help exited with code "
+        f"{exc_info.value.code}; stderr=\n{err_buf.getvalue()}"
+    )
+    stdout_text = out_buf.getvalue()
+    assert "usage:" in stdout_text.lower(), (
+        f"{script_name} --help did not render a usage line; "
+        f"stdout=\n{stdout_text[:500]}"
+    )

--- a/source/linear_interface.cpp
+++ b/source/linear_interface.cpp
@@ -919,22 +919,27 @@ LinearInterface LinearInterface::clone_from_flat(CloneKind kind) const
   // Pre-conditions: the manual route reads from
   // `m_snapshot_holder_.snapshot().flat_lp`, which is only populated when
   // `freeze_for_cuts` ran with `LowMemoryMode::compress` (or `snapshot`).
-  // Compressed snapshots are not directly readable here — the SDDP aperture
-  // path decompresses around the backward pass via `DecompressionGuard`
-  // (sddp_aperture_pass.cpp:390, 579), so callers reaching this
-  // method during the aperture window are guaranteed an
-  // uncompressed snapshot.
+  // The SDDP aperture path decompresses around the backward pass via
+  // `DecompressionGuard` (sddp_aperture_pass.cpp:460 / 693), so callers
+  // reaching this method during the aperture window are guaranteed a
+  // hydrated `flat_lp.matbeg` even though the persistent compressed
+  // buffer (`m_snapshot_holder_.is_compressed()`) may still report
+  // ``true`` — the buffer is kept alive as a cache by
+  // `LowMemorySnapshot::decompress` and survives the rehydrate.  The
+  // check below is therefore on the *accessibility* of the flat LP
+  // (matbeg populated), not on the secondary compressed cache.
   if (!m_snapshot_holder_.has_data()) {
     throw std::runtime_error(
         "LinearInterface::clone_from_flat: source has no snapshot — call "
         "freeze_for_cuts(LowMemoryMode::compress) on the source first, or "
         "fall back to clone(kind) which uses the backend's native clone.");
   }
-  if (m_snapshot_holder_.is_compressed()) {
+  if (m_snapshot_holder_.snapshot().flat_lp.matbeg.empty()) {
     throw std::runtime_error(
-        "LinearInterface::clone_from_flat: source snapshot is compressed; "
-        "decompress first (DecompressionGuard) or fall back to "
-        "clone(kind).");
+        "LinearInterface::clone_from_flat: source flat LP is not "
+        "decompressed (matbeg is empty while compressed cache may be "
+        "present); decompress first (DecompressionGuard) or fall back "
+        "to clone(kind).");
   }
 
   // Build the clone via load_flat — no backend.clone() call, no

--- a/source/sddp_aperture.cpp
+++ b/source/sddp_aperture.cpp
@@ -495,7 +495,10 @@ auto solve_apertures_for_phase(
   spdlog::info(
       "{}: {}/{} feasible, {} infeasible, {} skipped ({:.3f}s) "
       "[thread {}]",
-      sddp_log("Aperture", iteration_index, scene_uid_val, phase_uid_val),
+      sddp_log("Aperture",
+               gtopt::uid_of(iteration_index),
+               scene_uid_val,
+               phase_uid_val),
       n_feasible,
       n_total,
       n_infeasible,

--- a/source/sddp_aperture_pass.cpp
+++ b/source/sddp_aperture_pass.cpp
@@ -169,7 +169,7 @@ auto SDDPMethod::install_aperture_backward_cut(
     bool keep_expected_cut = true;
     if (src_phase_index) {
       src_li.set_log_tag(sddp_log("Backward",
-                                  iteration_index,
+                                  gtopt::uid_of(iteration_index),
                                   uid_of(scene_index),
                                   uid_of(src_phase_index)));
       const auto t_resolve = Clock::now();
@@ -182,13 +182,14 @@ auto SDDPMethod::install_aperture_backward_cut(
       } else {
         keep_expected_cut = false;
         SPDLOG_WARN(
-            "{}: non-optimal after expected cut (status {}), "
-            "reverting row and installing bcut fallback",
+            "{}: non-optimal after expected cut (status {}, resolve "
+            "{:.3f}s), reverting row and installing bcut fallback",
             sddp_log("Backward",
-                     iteration_index,
+                     gtopt::uid_of(iteration_index),
                      uid_of(scene_index),
                      uid_of(src_phase_index)),
-            src_li.get_status());
+            src_li.get_status(),
+            dt_resolve);
       }
     }
 
@@ -202,7 +203,7 @@ auto SDDPMethod::install_aperture_backward_cut(
       dt_store += elapsed_s(t_store);
       SPDLOG_TRACE("{}: cut for phase {} rhs={:.4f}",
                    sddp_log("Aperture",
-                            iteration_index,
+                            gtopt::uid_of(iteration_index),
                             uid_of(scene_index),
                             uid_of(phase_index)),
                    src_phase_index,
@@ -263,8 +264,10 @@ auto SDDPMethod::install_aperture_backward_cut(
     auto& tgt_sys = planning_lp().system(scene_index, phase_index);
     tgt_sys.ensure_lp_built();
     auto& tgt_li = tgt_sys.linear_interface();
-    tgt_li.set_log_tag(sddp_log(
-        "Backward", iteration_index, uid_of(scene_index), uid_of(phase_index)));
+    tgt_li.set_log_tag(sddp_log("Backward",
+                                gtopt::uid_of(iteration_index),
+                                uid_of(scene_index),
+                                uid_of(phase_index)));
     const auto t_tgt_resolve = Clock::now();
     auto r = tgt_li.resolve(opts);
     dt_resolve += elapsed_s(t_tgt_resolve);
@@ -281,7 +284,7 @@ auto SDDPMethod::install_aperture_backward_cut(
           "{}: backward_resolve_target re-solve non-optimal "
           "(status {}) — using forward-cached cut data for bcut",
           sddp_log("Backward",
-                   iteration_index,
+                   gtopt::uid_of(iteration_index),
                    uid_of(scene_index),
                    uid_of(phase_index)),
           tgt_li.get_status());
@@ -319,7 +322,7 @@ auto SDDPMethod::install_aperture_backward_cut(
 
   SPDLOG_TRACE("{}: bcut for phase {} rhs={:.4f}",
                sddp_log("Aperture",
-                        iteration_index,
+                        gtopt::uid_of(iteration_index),
                         uid_of(scene_index),
                         uid_of(phase_index)),
                src_phase_index,
@@ -583,7 +586,8 @@ auto SDDPMethod::backward_pass_with_apertures_single_phase(
       all_scenarios,
       m_options_.apertures,
       owned,
-      sddp_log("Aperture", iteration_index, uid_of(scene_index)));
+      sddp_log(
+          "Aperture", gtopt::uid_of(iteration_index), uid_of(scene_index)));
   if (!effective.has_value()) {
     return backward_pass_single_phase(
         scene_index, phase_index, cut_offset, opts, iteration_index);
@@ -616,7 +620,8 @@ auto SDDPMethod::backward_pass_with_apertures(SceneIndex scene_index,
       all_scenarios,
       m_options_.apertures,
       owned,
-      sddp_log("Aperture", iteration_index, uid_of(scene_index)));
+      sddp_log(
+          "Aperture", gtopt::uid_of(iteration_index), uid_of(scene_index)));
   if (!effective.has_value()) {
     return backward_pass(scene_index, opts, iteration_index);
   }
@@ -629,10 +634,11 @@ auto SDDPMethod::backward_pass_with_apertures(SceneIndex scene_index,
   int total_cuts = 0;
   [[maybe_unused]] const auto bwd_tid = std::this_thread::get_id();
 
-  SPDLOG_INFO("{}: backward starting ({} phases) [thread {}]",
-              sddp_log("Aperture", iteration_index, uid_of(scene_index)),
-              num_phases - 1,
-              std::hash<std::thread::id> {}(bwd_tid) % 10000);
+  SPDLOG_INFO(
+      "{}: backward starting ({} phases) [thread {}]",
+      sddp_log("Aperture", gtopt::uid_of(iteration_index), uid_of(scene_index)),
+      num_phases - 1,
+      std::hash<std::thread::id> {}(bwd_tid) % 10000);
 
   const auto& scene_lp = simulation.scenes()[scene_index];
   const auto& scene_scenarios = scene_lp.scenarios();
@@ -649,10 +655,11 @@ auto SDDPMethod::backward_pass_with_apertures(SceneIndex scene_index,
     if (should_stop()) {
       return std::unexpected(Error {
           .code = ErrorCode::SolverError,
-          .message = std::format(
-              "{}: cancelled at phase {}",
-              sddp_log("Aperture", iteration_index, uid_of(scene_index)),
-              uid_of(phase_index)),
+          .message = std::format("{}: cancelled at phase {}",
+                                 sddp_log("Aperture",
+                                          gtopt::uid_of(iteration_index),
+                                          uid_of(scene_index)),
+                                 uid_of(phase_index)),
       });
     }
 
@@ -781,7 +788,8 @@ auto SDDPMethod::backward_pass_with_apertures(SceneIndex scene_index,
     SPDLOG_WARN(
         "{}: all apertures infeasible at {} phase(s) [{}], "
         "used Benders fallback cuts",
-        sddp_log("Aperture", iteration_index, uid_of(scene_index)),
+        sddp_log(
+            "Aperture", gtopt::uid_of(iteration_index), uid_of(scene_index)),
         infeasible_phases.size(),
         join_values(infeasible_phases));
   }

--- a/source/sddp_forward_pass.cpp
+++ b/source/sddp_forward_pass.cpp
@@ -93,12 +93,14 @@ auto SDDPMethod::forward_pass(SceneIndex scene_index,
           uid_of(cur_phase));
       return std::unexpected(Error {
           .code = ErrorCode::SolverError,
-          .message = std::format(
-              "{}: forward pass exceeded forward_max_attempts={} "
-              "(last phase p{})",
-              sddp_log("Forward", iteration_index, uid_of(scene_index)),
-              max_attempts,
-              uid_of(cur_phase)),
+          .message =
+              std::format("{}: forward pass exceeded forward_max_attempts={} "
+                          "(last phase p{})",
+                          sddp_log("Forward",
+                                   gtopt::uid_of(iteration_index),
+                                   uid_of(scene_index)),
+                          max_attempts,
+                          uid_of(cur_phase)),
       });
     }
 
@@ -108,7 +110,7 @@ auto SDDPMethod::forward_pass(SceneIndex scene_index,
           .code = ErrorCode::SolverError,
           .message = std::format("{}: cancelled",
                                  sddp_log("Forward",
-                                          iteration_index,
+                                          gtopt::uid_of(iteration_index),
                                           uid_of(scene_index),
                                           uid_of(phase_index))),
       });
@@ -209,8 +211,10 @@ auto SDDPMethod::forward_pass(SceneIndex scene_index,
     // Tag the LP with the SDDP Forward key so fallback warnings emitted
     // by LinearInterface::resolve() carry the same context as the
     // surrounding SDDP info logs.
-    li.set_log_tag(sddp_log(
-        "Forward", iteration_index, uid_of(scene_index), uid_of(phase_index)));
+    li.set_log_tag(sddp_log("Forward",
+                            gtopt::uid_of(iteration_index),
+                            uid_of(scene_index),
+                            uid_of(phase_index)));
 
     // Solve directly — already running in a pool thread.
     auto result = li.resolve(effective_opts);
@@ -233,7 +237,7 @@ auto SDDPMethod::forward_pass(SceneIndex scene_index,
             .code = ErrorCode::SolverError,
             .message = std::format("{}: solve timeout ({:.1f}s) (status {})",
                                    sddp_log("Forward",
-                                            iteration_index,
+                                            gtopt::uid_of(iteration_index),
                                             uid_of(scene_index),
                                             uid_of(phase_index)),
                                    m_options_.solve_timeout,
@@ -561,7 +565,7 @@ auto SDDPMethod::forward_pass(SceneIndex scene_index,
                     std::format("{}: fail-stop after elastic fcut on p{} "
                                 "(infeas_count={})",
                                 sddp_log("Forward",
-                                         iteration_index,
+                                         gtopt::uid_of(iteration_index),
                                          uid_of(scene_index),
                                          uid_of(phase_index)),
                                 uid_of(prev_phase_index),
@@ -701,7 +705,7 @@ auto SDDPMethod::forward_pass(SceneIndex scene_index,
             .message = std::format("{}: elastic filter produced no "
                                    "feasibility cut (status {})",
                                    sddp_log("Forward",
-                                            iteration_index,
+                                            gtopt::uid_of(iteration_index),
                                             uid_of(scene_index),
                                             uid_of(phase_index)),
                                    solve_status),
@@ -790,7 +794,7 @@ auto SDDPMethod::forward_pass(SceneIndex scene_index,
             .code = ErrorCode::SolverError,
             .message = std::format("{}: optimal status but NaN in solution",
                                    sddp_log("Forward",
-                                            iteration_index,
+                                            gtopt::uid_of(iteration_index),
                                             uid_of(scene_index),
                                             uid_of(phase_index))),
         });
@@ -850,9 +854,10 @@ auto SDDPMethod::forward_pass(SceneIndex scene_index,
         uid_of(scene_index));
     return std::unexpected(Error {
         .code = ErrorCode::SolverError,
-        .message = std::format(
-            "{}: forward pass total cost is NaN",
-            sddp_log("Forward", iteration_index, uid_of(scene_index))),
+        .message = std::format("{}: forward pass total cost is NaN",
+                               sddp_log("Forward",
+                                        gtopt::uid_of(iteration_index),
+                                        uid_of(scene_index))),
     });
   }
 

--- a/source/sddp_forward_pass.cpp
+++ b/source/sddp_forward_pass.cpp
@@ -805,12 +805,13 @@ auto SDDPMethod::forward_pass(SceneIndex scene_index,
       // Compact format (`opex=12.3M`) keeps the line short enough for
       // a wide terminal even with N=16 scenes posting concurrently.
       // The aggregate scene-end "opex=…" line still emits below.
-      const auto num_phases = phases.size();
-      spdlog::info("SDDP Forward [i{} s{} p{}/{}]: opex={} (obj={}, α={})",
-                   gtopt::uid_of(iteration_index),
-                   uid_of(scene_index),
-                   uid_of(phase_index),
-                   num_phases,
+      // Routes through `sddp_log()` so the key matches the backward /
+      // aperture / forward-elastic call sites — `[iN sM pK]`, no `/T`.
+      spdlog::info("{}: opex={} (obj={}, α={})",
+                   sddp_log("Forward",
+                            gtopt::uid_of(iteration_index),
+                            uid_of(scene_index),
+                            uid_of(phase_index)),
                    format_si(state.forward_objective),
                    format_si(obj_physical),
                    format_si(alpha_val));

--- a/source/sddp_iteration.cpp
+++ b/source/sddp_iteration.cpp
@@ -796,8 +796,8 @@ auto SDDPMethod::solve(const SolverOptions& lp_opts)
         : next(results.back().iteration_index);
     const auto final_start = std::chrono::steady_clock::now();
 
-    SPDLOG_INFO("SDDP Sim [i{}]: === simulation pass ===",
-                final_iteration_index);
+    SPDLOG_INFO("{}: === simulation pass ===",
+                sddp_log("Sim", gtopt::uid_of(final_iteration_index)));
 
     // Suppress stop checks so the simulation pass always completes.
     // The stop was already honoured by exiting the iteration loop.
@@ -847,11 +847,10 @@ auto SDDPMethod::solve(const SolverOptions& lp_opts)
     std::expected<ForwardPassOutcome, Error> fwd;
     int p1_attempts = 0;
     for (; p1_attempts <= kMaxSimP1Retries; ++p1_attempts) {
-      SPDLOG_INFO(
-          "SDDP Sim [i{}]: Pass 1 attempt {}/{} — solve + populate cache",
-          final_iteration_index,
-          p1_attempts + 1,
-          kMaxSimP1Retries + 1);
+      SPDLOG_INFO("{}: Pass 1 attempt {}/{} — solve + populate cache",
+                  sddp_log("Sim", gtopt::uid_of(final_iteration_index)),
+                  p1_attempts + 1,
+                  kMaxSimP1Retries + 1);
       fwd = run_forward_pass_all_scenes(
           *sddp_pool, sim_opts, final_iteration_index);
       if (!fwd.has_value()) {
@@ -876,17 +875,17 @@ auto SDDPMethod::solve(const SolverOptions& lp_opts)
         const auto n_infeas =
             std::ranges::count(fwd->scene_feasible, uint8_t {0});
         SPDLOG_INFO(
-            "SDDP Sim [i{}]: no new fcuts after attempt {} — "
+            "{}: no new fcuts after attempt {} — "
             "{} infeasible scene(s) are terminal (status=-1 in output)",
-            final_iteration_index,
+            sddp_log("Sim", gtopt::uid_of(final_iteration_index)),
             p1_attempts + 1,
             n_infeas);
         break;
       }
     }
 
-    SPDLOG_INFO("SDDP Sim [i{}]: Pass 1 done after {} attempt(s)",
-                final_iteration_index,
+    SPDLOG_INFO("{}: Pass 1 done after {} attempt(s)",
+                sddp_log("Sim", gtopt::uid_of(final_iteration_index)),
                 p1_attempts + 1);
 
     // Aggressive post-Pass-1 memory release under low_memory: the
@@ -909,9 +908,9 @@ auto SDDPMethod::solve(const SolverOptions& lp_opts)
     if (fwd->has_feasibility_issue) {
       ir.feasibility_issue = true;
       SPDLOG_WARN(
-          "SDDP Sim [i{}]: residual feasibility issue — affected cells "
+          "{}: residual feasibility issue — affected cells "
           "left unsolved in output",
-          final_iteration_index);
+          sddp_log("Sim", gtopt::uid_of(final_iteration_index)));
 
       // Mark every (scene, phase) cell of an infeasible scene as
       // output_skipped so PlanningLP::write_out bypasses the
@@ -939,9 +938,9 @@ auto SDDPMethod::solve(const SolverOptions& lp_opts)
       }
       if (n_cells_skipped > 0) {
         SPDLOG_INFO(
-            "SDDP Sim [i{}]: {} cell(s) marked output_skipped "
+            "{}: {} cell(s) marked output_skipped "
             "(infeasible scenes will not be written out)",
-            final_iteration_index,
+            sddp_log("Sim", gtopt::uid_of(final_iteration_index)),
             n_cells_skipped);
       }
     }
@@ -974,9 +973,9 @@ auto SDDPMethod::solve(const SolverOptions& lp_opts)
           ? std::format(" feasible={}/{}", sim_feasible, sim_total)
           : std::string {};
       SPDLOG_INFO(
-          "SDDP Sim [i{}]: done in {:.3f}s — "
+          "{}: done in {:.3f}s — "
           "UB={} LB={} gap={:.2f}% Δgap={:.2f}%{}{}",
-          final_iteration_index,
+          sddp_log("Sim", gtopt::uid_of(final_iteration_index)),
           ir.iteration_s,
           format_si(ir.upper_bound),
           format_si(ir.lower_bound),
@@ -1164,11 +1163,9 @@ auto SDDPMethod::solve_async(SDDPWorkPool& pool,
       if (scene_gap < m_options_.convergence_tol && past_min) {
         tracker.mark_converged(scene_index, iteration_index);
         SPDLOG_INFO(
-            "SDDP Async [i{} s{}]: scene {} converged at iter {} (gap={:.6f})",
-            gtopt::uid_of(iteration_index),
-            uid_of(scene_index),
-            uid_of(scene_index),
-            gtopt::uid_of(iteration_index),
+            "{}: converged (gap={:.6f})",
+            sddp_log(
+                "Async", gtopt::uid_of(iteration_index), uid_of(scene_index)),
             scene_gap);
         return true;
       }
@@ -1187,10 +1184,10 @@ auto SDDPMethod::solve_async(SDDPWorkPool& pool,
       [&](SceneIndex scene_index,
           IterationIndex sim_iteration_index) -> std::expected<double, Error>
   {
-    SPDLOG_INFO("SDDP Sim [i{} s{}]: simulation pass for scene {}",
-                sim_iteration_index,
-                uid_of(scene_index),
-                uid_of(scene_index));
+    SPDLOG_INFO(
+        "{}: simulation pass",
+        sddp_log(
+            "Sim", gtopt::uid_of(sim_iteration_index), uid_of(scene_index)));
     auto result = forward_pass(scene_index, sim_opts, sim_iteration_index);
     if (!result.has_value()) {
       return result;
@@ -1201,10 +1198,10 @@ auto SDDPMethod::solve_async(SDDPWorkPool& pool,
       planning_lp().system(scene_index, phase_index).write_out();
     }
 
-    SPDLOG_INFO("SDDP Sim [i{} s{}]: scene {} outputs written",
-                sim_iteration_index,
-                uid_of(scene_index),
-                uid_of(scene_index));
+    SPDLOG_INFO(
+        "{}: outputs written",
+        sddp_log(
+            "Sim", gtopt::uid_of(sim_iteration_index), uid_of(scene_index)));
     return result;
   };
 
@@ -1392,14 +1389,13 @@ auto SDDPMethod::solve_async(SDDPWorkPool& pool,
           {
             const double scene_gap =
                 compute_convergence_gap(sp.upper_bound, sp.lower_bound);
-            SPDLOG_INFO(
-                "SDDP Async [i{} s{}]: completed (ub={:.4f} lb={:.4f}"
-                " gap={:.6f})",
-                sp.current_iteration_index,
-                uid_of(scene),
-                sp.upper_bound,
-                sp.lower_bound,
-                scene_gap);
+            SPDLOG_INFO("{}: completed (ub={:.4f} lb={:.4f} gap={:.6f})",
+                        sddp_log("Async",
+                                 gtopt::uid_of(sp.current_iteration_index),
+                                 uid_of(scene)),
+                        sp.upper_bound,
+                        sp.lower_bound,
+                        scene_gap);
           }
 
           // Per-scene convergence check
@@ -1427,9 +1423,10 @@ auto SDDPMethod::solve_async(SDDPWorkPool& pool,
           }
           auto sim = sp.fwd_future.get();
           if (!sim.has_value()) {
-            SPDLOG_WARN("SDDP Sim [i{} s{}]: simulation failed: {}",
-                        sp.current_iteration_index,
-                        uid_of(scene),
+            SPDLOG_WARN("{}: simulation failed: {}",
+                        sddp_log("Sim",
+                                 gtopt::uid_of(sp.current_iteration_index),
+                                 uid_of(scene)),
                         sim.error().message);
           } else {
             sp.upper_bound = *sim;
@@ -1444,10 +1441,11 @@ auto SDDPMethod::solve_async(SDDPWorkPool& pool,
               }
             }
             SPDLOG_INFO(
-                "SDDP Async [i{} s{}]: scene done — converged={} iters={}"
-                " sim_ub={:.4f} active={}/{}",
-                sp.current_iteration_index,
-                uid_of(scene),
+                "{}: scene done — converged={} iters={} sim_ub={:.4f}"
+                " active={}/{}",
+                sddp_log("Async",
+                         gtopt::uid_of(sp.current_iteration_index),
+                         uid_of(scene)),
                 sp.scene_converged,
                 iteration_relative(sp.current_iteration_index,
                                    m_iteration_offset_),

--- a/source/sddp_method.cpp
+++ b/source/sddp_method.cpp
@@ -450,14 +450,36 @@ auto SDDPMethod::initialize_solver() -> std::expected<void, Error>
   std::size_t named_count = 0;
   bool state_loaded = false;
 
+  // Resolve relative SDDP file paths against `input_directory` (mirrors the
+  // aperture-directory resolution at sddp_method.cpp:179-186).  Without
+  // this, gtopt invoked from a cwd other than the case dir silently skips
+  // boundary / named / hot-start cut files even when the JSON wires them
+  // up correctly — observed on `support/juan/gtopt_iplp_plain` as
+  // `boundary=none` in the HotStart summary and α=0 throughout the last
+  // phase.  Absolute paths pass through unchanged.
+  const auto resolve_input = [&](const std::string& path) -> std::string
+  {
+    if (path.empty()) {
+      return path;
+    }
+    std::filesystem::path p {path};
+    if (p.is_absolute()) {
+      return path;
+    }
+    return (std::filesystem::path {planning_lp().options().input_directory()}
+            / p)
+        .string();
+  };
+
   if (m_options_.recovery_mode >= RecoveryMode::cuts) {
     if (!m_options_.cuts_input_file.empty()) {
-      auto result = load_cuts(m_options_.cuts_input_file);
+      const auto cuts_path = resolve_input(m_options_.cuts_input_file);
+      auto result = load_cuts(cuts_path);
       if (result.has_value()) {
         // load_cuts() already updated m_iteration_offset_ via next() so
         // the first new iteration is strictly past result->max_iteration.
         cuts_count = result->count;
-        cuts_source = m_options_.cuts_input_file;
+        cuts_source = cuts_path;
         SPDLOG_DEBUG("SDDP hot-start: loaded {} cuts (max_iter={})",
                      result->count,
                      result->max_iteration);
@@ -503,37 +525,50 @@ auto SDDPMethod::initialize_solver() -> std::expected<void, Error>
   // PLP's "planos de embalse"), NOT recovery state.  They do NOT
   // affect the iteration offset — the solver always starts from
   // iteration 0 (or from the recovery offset if recovery cuts exist).
-  // Missing file = cold-start (silent); parse error = WARN.
-  if (!m_options_.boundary_cuts_file.empty()
-      && std::filesystem::exists(m_options_.boundary_cuts_file))
-  {
-    auto result = load_boundary_cuts(m_options_.boundary_cuts_file);
-    if (result.has_value()) {
-      boundary_count = result->count;
-      SPDLOG_DEBUG("SDDP: loaded {} boundary cuts from {}",
-                   result->count,
-                   m_options_.boundary_cuts_file);
+  // Missing file with a non-empty config path = WARN (silent skip used
+  // to mask common "cwd ≠ case dir" mistakes).
+  if (!m_options_.boundary_cuts_file.empty()) {
+    const auto bc_path = resolve_input(m_options_.boundary_cuts_file);
+    if (std::filesystem::exists(bc_path)) {
+      auto result = load_boundary_cuts(bc_path);
+      if (result.has_value()) {
+        boundary_count = result->count;
+        SPDLOG_DEBUG(
+            "SDDP: loaded {} boundary cuts from {}", result->count, bc_path);
+      } else {
+        SPDLOG_WARN("SDDP: could not load boundary cuts: {}",
+                    result.error().message);
+      }
     } else {
-      SPDLOG_WARN("SDDP: could not load boundary cuts: {}",
-                  result.error().message);
+      SPDLOG_WARN(
+          "SDDP: boundary_cuts_file '{}' not found (resolved to '{}') — "
+          "α at the last phase will stay pinned at 0",
+          m_options_.boundary_cuts_file,
+          bc_path);
     }
   }
 
   // ── Load named cuts (all phases, named state variables) ────────────────
   // Named cuts are also part of the problem specification — always load,
   // but do NOT affect the iteration offset.
-  if (!m_options_.named_cuts_file.empty()
-      && std::filesystem::exists(m_options_.named_cuts_file))
-  {
-    auto result = load_named_cuts(m_options_.named_cuts_file);
-    if (result.has_value()) {
-      named_count = result->count;
-      SPDLOG_DEBUG("SDDP: loaded {} named cuts from {}",
-                   result->count,
-                   m_options_.named_cuts_file);
+  if (!m_options_.named_cuts_file.empty()) {
+    const auto nc_path = resolve_input(m_options_.named_cuts_file);
+    if (std::filesystem::exists(nc_path)) {
+      auto result = load_named_cuts(nc_path);
+      if (result.has_value()) {
+        named_count = result->count;
+        SPDLOG_DEBUG(
+            "SDDP: loaded {} named cuts from {}", result->count, nc_path);
+      } else {
+        SPDLOG_WARN("SDDP: could not load named cuts: {}",
+                    result.error().message);
+      }
     } else {
-      SPDLOG_WARN("SDDP: could not load named cuts: {}",
-                  result.error().message);
+      SPDLOG_WARN(
+          "SDDP: named_cuts_file '{}' not found (resolved to '{}') — "
+          "no named hot-start cuts will be installed",
+          m_options_.named_cuts_file,
+          nc_path);
     }
   }
 

--- a/source/sddp_method_iteration.cpp
+++ b/source/sddp_method_iteration.cpp
@@ -119,8 +119,10 @@ void SDDPMethod::diagnose_kappa(SceneIndex scene_index,
                                 const LinearInterface& li,
                                 IterationIndex iteration_index)
 {
-  const auto prefix = sddp_log(
-      "Kappa", iteration_index, uid_of(scene_index), uid_of(phase_index));
+  const auto prefix = sddp_log("Kappa",
+                               gtopt::uid_of(iteration_index),
+                               uid_of(scene_index),
+                               uid_of(phase_index));
 
   // Collect cut rows for this (scene, phase) from the cut store
   const auto& scene_cuts = m_cut_store_.scene_cuts();
@@ -440,8 +442,10 @@ auto SDDPMethod::backward_pass_single_phase(SceneIndex scene_index,
     // (same coefficient re-written), so this is a no-op cost.
     update_lp_for_phase(scene_index, phase_index);
 
-    tgt_li.set_log_tag(sddp_log(
-        "Backward", iteration_index, uid_of(scene_index), uid_of(phase_index)));
+    tgt_li.set_log_tag(sddp_log("Backward",
+                                gtopt::uid_of(iteration_index),
+                                uid_of(scene_index),
+                                uid_of(phase_index)));
     const auto z_old = phase_states[phase_index].forward_full_obj_physical;
 
     // Optional LP dump for off↔compress diff debugging.  Activated by
@@ -515,7 +519,7 @@ auto SDDPMethod::backward_pass_single_phase(SceneIndex scene_index,
           "{}: backward_resolve_target re-solve non-optimal "
           "(status {}) — falling back to forward-cached cut data",
           sddp_log("Backward",
-                   iteration_index,
+                   gtopt::uid_of(iteration_index),
                    uid_of(scene_index),
                    uid_of(phase_index)),
           tgt_li.get_status());
@@ -693,7 +697,7 @@ auto SDDPMethod::backward_pass_single_phase(SceneIndex scene_index,
   double dt_kappa = 0.0;
   if (phase_index) {
     src_li.set_log_tag(sddp_log("Backward",
-                                iteration_index,
+                                gtopt::uid_of(iteration_index),
                                 uid_of(scene_index),
                                 uid_of(prev_phase_index)));
     const auto t_resolve = Clock::now();
@@ -708,7 +712,7 @@ auto SDDPMethod::backward_pass_single_phase(SceneIndex scene_index,
           "{}: post-cut resolve non-optimal (status {}) — keeping "
           "cut, next forward pass will re-solve",
           sddp_log("Backward",
-                   iteration_index,
+                   gtopt::uid_of(iteration_index),
                    uid_of(scene_index),
                    uid_of(prev_phase_index)),
           src_li.get_status());
@@ -759,7 +763,7 @@ auto SDDPMethod::backward_pass(SceneIndex scene_index,
           .code = ErrorCode::SolverError,
           .message = std::format("{}: cancelled",
                                  sddp_log("Backward",
-                                          iteration_index,
+                                          gtopt::uid_of(iteration_index),
                                           uid_of(scene_index),
                                           uid_of(phase_index))),
       });

--- a/source/validate_planning.cpp
+++ b/source/validate_planning.cpp
@@ -460,16 +460,6 @@ template<typename OptField>
       *field);
 }
 
-[[nodiscard]] std::optional<Real> try_scalar_emin(const Reservoir& res)
-{
-  return try_scalar_value(res.emin);
-}
-
-[[nodiscard]] std::optional<Real> try_scalar_emax(const Reservoir& res)
-{
-  return try_scalar_value(res.emax);
-}
-
 // Look up a reservoir struct by SingleId (Uid or Name).
 [[nodiscard]] const Reservoir* find_reservoir(
     const std::vector<Reservoir>& reservoirs, const SingleId& sid)
@@ -558,13 +548,321 @@ struct LinearRange
                                           Real constant,
                                           const SegmentRange& r)
 {
-  return {.f_low = constant + slope * r.v_low,
-          .f_high = constant + slope * r.v_high};
+  return {
+      .f_low = constant + (slope * r.v_low),
+      .f_high = constant + (slope * r.v_high),
+  };
 }
+
+/// Extract one Real per stage from a 1D `OptTRealFieldSched`-shaped
+/// field.  Scalar broadcasts to every stage; vector indexes by stage
+/// (truncated/padded to `num_stages` with `default_value`); file-
+/// schedule returns `nullopt` (truly deferred to load-time).
+template<typename OptField>
+[[nodiscard]] std::optional<std::vector<Real>> per_stage_values(
+    const OptField& field, std::size_t num_stages, Real default_value)
+{
+  if (!field.has_value()) {
+    return std::vector<Real>(num_stages, default_value);
+  }
+  return std::visit(
+      [&](const auto& v) -> std::optional<std::vector<Real>>
+      {
+        using T = std::remove_cvref_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, Real>) {
+          return std::vector<Real>(num_stages, v);
+        } else if constexpr (std::is_same_v<T, std::vector<Real>>) {
+          std::vector<Real> out(num_stages, default_value);
+          for (std::size_t s = 0; s < num_stages && s < v.size(); ++s) {
+            out[s] = v[s];
+          }
+          return out;
+        } else {
+          // FileSched (string) — truly deferred.
+          return std::nullopt;
+        }
+      },
+      *field);
+}
+
+/// 2D variant for `OptTBRealFieldSched` (per-stage, per-block).
+/// Reduces each stage's block vector to a single scalar via
+/// `reducer` (use `std::ranges::min` for upper-bound fields where the
+/// strictest stage-level value is the smallest, `std::ranges::max`
+/// for lower-bound fields where the strictest is the largest).
+template<typename OptField, typename Reducer>
+[[nodiscard]] std::optional<std::vector<Real>> per_stage_values_2d(
+    const OptField& field,
+    std::size_t num_stages,
+    Real default_value,
+    Reducer reducer)
+{
+  if (!field.has_value()) {
+    return std::vector<Real>(num_stages, default_value);
+  }
+  return std::visit(
+      [&](const auto& v) -> std::optional<std::vector<Real>>
+      {
+        using T = std::remove_cvref_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, Real>) {
+          return std::vector<Real>(num_stages, v);
+        } else if constexpr (std::is_same_v<T,
+                                            std::vector<std::vector<Real>>>) {
+          std::vector<Real> out(num_stages, default_value);
+          for (std::size_t s = 0; s < num_stages && s < v.size(); ++s) {
+            if (!v[s].empty()) {
+              out[s] = reducer(v[s]);
+            }
+          }
+          return out;
+        } else {
+          return std::nullopt;
+        }
+      },
+      *field);
+}
+
+/// Per-stage scan summary for one piecewise segment in one direction
+/// (below the lower bound or above the upper bound).  Aggregated
+/// across all stages so the validator emits exactly ONE warning per
+/// (element, segment, direction) instead of one per stage.
+struct StageViolation
+{
+  std::size_t count {0};  ///< Number of stages where the bound is violated.
+  Real worst_diff {0.0};  ///< Largest |bound − f| across the failing stages.
+  std::size_t worst_stage {0};  ///< Stage index achieving `worst_diff`.
+  LinearRange worst_fr {};  ///< Linear range at the worst stage.
+  SegmentRange worst_range {};  ///< Active [V_low, V_high] at the worst stage.
+  Real worst_bound {0.0};  ///< Bound value at the worst stage.
+};
+
+/// Walk every stage and accumulate the worst lower-bound violation
+/// (`fr.fmin() < lower_bounds[s]`) and worst upper-bound violation
+/// (`fr.fmax() > upper_bounds[s]`) for the given segment.  Returns a
+/// pair `{below, above}`; either may have `count == 0` for "no
+/// violation in that direction".
+template<typename Segment>
+[[nodiscard]] std::pair<StageViolation, StageViolation> scan_segment_per_stage(
+    const std::vector<Segment>& segments,
+    std::size_t k,
+    Real slope,
+    Real constant,
+    std::span<const Real> emins,
+    std::span<const Real> emaxs,
+    std::span<const Real> lower_bounds,
+    std::span<const Real> upper_bounds)
+{
+  StageViolation below;
+  StageViolation above;
+  const std::size_t num_stages = emins.size();
+  for (std::size_t s = 0; s < num_stages; ++s) {
+    const auto range = segment_range(segments, k, emins[s], emaxs[s]);
+    if (range.v_high < range.v_low) {
+      continue;  // segment outside this stage's [emin, emax] envelope
+    }
+    const auto fr = evaluate_linear(slope, constant, range);
+
+    if (fr.fmin() < lower_bounds[s]) {
+      ++below.count;
+      const Real diff = lower_bounds[s] - fr.fmin();
+      if (diff > below.worst_diff) {
+        below.worst_diff = diff;
+        below.worst_stage = s;
+        below.worst_fr = fr;
+        below.worst_range = range;
+        below.worst_bound = lower_bounds[s];
+      }
+    }
+    if (fr.fmax() > upper_bounds[s]) {
+      ++above.count;
+      const Real diff = fr.fmax() - upper_bounds[s];
+      if (diff > above.worst_diff) {
+        above.worst_diff = diff;
+        above.worst_stage = s;
+        above.worst_fr = fr;
+        above.worst_range = range;
+        above.worst_bound = upper_bounds[s];
+      }
+    }
+  }
+  return {below, above};
+}
+
+/// Per-stage seepage envelopes.  Returns `nullopt` for any field that
+/// is file-schedule (truly deferred to load-time validation).
+struct SeepageEnvelopes
+{
+  std::vector<Real> emins;  ///< Reservoir per-stage emin.
+  std::vector<Real> emaxs;  ///< Reservoir per-stage emax.
+  std::vector<Real>
+      fmins;  ///< Strictest per-stage waterway floor (max-reduced).
+  std::vector<Real>
+      fmaxs;  ///< Strictest per-stage waterway ceiling (min-reduced).
+};
+
+[[nodiscard]] std::optional<SeepageEnvelopes> resolve_seepage_envelopes(
+    const Reservoir& res, const Waterway& ww, std::size_t num_stages)
+{
+  using std::ranges::max;
+  using std::ranges::min;
+
+  auto emins = per_stage_values(res.emin, num_stages, 0.0);
+  auto emaxs = per_stage_values(
+      res.emax, num_stages, std::numeric_limits<Real>::infinity());
+  // Reduce per-stage block vectors to the strictest stage-level
+  // value: max(fmin) (highest required floor), min(fmax) (lowest
+  // allowed ceiling).
+  auto fmins =
+      per_stage_values_2d(ww.fmin,
+                          num_stages,
+                          0.0,
+                          [](const std::vector<Real>& v) { return max(v); });
+  auto fmaxs =
+      per_stage_values_2d(ww.fmax,
+                          num_stages,
+                          std::numeric_limits<Real>::infinity(),
+                          [](const std::vector<Real>& v) { return min(v); });
+  if (!emins.has_value() || !emaxs.has_value() || !fmins.has_value()
+      || !fmaxs.has_value())
+  {
+    return std::nullopt;
+  }
+  return SeepageEnvelopes {
+      .emins = std::move(*emins),
+      .emaxs = std::move(*emaxs),
+      .fmins = std::move(*fmins),
+      .fmaxs = std::move(*fmaxs),
+  };
+}
+
+/// Per-stage discharge-limit envelopes (only the reservoir
+/// [emin, emax] matter; the LP constrains the discharge col bound to
+/// `intercept + slope·V ≥ 0`).
+struct DischargeLimitEnvelopes
+{
+  std::vector<Real> emins;
+  std::vector<Real> emaxs;
+};
+
+[[nodiscard]] std::optional<DischargeLimitEnvelopes>
+resolve_discharge_limit_envelopes(const Reservoir& res, std::size_t num_stages)
+{
+  auto emins = per_stage_values(res.emin, num_stages, 0.0);
+  auto emaxs = per_stage_values(
+      res.emax, num_stages, std::numeric_limits<Real>::infinity());
+  if (!emins.has_value() || !emaxs.has_value()) {
+    return std::nullopt;
+  }
+  return DischargeLimitEnvelopes {
+      .emins = std::move(*emins),
+      .emaxs = std::move(*emaxs),
+  };
+}
+
+/// Format the standard "below fmin" warning for a seepage segment.
+[[nodiscard]] std::string format_seepage_below_warning(
+    const ReservoirSeepage& seep,
+    const Reservoir& res,
+    const Waterway& ww,
+    std::size_t k,
+    std::size_t num_stages,
+    const StageViolation& v)
+{
+  return std::format(
+      "ReservoirSeepage '{}' (reservoir '{}', waterway '{}'): "
+      "segment {} produces qfilt below waterway fmin in {} of {} "
+      "stages (worst at stage {}: {:.3g} ≤ efin ≤ {:.3g} → qfilt "
+      "range [{:.6g}, {:.6g}] vs fmin={:.6g}, slope={:.6g}, "
+      "constant={:.6g}); the LP will go primal-infeasible whenever "
+      "efin lands in the segment's lower portion.  Adjust the "
+      "segment data so that `constant + slope * V ≥ fmin` for all "
+      "V in [V_low, V_high].",
+      seep.name,
+      res.name,
+      ww.name,
+      k,
+      v.count,
+      num_stages,
+      v.worst_stage,
+      v.worst_range.v_low,
+      v.worst_range.v_high,
+      v.worst_fr.fmin(),
+      v.worst_fr.fmax(),
+      v.worst_bound,
+      seep.segments[k].slope,
+      seep.segments[k].constant);
+}
+
+/// Format the standard "above fmax" warning for a seepage segment.
+[[nodiscard]] std::string format_seepage_above_warning(
+    const ReservoirSeepage& seep,
+    const Reservoir& res,
+    const Waterway& ww,
+    std::size_t k,
+    std::size_t num_stages,
+    const StageViolation& v)
+{
+  return std::format(
+      "ReservoirSeepage '{}' (reservoir '{}', waterway '{}'): "
+      "segment {} produces qfilt above waterway fmax in {} of {} "
+      "stages (worst at stage {}: {:.3g} ≤ efin ≤ {:.3g} → qfilt "
+      "range [{:.6g}, {:.6g}] vs fmax={:.6g}, slope={:.6g}, "
+      "constant={:.6g}); the LP will go primal-infeasible whenever "
+      "efin lands in the segment's upper portion.",
+      seep.name,
+      res.name,
+      ww.name,
+      k,
+      v.count,
+      num_stages,
+      v.worst_stage,
+      v.worst_range.v_low,
+      v.worst_range.v_high,
+      v.worst_fr.fmin(),
+      v.worst_fr.fmax(),
+      v.worst_bound,
+      seep.segments[k].slope,
+      seep.segments[k].constant);
+}
+
+/// Format the standard "negative discharge bound" warning for a
+/// discharge-limit segment.
+[[nodiscard]] std::string format_discharge_limit_warning(
+    const ReservoirDischargeLimit& ddl,
+    const Reservoir& res,
+    std::size_t k,
+    std::size_t num_stages,
+    const StageViolation& v)
+{
+  return std::format(
+      "ReservoirDischargeLimit '{}' (reservoir '{}'): segment {} "
+      "produces a negative discharge upper bound in {} of {} "
+      "stages (worst at stage {}: {:.3g} ≤ efin ≤ {:.3g} → bound "
+      "range [{:.6g}, {:.6g}], slope={:.6g}, intercept={:.6g}); "
+      "the LP will go primal-infeasible whenever efin lands in "
+      "the segment's lower portion.  Adjust the segment so that "
+      "`intercept + slope * V >= 0` for all V in [V_low, V_high].",
+      ddl.name,
+      res.name,
+      k,
+      v.count,
+      num_stages,
+      v.worst_stage,
+      v.worst_range.v_low,
+      v.worst_range.v_high,
+      v.worst_fr.fmin(),
+      v.worst_fr.fmax(),
+      ddl.segments[k].slope,
+      ddl.segments[k].intercept);
+}
+
 }  // namespace
 
-void check_piecewise_feasibility(ValidationResult& result, const System& sys)
+void check_piecewise_feasibility(ValidationResult& result,
+                                 const Planning& planning)
 {
+  const auto& sys = planning.system;
+  const auto num_stages = planning.simulation.stage_array.size();
   // **ReservoirSeepage** — per-segment range feasibility.
   //
   // The LP constraint per (block, stage) is the equality
@@ -579,14 +877,11 @@ void check_piecewise_feasibility(ValidationResult& result, const System& sys)
   //   fmin  ≤  constant_k + slope_k · efin  ≤  fmax,  ∀ efin ∈ [V_low_k,
   //   V_high_k]
   //
-  // The function is linear in efin, so the min and max over the
-  // range are attained at the endpoints.  Validation walks every
-  // segment and emits a warning whenever
-  //   min(f(V_low), f(V_high)) < fmin     OR
-  //   max(f(V_low), f(V_high)) > fmax
-  // — pointing the user at the offending segment so they can fix
-  // the input data.  Schedule-form `emin/emax/fmin/fmax` are
-  // deferred (skipped here) because they need per-stage resolution.
+  // For schedule-form `emin/emax/fmin/fmax` (vector-per-stage), the
+  // check fires per-stage and is summarised: ONE warning per
+  // (element, segment, direction) listing how many stages fail and
+  // pointing at the worst offender.  File-schedules (string paths)
+  // are still deferred — we don't load them here.
   for (const auto& seep : sys.reservoir_seepage_array) {
     if (seep.segments.empty()) {
       continue;
@@ -595,67 +890,32 @@ void check_piecewise_feasibility(ValidationResult& result, const System& sys)
     if (res == nullptr) {
       continue;  // referential integrity check elsewhere catches missing refs
     }
-    const auto emin_opt = try_scalar_emin(*res);
-    const auto emax_opt = try_scalar_emax(*res);
-    if (!emin_opt.has_value() || !emax_opt.has_value()) {
-      continue;  // schedule form — defer to load-time validation
-    }
     const auto* ww = find_waterway(sys.waterway_array, seep.waterway);
     if (ww == nullptr) {
       continue;
     }
-    const auto fmin_val = try_scalar_value(ww->fmin).value_or(0.0);
-    const auto fmax_val = try_scalar_value(ww->fmax).value_or(
-        std::numeric_limits<Real>::infinity());
+    const auto envs = resolve_seepage_envelopes(*res, *ww, num_stages);
+    if (!envs.has_value()) {
+      continue;  // some field is file-schedule — truly deferred
+    }
 
     for (std::size_t k = 0; k < seep.segments.size(); ++k) {
       const auto& seg = seep.segments[k];
-      const auto range = segment_range(seep.segments, k, *emin_opt, *emax_opt);
-      if (range.v_high < range.v_low) {
-        continue;  // empty range (segment outside [emin, emax])
+      const auto [below, above] = scan_segment_per_stage(seep.segments,
+                                                         k,
+                                                         seg.slope,
+                                                         seg.constant,
+                                                         envs->emins,
+                                                         envs->emaxs,
+                                                         envs->fmins,
+                                                         envs->fmaxs);
+      if (below.count > 0) {
+        result.warnings.push_back(format_seepage_below_warning(
+            seep, *res, *ww, k, num_stages, below));
       }
-      const auto fr = evaluate_linear(seg.slope, seg.constant, range);
-
-      if (fr.fmin() < fmin_val) {
-        result.warnings.push_back(std::format(
-            "ReservoirSeepage '{}' (reservoir '{}', waterway '{}'): "
-            "segment {} ({:.3g} ≤ efin ≤ {:.3g}) produces qfilt below "
-            "waterway fmin (slope={:.6g}, constant={:.6g} → qfilt range "
-            "[{:.6g}, {:.6g}] vs fmin={:.6g}); the LP will go "
-            "primal-infeasible whenever efin lands in the segment's "
-            "lower portion.  Adjust the segment data so that "
-            "`constant + slope * V ≥ fmin` for all V in [V_low, V_high].",
-            seep.name,
-            res->name,
-            ww->name,
-            k,
-            range.v_low,
-            range.v_high,
-            seg.slope,
-            seg.constant,
-            fr.fmin(),
-            fr.fmax(),
-            fmin_val));
-      }
-      if (fr.fmax() > fmax_val) {
-        result.warnings.push_back(std::format(
-            "ReservoirSeepage '{}' (reservoir '{}', waterway '{}'): "
-            "segment {} ({:.3g} ≤ efin ≤ {:.3g}) produces qfilt above "
-            "waterway fmax (slope={:.6g}, constant={:.6g} → qfilt range "
-            "[{:.6g}, {:.6g}] vs fmax={:.6g}); the LP will go "
-            "primal-infeasible whenever efin lands in the segment's "
-            "upper portion.",
-            seep.name,
-            res->name,
-            ww->name,
-            k,
-            range.v_low,
-            range.v_high,
-            seg.slope,
-            seg.constant,
-            fr.fmin(),
-            fr.fmax(),
-            fmax_val));
+      if (above.count > 0) {
+        result.warnings.push_back(format_seepage_above_warning(
+            seep, *res, *ww, k, num_stages, above));
       }
     }
   }
@@ -664,12 +924,18 @@ void check_piecewise_feasibility(ValidationResult& result, const System& sys)
   //
   // The LP row is `qeh − slope_k · efin ≤ intercept_k`, where qeh has
   // lower bound 0 (default for a free non-negative col).  For each
-  // segment k active at efin ∈ [V_low_k, V_high_k]:
+  // segment k active at efin ∈ [V_low_k, V_high_k] at stage s:
   //
   //   0 ≤ intercept_k + slope_k · efin   for all efin in the range.
   //
-  // Linear in efin, so check the minimum over the range at the
-  // endpoints.  Warn when min < 0.
+  // Per-stage scan with the same dedup semantics as the seepage
+  // check above: ONE warning per (DDL, segment) summarising the
+  // count of failing stages plus the worst case.  Only the lower
+  // bound (≥ 0) matters; upper-bound is +∞ so the "above" branch of
+  // `scan_segment_per_stage` never fires.
+  const std::vector<Real> ddl_lower(num_stages, 0.0);
+  const std::vector<Real> ddl_upper(num_stages,
+                                    std::numeric_limits<Real>::infinity());
   for (const auto& ddl : sys.reservoir_discharge_limit_array) {
     if (ddl.segments.empty()) {
       continue;
@@ -678,38 +944,24 @@ void check_piecewise_feasibility(ValidationResult& result, const System& sys)
     if (res == nullptr) {
       continue;
     }
-    const auto emin_opt = try_scalar_emin(*res);
-    const auto emax_opt = try_scalar_emax(*res);
-    if (!emin_opt.has_value() || !emax_opt.has_value()) {
+    const auto envs = resolve_discharge_limit_envelopes(*res, num_stages);
+    if (!envs.has_value()) {
       continue;
     }
 
     for (std::size_t k = 0; k < ddl.segments.size(); ++k) {
       const auto& seg = ddl.segments[k];
-      const auto range = segment_range(ddl.segments, k, *emin_opt, *emax_opt);
-      if (range.v_high < range.v_low) {
-        continue;  // empty range
-      }
-      const auto fr = evaluate_linear(seg.slope, seg.intercept, range);
-
-      if (fr.fmin() < 0.0) {
-        result.warnings.push_back(std::format(
-            "ReservoirDischargeLimit '{}' (reservoir '{}'): segment {} "
-            "({:.3g} ≤ efin ≤ {:.3g}) produces a negative discharge "
-            "upper bound (slope={:.6g}, intercept={:.6g} → bound range "
-            "[{:.6g}, {:.6g}]); the LP will go primal-infeasible "
-            "whenever efin lands in the segment's lower portion.  "
-            "Adjust the segment so that `intercept + slope * V >= 0` "
-            "for all V in [V_low, V_high].",
-            ddl.name,
-            res->name,
-            k,
-            range.v_low,
-            range.v_high,
-            seg.slope,
-            seg.intercept,
-            fr.fmin(),
-            fr.fmax()));
+      const auto [below, _above] = scan_segment_per_stage(ddl.segments,
+                                                          k,
+                                                          seg.slope,
+                                                          seg.intercept,
+                                                          envs->emins,
+                                                          envs->emaxs,
+                                                          ddl_lower,
+                                                          ddl_upper);
+      if (below.count > 0) {
+        result.warnings.push_back(
+            format_discharge_limit_warning(ddl, *res, k, num_stages, below));
       }
     }
   }
@@ -964,7 +1216,7 @@ void check_scenario_probabilities(ValidationResult& result, Planning& planning)
   check_referential_integrity(result, planning.system);
   check_ranges(result, planning);
   check_positivity(result, planning.system);
-  check_piecewise_feasibility(result, planning.system);
+  check_piecewise_feasibility(result, planning);
   check_aperture_references(result, planning);
   check_completeness(result, planning);
   check_scenario_probabilities(result, planning);

--- a/standalone/source/main.cpp
+++ b/standalone/source/main.cpp
@@ -51,6 +51,90 @@ int main(int argc, char** argv)
 
     if (vm.contains("help")) {
       std::cout << desc << '\n';
+      std::cout << R"(Examples
+========
+
+  Run a planning JSON file (default: monolithic, multi-bus, all auto):
+    gtopt case.json
+
+  Run on a directory ('case_dir/case_dir.json' is auto-detected):
+    gtopt case_dir/
+
+  SDDP with the compressed memory mode (releases solver between phases,
+  keeps a compressed flat-LP snapshot for fast reconstruct):
+    gtopt case.json --memory-saving compress
+
+  Same with the in-place rebuild mode (lowest steady-state RAM,
+  re-flattens from collections on every solve):
+    gtopt case.json --memory-saving rebuild
+
+  Single-bus (copper-plate) mode — ignores all line limits:
+    gtopt case.json --set model_options.use_single_bus=true
+
+  Skip Kirchhoff voltage-law constraints (DC OPF only):
+    gtopt case.json --set model_options.use_kirchhoff=false
+
+  Pick a specific LP/MIP backend:
+    gtopt case.json --solver cplex
+    gtopt case.json --solver highs
+
+  Validate input + build the LP without solving (fast schema /
+  feasibility check; emits 'Validation: …' warnings + errors):
+    gtopt case.json --lp-only
+
+  Suppress all log output to stdout (logs still land in the per-run
+  '<output>/logs/gtopt_N.log' file when stdout is non-interactive):
+    gtopt case.json --quiet
+
+  Override scalar fields via --set (dotted path, repeatable; values
+  are auto-typed bool/int/double/string).  Example: pin SDDP threads
+  and disable Kirchhoff in one shot:
+    gtopt case.json --set sddp_options.forward_solver_options.threads=8 \
+                    --set model_options.use_kirchhoff=false
+
+  Save the merged planning JSON for inspection:
+    gtopt case.json --json-file merged_case.json
+
+  Save the assembled LP for solver-side inspection:
+    gtopt case.json --lp-file model
+
+  Tighten / loosen SDDP convergence:
+    gtopt case.json --set sddp_options.max_iterations=200 \
+                    --set sddp_options.convergence_tol=1e-5
+
+Outputs
+=======
+
+By default gtopt writes its results, logs, and traces under the
+configured output directory (CLI: --set output_directory=<dir>;
+default: 'output' relative to the case file's parent).  The layout
+is:
+
+  <output_directory>/                 results: per-element parquet/csv
+                    /solution.csv     scalar solve summary (status,
+                                      objective, kappa, per-(scene,
+                                      phase) breakdown)
+                    /Generator/       generation_sol.parquet, etc.
+                    /Bus/             balance_dual.parquet (LMPs), etc.
+                    /Reservoir/       efin_sol, …
+                    /cuts/            saved Benders cuts (SDDP only)
+                    /logs/            per-run log files (see below)
+
+  <output_directory>/logs/gtopt_N.log     INFO/WARN log of run #N
+                        /trace_N.log      trace-level log of run #N
+                        /error_*.lp[.zst] LP debug files when a
+                                          solve goes infeasible
+
+The 'N' suffix is shared between gtopt_N.log and trace_N.log of the
+same run (next free integer not present in the directory), so you
+can pair the two by suffix when investigating an issue across runs.
+
+When stdout is interactive (a TTY), spdlog also prints INFO+ to the
+terminal in addition to writing the log file.  When stdout is
+non-interactive (piped, redirected, or run via run_gtopt / CI),
+stdout is suppressed entirely and the log file is the canonical
+record — `--quiet` further silences the log file too.
+)";
       return 0;
     }
 

--- a/test/source/test_clone_via_load_flat.cpp
+++ b/test/source/test_clone_via_load_flat.cpp
@@ -484,6 +484,40 @@ TEST_CASE(  // NOLINT
   CHECK_THROWS_AS(std::ignore = src.clone_from_flat(), std::runtime_error);
 }
 
+TEST_CASE(  // NOLINT
+    "LinearInterface::clone_from_flat — succeeds after DecompressionGuard "
+    "even when persistent compressed buffer is present")
+{
+  // Pin the bug fix where ``clone_from_flat`` previously rejected a
+  // source whose persistent compressed buffer was non-empty, even if
+  // the flat LP itself had been re-hydrated by ``DecompressionGuard``.
+  // The aperture path under ``low_memory_mode=compress`` after PR #465
+  // (eager build-time compression) hits exactly this case: the source
+  // LP is built, compressed, then the aperture pass wraps it in a
+  // ``DecompressionGuard`` before calling ``clone_from_flat`` for each
+  // aperture.  The persistent compressed cache stays alive through the
+  // guard, but the flat LP is fully accessible.
+  auto problem = build_feature_problem();
+  auto flat_for_src = problem.flatten({});
+
+  LinearInterface src;
+  src.set_low_memory(LowMemoryMode::compress);
+  src.load_flat(flat_for_src);
+  src.save_snapshot(std::move(flat_for_src));
+  REQUIRE(src.has_snapshot_data());
+
+  // Compress the snapshot, then decompress (mimicking the
+  // build → release → DecompressionGuard sequence in production).
+  src.enable_compression();
+  src.disable_compression();
+
+  // Even though the persistent compressed cache is still non-empty
+  // (kept by ``LowMemorySnapshot::decompress`` as a one-time-only cache
+  // for future reload cycles), ``clone_from_flat`` must succeed because
+  // ``flat_lp.matbeg`` is now populated.
+  CHECK_NOTHROW(std::ignore = src.clone_from_flat());
+}
+
 // ─── 7. Timing comparison (informational) ───────────────────────────
 
 TEST_CASE(  // NOLINT

--- a/test/source/test_planning_method_dispatch.cpp
+++ b/test/source/test_planning_method_dispatch.cpp
@@ -267,7 +267,8 @@ TEST_CASE("make_planning_method SDDP wiring snapshot")  // NOLINT
     CHECK(so.api_stop_request_file == expected_api_stop);
 
     // ── Pool / async ──
-    CHECK(so.max_async_spread == 0);
+    CHECK(so.max_async_spread
+          == 2);  // default flipped from 0 to 2 — async by default
     CHECK(so.pool_cpu_factor == doctest::Approx(4.0));
     CHECK(so.pool_memory_limit_mb == doctest::Approx(0.0));
 

--- a/test/source/test_sddp_pool.cpp
+++ b/test/source/test_sddp_pool.cpp
@@ -20,10 +20,11 @@ TEST_CASE("SDDPTaskKey type and constants")  // NOLINT
 {
   using namespace gtopt;  // NOLINT(google-build-using-namespace)
 
-  SUBCASE("SDDPTaskKey is a 3-tuple")
+  SUBCASE("SDDPTaskKey is a 4-tuple (iter, is_backward, signed_phase, kind)")
   {
-    static_assert(std::same_as<SDDPTaskKey,
-                               std::tuple<IterationIndex, int, SDDPTaskKind>>);
+    static_assert(
+        std::same_as<SDDPTaskKey,
+                     std::tuple<IterationIndex, int, int, SDDPTaskKind>>);
     CHECK(true);
   }
 
@@ -37,27 +38,28 @@ TEST_CASE("SDDPTaskKey type and constants")  // NOLINT
     CHECK(static_cast<int>(SDDPPassDirection::backward) == -1);
   }
 
-  SUBCASE("make_sddp_task_key encodes signed_phase = direction * phase")
+  SUBCASE("make_sddp_task_key encodes is_backward + signed_phase")
   {
     const auto fwd = make_sddp_task_key(IterationIndex {1},
                                         SDDPPassDirection::forward,
                                         PhaseIndex {2},
                                         SDDPTaskKind::lp);
     CHECK(std::get<0>(fwd) == IterationIndex {1});
-    CHECK(std::get<1>(fwd) == 2);  // +1 * 2
-    CHECK(std::get<2>(fwd) == SDDPTaskKind::lp);
+    CHECK(std::get<1>(fwd) == 0);  // is_backward = 0 for forward
+    CHECK(std::get<2>(fwd) == 2);  // +1 * 2
+    CHECK(std::get<3>(fwd) == SDDPTaskKind::lp);
 
     const auto bwd = make_sddp_task_key(IterationIndex {1},
                                         SDDPPassDirection::backward,
                                         PhaseIndex {2},
                                         SDDPTaskKind::lp);
     CHECK(std::get<0>(bwd) == IterationIndex {1});
-    CHECK(std::get<1>(bwd) == -2);  // -1 * 2
-    CHECK(std::get<2>(bwd) == SDDPTaskKind::lp);
+    CHECK(std::get<1>(bwd) == 1);  // is_backward = 1 for backward
+    CHECK(std::get<2>(bwd) == -2);  // -1 * 2
+    CHECK(std::get<3>(bwd) == SDDPTaskKind::lp);
 
-    // Phase 0 collapses to 0 for both directions — direction information
-    // is lost at phase 0, which is fine because the SDDP scheduler never
-    // queues forward and backward phase 0 LP tasks at the same time.
+    // Phase 0 collapses signed_phase to 0 for both directions, but the
+    // is_backward field still distinguishes them — forward(0) wins.
     const auto fwd0 = make_sddp_task_key(IterationIndex {0},
                                          SDDPPassDirection::forward,
                                          first_phase_index(),
@@ -67,7 +69,9 @@ TEST_CASE("SDDPTaskKey type and constants")  // NOLINT
                                          first_phase_index(),
                                          SDDPTaskKind::lp);
     CHECK(std::get<1>(fwd0) == 0);
-    CHECK(std::get<1>(bwd0) == 0);
+    CHECK(std::get<1>(bwd0) == 1);
+    CHECK(std::get<2>(fwd0) == 0);
+    CHECK(std::get<2>(bwd0) == 0);
   }
 }
 
@@ -104,13 +108,11 @@ TEST_CASE("Task<SDDPTaskKey> ordering is lexicographic")  // NOLINT
     CHECK(iter1 < iter0);  // iter1 has lower priority
   }
 
-  SUBCASE("backward at phase N beats forward at phase N (signed_phase sign)")
+  SUBCASE("forward beats backward at the same iteration and phase (any phase)")
   {
-    // signed_phase: forward(+1)*N = +N, backward(-1)*N = -N.
-    // In the queue, -N < +N → backward dequeues first.  In practice the
-    // SDDP scheduler never overlaps forward and backward within an
-    // iteration (synchronised via fut.wait()), so this is the degenerate
-    // cross-direction case the design intentionally accepts.
+    // is_backward field: forward(0) < backward(1), so forward wins
+    // unconditionally — even at non-zero phase where the signed_phase
+    // encoding alone would otherwise let backward win (-N < +N).
     STask fwd {
         [] {},
         SReq {
@@ -129,15 +131,15 @@ TEST_CASE("Task<SDDPTaskKey> ordering is lexicographic")  // NOLINT
                                                SDDPTaskKind::lp),
             .name = {},
         }};
-    CHECK(fwd < bwd);  // forward(+3) > backward(-3) in std::less
-    CHECK_FALSE(bwd < fwd);
+    CHECK_FALSE(fwd < bwd);  // forward has higher priority
+    CHECK(bwd < fwd);  // backward has lower priority
   }
 
-  SUBCASE("cross-direction at phase 0 collapses to a tie (submit-time wins)")
+  SUBCASE("forward beats backward at phase 0 too (is_backward field)")
   {
-    // signed_phase = 0 for both → tuples are equal → Task ordering falls
-    // through to submit time (older submission is greater in the heap).
-    STask fwd_first {
+    // signed_phase ties at 0 for both, but is_backward 0 < 1 still
+    // gives forward priority — no submit-time-tiebreak ambiguity.
+    STask fwd {
         [] {},
         SReq {
             .priority_key = make_sddp_task_key(IterationIndex {0},
@@ -146,7 +148,7 @@ TEST_CASE("Task<SDDPTaskKey> ordering is lexicographic")  // NOLINT
                                                SDDPTaskKind::lp),
             .name = {},
         }};
-    STask bwd_later {
+    STask bwd {
         [] {},
         SReq {
             .priority_key = make_sddp_task_key(IterationIndex {0},
@@ -155,8 +157,8 @@ TEST_CASE("Task<SDDPTaskKey> ordering is lexicographic")  // NOLINT
                                                SDDPTaskKind::lp),
             .name = {},
         }};
-    CHECK_FALSE(fwd_first < bwd_later);  // older = higher priority
-    CHECK(bwd_later < fwd_first);
+    CHECK_FALSE(fwd < bwd);
+    CHECK(bwd < fwd);
   }
 
   SUBCASE("LP solve (0) has higher priority than non-LP (1)")
@@ -287,14 +289,13 @@ TEST_CASE("SDDPWorkPool submit and execute")  // NOLINT
     pool.shutdown();
   }
 
-  SUBCASE("forward task runs before backward task at non-zero phase")
+  SUBCASE("forward task runs before backward task")
   {
-    // signed_phase: forward(+1)*3 = +3 vs backward(-1)*3 = -3.
-    // Tuple comparison: -3 < +3 so backward dequeues FIRST under
-    // std::less.  This documents the cross-direction sign-trick semantics
-    // — in normal SDDP runs the scheduler's fut.wait() barrier ensures
-    // forward and backward never coexist in the queue, so this ordering
-    // is observable only in standalone tests like this one.
+    // is_backward 0 < 1 wins the cross-direction comparison
+    // unconditionally — even at the same |phase|, where the
+    // signed_phase encoding alone would let backward(-3) sort before
+    // forward(+3).  Matches the SDDP rule that the forward pass
+    // produces the trial points the backward pass needs.
     SDDPWorkPool pool;
     pool.start();
 

--- a/test/source/test_sddp_pool.cpp
+++ b/test/source/test_sddp_pool.cpp
@@ -20,38 +20,54 @@ TEST_CASE("SDDPTaskKey type and constants")  // NOLINT
 {
   using namespace gtopt;  // NOLINT(google-build-using-namespace)
 
-  SUBCASE("SDDPTaskKey is a 4-tuple of strong types")
+  SUBCASE("SDDPTaskKey is a 3-tuple")
   {
     static_assert(std::same_as<SDDPTaskKey,
-                               std::tuple<IterationIndex,
-                                          SDDPPassDirection,
-                                          PhaseIndex,
-                                          SDDPTaskKind>>);
+                               std::tuple<IterationIndex, int, SDDPTaskKind>>);
     CHECK(true);
   }
 
-  SUBCASE("SDDPPassDirection and SDDPTaskKind have correct values")
+  SUBCASE("SDDPPassDirection enum values are sign multipliers")
   {
     CHECK(static_cast<int>(SDDPTaskKind::lp) == 0);
     CHECK(static_cast<int>(SDDPTaskKind::non_lp) == 1);
-    CHECK(static_cast<int>(SDDPPassDirection::forward) == 0);
-    CHECK(static_cast<int>(SDDPPassDirection::backward) == 1);
+    // forward = +1 and backward = -1 so the enum value can be used
+    // directly as the phase-sign multiplier in make_sddp_task_key.
+    CHECK(static_cast<int>(SDDPPassDirection::forward) == 1);
+    CHECK(static_cast<int>(SDDPPassDirection::backward) == -1);
   }
 
-  SUBCASE("BasicTaskRequirements with SDDPTaskKey")
+  SUBCASE("make_sddp_task_key encodes signed_phase = direction * phase")
   {
-    BasicTaskRequirements<SDDPTaskKey> req {
-        .priority = TaskPriority::Medium,
-        .priority_key = make_sddp_task_key(IterationIndex {1},
-                                           SDDPPassDirection::forward,
-                                           PhaseIndex {2},
-                                           SDDPTaskKind::lp),
-        .name = {},
-    };
-    CHECK(std::get<0>(req.priority_key) == IterationIndex {1});
-    CHECK(std::get<1>(req.priority_key) == SDDPPassDirection::forward);
-    CHECK(std::get<2>(req.priority_key) == PhaseIndex {2});
-    CHECK(std::get<3>(req.priority_key) == SDDPTaskKind::lp);
+    const auto fwd = make_sddp_task_key(IterationIndex {1},
+                                        SDDPPassDirection::forward,
+                                        PhaseIndex {2},
+                                        SDDPTaskKind::lp);
+    CHECK(std::get<0>(fwd) == IterationIndex {1});
+    CHECK(std::get<1>(fwd) == 2);  // +1 * 2
+    CHECK(std::get<2>(fwd) == SDDPTaskKind::lp);
+
+    const auto bwd = make_sddp_task_key(IterationIndex {1},
+                                        SDDPPassDirection::backward,
+                                        PhaseIndex {2},
+                                        SDDPTaskKind::lp);
+    CHECK(std::get<0>(bwd) == IterationIndex {1});
+    CHECK(std::get<1>(bwd) == -2);  // -1 * 2
+    CHECK(std::get<2>(bwd) == SDDPTaskKind::lp);
+
+    // Phase 0 collapses to 0 for both directions — direction information
+    // is lost at phase 0, which is fine because the SDDP scheduler never
+    // queues forward and backward phase 0 LP tasks at the same time.
+    const auto fwd0 = make_sddp_task_key(IterationIndex {0},
+                                         SDDPPassDirection::forward,
+                                         first_phase_index(),
+                                         SDDPTaskKind::lp);
+    const auto bwd0 = make_sddp_task_key(IterationIndex {0},
+                                         SDDPPassDirection::backward,
+                                         first_phase_index(),
+                                         SDDPTaskKind::lp);
+    CHECK(std::get<1>(fwd0) == 0);
+    CHECK(std::get<1>(bwd0) == 0);
   }
 }
 
@@ -88,14 +104,19 @@ TEST_CASE("Task<SDDPTaskKey> ordering is lexicographic")  // NOLINT
     CHECK(iter1 < iter0);  // iter1 has lower priority
   }
 
-  SUBCASE("forward (0) has higher priority than backward (1)")
+  SUBCASE("backward at phase N beats forward at phase N (signed_phase sign)")
   {
+    // signed_phase: forward(+1)*N = +N, backward(-1)*N = -N.
+    // In the queue, -N < +N → backward dequeues first.  In practice the
+    // SDDP scheduler never overlaps forward and backward within an
+    // iteration (synchronised via fut.wait()), so this is the degenerate
+    // cross-direction case the design intentionally accepts.
     STask fwd {
         [] {},
         SReq {
             .priority_key = make_sddp_task_key(IterationIndex {0},
                                                SDDPPassDirection::forward,
-                                               first_phase_index(),
+                                               PhaseIndex {3},
                                                SDDPTaskKind::lp),
             .name = {},
         }};
@@ -104,12 +125,38 @@ TEST_CASE("Task<SDDPTaskKey> ordering is lexicographic")  // NOLINT
         SReq {
             .priority_key = make_sddp_task_key(IterationIndex {0},
                                                SDDPPassDirection::backward,
+                                               PhaseIndex {3},
+                                               SDDPTaskKind::lp),
+            .name = {},
+        }};
+    CHECK(fwd < bwd);  // forward(+3) > backward(-3) in std::less
+    CHECK_FALSE(bwd < fwd);
+  }
+
+  SUBCASE("cross-direction at phase 0 collapses to a tie (submit-time wins)")
+  {
+    // signed_phase = 0 for both → tuples are equal → Task ordering falls
+    // through to submit time (older submission is greater in the heap).
+    STask fwd_first {
+        [] {},
+        SReq {
+            .priority_key = make_sddp_task_key(IterationIndex {0},
+                                               SDDPPassDirection::forward,
                                                first_phase_index(),
                                                SDDPTaskKind::lp),
             .name = {},
         }};
-    CHECK_FALSE(fwd < bwd);  // forward has higher priority
-    CHECK(bwd < fwd);  // backward has lower priority
+    STask bwd_later {
+        [] {},
+        SReq {
+            .priority_key = make_sddp_task_key(IterationIndex {0},
+                                               SDDPPassDirection::backward,
+                                               first_phase_index(),
+                                               SDDPTaskKind::lp),
+            .name = {},
+        }};
+    CHECK_FALSE(fwd_first < bwd_later);  // older = higher priority
+    CHECK(bwd_later < fwd_first);
   }
 
   SUBCASE("LP solve (0) has higher priority than non-LP (1)")
@@ -135,8 +182,9 @@ TEST_CASE("Task<SDDPTaskKey> ordering is lexicographic")  // NOLINT
     CHECK(nonlp < lp);  // non-LP has lower priority
   }
 
-  SUBCASE("lower phase index has higher priority")
+  SUBCASE("within forward, lower phase has higher priority")
   {
+    // signed_phase: forward(+1)*0 = 0 < forward(+1)*2 = +2.
     STask ph0 {
         [] {},
         SReq {
@@ -155,8 +203,34 @@ TEST_CASE("Task<SDDPTaskKey> ordering is lexicographic")  // NOLINT
                                                SDDPTaskKind::lp),
             .name = {},
         }};
-    CHECK_FALSE(ph0 < ph2);  // phase 0 has higher priority
-    CHECK(ph2 < ph0);  // phase 2 has lower priority
+    CHECK_FALSE(ph0 < ph2);  // forward phase 0 has higher priority
+    CHECK(ph2 < ph0);  // forward phase 2 has lower priority
+  }
+
+  SUBCASE("within backward, higher phase has higher priority")
+  {
+    // signed_phase: backward(-1)*5 = -5 < backward(-1)*1 = -1, so phase 5
+    // dequeues before phase 1 — matches the backward pass walking N → 0.
+    STask ph5 {
+        [] {},
+        SReq {
+            .priority_key = make_sddp_task_key(IterationIndex {0},
+                                               SDDPPassDirection::backward,
+                                               PhaseIndex {5},
+                                               SDDPTaskKind::lp),
+            .name = {},
+        }};
+    STask ph1 {
+        [] {},
+        SReq {
+            .priority_key = make_sddp_task_key(IterationIndex {0},
+                                               SDDPPassDirection::backward,
+                                               PhaseIndex {1},
+                                               SDDPTaskKind::lp),
+            .name = {},
+        }};
+    CHECK_FALSE(ph5 < ph1);  // backward phase 5 has higher priority
+    CHECK(ph1 < ph5);  // backward phase 1 has lower priority
   }
 }
 
@@ -213,8 +287,14 @@ TEST_CASE("SDDPWorkPool submit and execute")  // NOLINT
     pool.shutdown();
   }
 
-  SUBCASE("forward task runs before backward task")
+  SUBCASE("forward task runs before backward task at non-zero phase")
   {
+    // signed_phase: forward(+1)*3 = +3 vs backward(-1)*3 = -3.
+    // Tuple comparison: -3 < +3 so backward dequeues FIRST under
+    // std::less.  This documents the cross-direction sign-trick semantics
+    // — in normal SDDP runs the scheduler's fut.wait() barrier ensures
+    // forward and backward never coexist in the queue, so this ordering
+    // is observable only in standalone tests like this one.
     SDDPWorkPool pool;
     pool.start();
 
@@ -234,7 +314,7 @@ TEST_CASE("SDDPWorkPool submit and execute")  // NOLINT
         Req {
             .priority_key = make_sddp_task_key(IterationIndex {0},
                                                SDDPPassDirection::forward,
-                                               first_phase_index(),
+                                               PhaseIndex {3},
                                                SDDPTaskKind::lp),
             .name = {},
         });
@@ -249,7 +329,7 @@ TEST_CASE("SDDPWorkPool submit and execute")  // NOLINT
         Req {
             .priority_key = make_sddp_task_key(IterationIndex {0},
                                                SDDPPassDirection::backward,
-                                               first_phase_index(),
+                                               PhaseIndex {3},
                                                SDDPTaskKind::lp),
             .name = {},
         });

--- a/test/source/test_validate_planning.cpp
+++ b/test/source/test_validate_planning.cpp
@@ -1112,15 +1112,61 @@ TEST_CASE(  // NOLINT
 }
 
 TEST_CASE(  // NOLINT
-    "validate_planning - schedule-form emin defers segment validation")
+    "validate_planning - vector-schedule emin validates per stage")
 {
   auto p = make_minimal_with_reservoir_and_waterway();
-  // Replace scalar emin with a vector schedule — validation must
-  // skip segment feasibility (deferred to per-stage load-time check).
+  // Replace scalar emin with a vector schedule.  The validator now
+  // walks every stage and emits ONE summary warning per (element,
+  // segment, direction) listing how many stages fail and the worst
+  // offender — replaces the earlier "skip on schedule form" behavior
+  // that hid real feasibility bugs in PLP-converted cases.
   p.system.reservoir_array.front().emin = std::vector<Real> {100.0, 200.0};
-  // Even an obviously infeasible segment now produces no warning,
-  // because we can't statically prove which efin value the schedule
-  // will resolve to at any given stage.
+  p.system.reservoir_seepage_array = {
+      {
+          .uid = Uid {1},
+          .name = "seep1",
+          .waterway = Uid {1},
+          .reservoir = Uid {1},
+          .segments =
+              {
+                  // f(100) = -50 + 0.01·100 = -49 < fmin=0 — INFEASIBLE.
+                  {
+                      .volume = 0.0,
+                      .slope = 0.01,
+                      .constant = -50.0,
+                  },
+              },
+      },
+  };
+  auto result = validate_planning(p);
+  // Warn-only — `result.ok()` still true (no errors).
+  CHECK(result.ok());
+  const auto seep_warns = std::ranges::count_if(
+      result.warnings,
+      [](const auto& w) { return w.find("seep1") != std::string::npos; });
+  CHECK(seep_warns == 1);
+  // The summary message names the failure count and points at the
+  // worst stage.
+  const auto found =
+      std::ranges::any_of(result.warnings,
+                          [](const auto& w)
+                          {
+                            return w.find("seep1") != std::string::npos
+                                && w.find("fmin") != std::string::npos
+                                && w.find("of 1 stages") != std::string::npos;
+                          });
+  CHECK(found);
+}
+
+TEST_CASE(  // NOLINT
+    "validate_planning - file-schedule emin defers segment validation")
+{
+  auto p = make_minimal_with_reservoir_and_waterway();
+  // File-schedule (string path) is the ONLY remaining "deferred" path
+  // — we don't load arbitrary CSV/parquet at validation time, so the
+  // segment feasibility check truly cannot evaluate.  Vector schedule
+  // (covered above) now validates per-stage.
+  p.system.reservoir_array.front().emin = std::string {"input/emin.csv"};
   p.system.reservoir_seepage_array = {
       {
           .uid = Uid {1},
@@ -1139,7 +1185,8 @@ TEST_CASE(  // NOLINT
   };
   auto result = validate_planning(p);
   CHECK(result.ok());
-  // No piecewise-feasibility warnings — deferred to load-time.
+  // No warning: the file path can't be resolved at validation time,
+  // so the segment check is genuinely deferred to the LP-build stage.
   const auto piecewise_warns = std::ranges::count_if(
       result.warnings,
       [](const auto& w) { return w.find("seep1") != std::string::npos; });

--- a/webservice/next-env.d.ts
+++ b/webservice/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/webservice/next.config.mjs
+++ b/webservice/next.config.mjs
@@ -1,4 +1,17 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  // Pin the NFT (Node File Trace) root to the webservice directory so
+  // Turbopack does not walk up into the sibling gtopt/ tree when it
+  // sees a `path.join(process.cwd(), '..', …)` in jobs.ts.  Without
+  // this, the build reports "Encountered unexpected file in NFT list"
+  // because the dynamic-cwd path that resolves to the sibling build/
+  // directory triggers a whole-project trace.
+  outputFileTracingRoot: __dirname,
+};
 
 export default nextConfig;

--- a/webservice/src/app/api/ping/route.ts
+++ b/webservice/src/app/api/ping/route.ts
@@ -29,10 +29,17 @@ export async function GET() {
     log.warn(`GET /api/ping: could not get gtopt version: ${err}`);
   }
 
-  // Read build ID for diagnostics
+  // Read build ID for diagnostics.  The /*turbopackIgnore: true*/ on
+  // process.cwd() prevents Turbopack from tracing the entire project
+  // into the NFT (Node File Trace) bundle just because we touch the
+  // cwd at request time — see https://nextjs.org/docs/app/api-reference/config/turbopack#turbopackignore
   let buildId = "";
   try {
-    const buildIdPath = path.join(process.cwd(), ".next", "BUILD_ID");
+    const buildIdPath = path.join(
+      /*turbopackIgnore: true*/ process.cwd(),
+      ".next",
+      "BUILD_ID"
+    );
     if (existsSync(buildIdPath)) {
       buildId = readFileSync(buildIdPath, "utf-8").trim();
     }

--- a/webservice/src/lib/jobs.ts
+++ b/webservice/src/lib/jobs.ts
@@ -16,22 +16,43 @@ export interface JobInfo {
   error?: string;
 }
 
-const DATA_DIR = process.env.GTOPT_DATA_DIR || path.join(process.cwd(), "data");
-const GTOPT_BIN =
-  process.env.GTOPT_BIN || path.join(process.cwd(), "..", "build", "gtopt");
-
 // In-memory job store (for production, use a database)
 const jobs = new Map<string, JobInfo>();
 
 // In-memory map of running child processes keyed by job token
 const runningProcesses = new Map<string, ChildProcess>();
 
+// Lazy data-dir / gtopt-binary resolution.  Calling `process.cwd()` at
+// module scope makes Turbopack's NFT walk pull the entire project into
+// the deployment bundle (warned as "Encountered unexpected file in
+// NFT list").  Lazy initialisation defers the cwd read to first-call
+// time — well past the build-time trace — and the cached value still
+// behaves like a module constant for the rest of the process lifetime.
+let _dataDir: string | undefined;
+function dataDir(): string {
+  if (_dataDir === undefined) {
+    _dataDir =
+      process.env.GTOPT_DATA_DIR || path.join(process.cwd(), "data");
+  }
+  return _dataDir;
+}
+
+// `gtoptBinPath()` returns the explicit-config path (`$GTOPT_BIN`) or
+// empty string when not set.  The full lookup chain — including the
+// in-project `../build/gtopt` fallback that walks out of the webservice
+// tree — lives entirely inside `resolveGtoptBinary()` below, so the
+// `..` traversal never appears at module scope and never triggers
+// Turbopack's "Encountered unexpected file in NFT list" warning.
+function gtoptBinPath(): string {
+  return process.env.GTOPT_BIN ?? "";
+}
+
 export function getDataDir(): string {
-  return DATA_DIR;
+  return dataDir();
 }
 
 export function getJobDir(token: string): string {
-  return path.join(DATA_DIR, "jobs", token);
+  return path.join(dataDir(), "jobs", token);
 }
 
 export function getJobInputDir(token: string): string {
@@ -43,7 +64,7 @@ export function getJobOutputDir(token: string): string {
 }
 
 export async function ensureDataDir(): Promise<void> {
-  await fs.mkdir(path.join(DATA_DIR, "jobs"), { recursive: true });
+  await fs.mkdir(path.join(dataDir(), "jobs"), { recursive: true });
 }
 
 export async function createJob(systemFile: string): Promise<JobInfo> {
@@ -347,23 +368,28 @@ export async function getJobMonitorData(
 }
 
 export async function resolveGtoptBinary(): Promise<string> {
-  // Check configured path first
-  try {
-    await fs.access(GTOPT_BIN, fs.constants.X_OK);
-    log.info(`Using configured gtopt binary: ${GTOPT_BIN}`);
-    return GTOPT_BIN;
-  } catch {
-    // Fall through
+  // Check configured path first ($GTOPT_BIN, when set).
+  const configured = gtoptBinPath();
+  if (configured) {
+    try {
+      await fs.access(configured, fs.constants.X_OK);
+      log.info(`Using configured gtopt binary: ${configured}`);
+      return configured;
+    } catch {
+      // Fall through
+    }
   }
 
   // Check common install locations — user-local installation first so that a
   // non-root installation in ~/.local/bin takes precedence over a system-wide
   // one in /usr/local/bin.
   const candidates = [
-    path.join(process.env.HOME || "", ".local", "bin", "gtopt"),
+    path.join(/*turbopackIgnore: true*/ process.env.HOME || "", ".local",
+              "bin", "gtopt"),
     "/usr/local/bin/gtopt",
     "/usr/bin/gtopt",
-    path.join(process.cwd(), "..", "build", "standalone", "gtopt"),
+    path.join(/*turbopackIgnore: true*/ process.cwd(), "..", "build",
+              "standalone", "gtopt"),
   ];
 
   for (const candidate of candidates) {
@@ -382,7 +408,7 @@ export async function resolveGtoptBinary(): Promise<string> {
 }
 
 export async function listJobs(): Promise<JobInfo[]> {
-  const jobsDir = path.join(DATA_DIR, "jobs");
+  const jobsDir = path.join(dataDir(), "jobs");
   try {
     const entries = await fs.readdir(jobsDir, { withFileTypes: true });
     const result: JobInfo[] = [];

--- a/webservice/src/proxy.ts
+++ b/webservice/src/proxy.ts
@@ -2,10 +2,14 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 /**
- * Middleware that logs every incoming request for diagnostics.
+ * Proxy that logs every incoming request for diagnostics.
  * Helps pinpoint routing issues (e.g. API routes returning 404).
+ *
+ * Renamed from `middleware()` to `proxy()` per Next.js 16+ convention
+ * (the `middleware` file/export name was deprecated — see
+ * https://nextjs.org/docs/messages/middleware-to-proxy).
  */
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const response = NextResponse.next();
 
   // Log request path, method, and user-agent on every request.
@@ -16,13 +20,13 @@ export function middleware(request: NextRequest) {
   const shortUa = ua.length > 60 ? ua.slice(0, 60) + "…" : ua;
 
   console.log(
-    `[${new Date().toISOString()}] [INFO] [middleware] ${method} ${path} (ua=${shortUa})`
+    `[${new Date().toISOString()}] [INFO] [proxy] ${method} ${path} (ua=${shortUa})`
   );
 
   return response;
 }
 
-// Run the middleware on API routes and the landing page.
+// Run the proxy on API routes and the landing page.
 // Excludes static assets (_next/static, favicon, etc.) to reduce noise.
 export const config = {
   matcher: ["/", "/api/:path*"],

--- a/webservice/tsconfig.json
+++ b/webservice/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,11 +15,27 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
-    "paths": { "@/*": ["./src/*"] }
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary

Cascade level 0 (the uninodal / single-bus relaxation) is a pure-Benders pass intended to converge fast and seed state-variable targets for level 1. Per-aperture solves at level 0 are pure overhead — the single-bus problem converges much faster without them, and the targets it inherits to level 1 are unaffected by aperture quality at level 0.

Level 1 (transport) and level 2 (full_network) keep apertures on their per-phase default, unchanged.

## Implementation

| Level | `sddp_options.apertures` | Runtime semantics |
|-------|--------------------------|-------------------|
| 0 (uninodal) | `[]` (empty array) | `optional<empty>` → `!apertures->empty()` is false → **"apertures=disabled"** banner |
| 1 (transport) | _key omitted_ | `nullopt` → no override → falls back to base `nullopt` → **per-phase default** (= global `aperture_array` when `Phase.apertures` is empty) |
| 2 (full_network) | _key omitted_ | same as level 1 → per-phase default |

The C++ cascade merge in `cascade_method.cpp::build_level_sddp_opts` only overrides `opts.apertures` when `level_solver->apertures.has_value()`; an absent key serialises to `nullopt` which preserves the base. An earlier draft used `apertures: None` (JSON `null`) to make the intent explicit, but that reads literally as "no apertures" in the JSON file and was confusing — the omission is cleaner.

## Verification

```
$ plp2gtopt cases/plp_case_2y -o /tmp/cascade --method cascade --num-apertures 2 ...
$ jq '.options.cascade_options.level_array | map({name, apertures: .sddp_options.apertures})'
[
  {"name":"uninodal",     "apertures": []},
  {"name":"transport",    "apertures": null},   # absent in JSON
  {"name":"full_network", "apertures": null}    # absent in JSON
]
```

## Test plan

- [x] All 1446 plp2gtopt tests pass under `pytest -n auto`.
- [x] Cascade JSON emitted by plp2gtopt has the expected per-level apertures shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)