### PR TITLE
feat(node_lp): carrier-side balance rows + storage activation

### DIFF
--- a/include/gtopt/ammonia_node_lp.hpp
+++ b/include/gtopt/ammonia_node_lp.hpp
@@ -1,0 +1,58 @@
+/**
+ * @file      ammonia_node_lp.hpp
+ * @brief     LP wrapper for ``AmmoniaNode`` — carrier-side balance row
+ * @date      Sat May 23 2026
+ * @author    marcelo
+ * @copyright BSD-3-Clause
+ *
+ * Mirror of ``thermal_node_lp.hpp`` for the ammonia carrier (MWh_LHV).
+ */
+
+#pragma once
+
+#include <gtopt/ammonia_node.hpp>
+#include <gtopt/object_lp.hpp>
+#include <gtopt/single_id.hpp>
+#include <gtopt/system_context.hpp>
+#include <gtopt/utils.hpp>
+
+namespace gtopt
+{
+
+class AmmoniaNodeLP : public ObjectLP<AmmoniaNode>
+{
+public:
+  static constexpr std::string_view BalanceName {"balance"};
+
+  explicit AmmoniaNodeLP(const AmmoniaNode& pan,
+                         [[maybe_unused]] const InputContext& ic)
+      : ObjectLP<AmmoniaNode>(pan)
+  {
+  }
+
+  [[nodiscard]] constexpr auto&& ammonia_node(this auto&& self) noexcept
+  {
+    return self.object();
+  }
+
+  bool add_to_lp(const SystemContext& sc,
+                 const ScenarioLP& scenario,
+                 const StageLP& stage,
+                 LinearProblem& lp);
+
+  bool add_to_output(OutputContext& out) const;
+
+  [[nodiscard]] const auto& balance_rows_at(const ScenarioLP& scenario,
+                                            const StageLP& stage) const
+  {
+    return balance_rows.at({scenario.uid(), stage.uid()});
+  }
+
+private:
+  STBIndexHolder<RowIndex> balance_rows;
+};
+
+using AmmoniaNodeLPId = ObjectId<class AmmoniaNodeLP>;
+using AmmoniaNodeLPSId = ObjectSingleId<class AmmoniaNodeLP>;
+
+}  // namespace gtopt

--- a/include/gtopt/hydrogen_node_lp.hpp
+++ b/include/gtopt/hydrogen_node_lp.hpp
@@ -1,0 +1,58 @@
+/**
+ * @file      hydrogen_node_lp.hpp
+ * @brief     LP wrapper for ``HydrogenNode`` — carrier-side balance row
+ * @date      Sat May 23 2026
+ * @author    marcelo
+ * @copyright BSD-3-Clause
+ *
+ * Mirror of ``thermal_node_lp.hpp`` for the hydrogen carrier (MWh_LHV).
+ */
+
+#pragma once
+
+#include <gtopt/hydrogen_node.hpp>
+#include <gtopt/object_lp.hpp>
+#include <gtopt/single_id.hpp>
+#include <gtopt/system_context.hpp>
+#include <gtopt/utils.hpp>
+
+namespace gtopt
+{
+
+class HydrogenNodeLP : public ObjectLP<HydrogenNode>
+{
+public:
+  static constexpr std::string_view BalanceName {"balance"};
+
+  explicit HydrogenNodeLP(const HydrogenNode& phn,
+                          [[maybe_unused]] const InputContext& ic)
+      : ObjectLP<HydrogenNode>(phn)
+  {
+  }
+
+  [[nodiscard]] constexpr auto&& hydrogen_node(this auto&& self) noexcept
+  {
+    return self.object();
+  }
+
+  bool add_to_lp(const SystemContext& sc,
+                 const ScenarioLP& scenario,
+                 const StageLP& stage,
+                 LinearProblem& lp);
+
+  bool add_to_output(OutputContext& out) const;
+
+  [[nodiscard]] const auto& balance_rows_at(const ScenarioLP& scenario,
+                                            const StageLP& stage) const
+  {
+    return balance_rows.at({scenario.uid(), stage.uid()});
+  }
+
+private:
+  STBIndexHolder<RowIndex> balance_rows;
+};
+
+using HydrogenNodeLPId = ObjectId<class HydrogenNodeLP>;
+using HydrogenNodeLPSId = ObjectSingleId<class HydrogenNodeLP>;
+
+}  // namespace gtopt

--- a/include/gtopt/lp_element_types.hpp
+++ b/include/gtopt/lp_element_types.hpp
@@ -27,10 +27,13 @@ namespace gtopt
 
 // ── Forward declarations for all LP element types
 // ─────────────────────────────
+class AmmoniaNodeLP;
 class AmmoniaStorageLP;
 class BatteryLP;
 class BusLP;
+class HydrogenNodeLP;
 class HydrogenStorageLP;
+class ThermalNodeLP;
 class ThermalStorageLP;
 class CommitmentLP;
 class ConverterLP;
@@ -94,8 +97,11 @@ using lp_element_types_t = std::tuple<BusLP,
                                       DemandProfileLP,
                                       CapacityProfileLP,
                                       BatteryLP,
+                                      ThermalNodeLP,
                                       ThermalStorageLP,
+                                      HydrogenNodeLP,
                                       HydrogenStorageLP,
+                                      AmmoniaNodeLP,
                                       AmmoniaStorageLP,
                                       ReserveZoneLP,
                                       ReserveProvisionLP,

--- a/include/gtopt/system_lp.hpp
+++ b/include/gtopt/system_lp.hpp
@@ -16,6 +16,7 @@
 #include <optional>
 #include <stdexcept>
 
+#include <gtopt/ammonia_node_lp.hpp>
 #include <gtopt/ammonia_storage_lp.hpp>
 #include <gtopt/battery_lp.hpp>
 #include <gtopt/bus_lp.hpp>
@@ -34,6 +35,7 @@
 #include <gtopt/fuel_lp.hpp>
 #include <gtopt/generator_lp.hpp>
 #include <gtopt/generator_profile_lp.hpp>
+#include <gtopt/hydrogen_node_lp.hpp>
 #include <gtopt/hydrogen_storage_lp.hpp>
 #include <gtopt/inertia_provision_lp.hpp>
 #include <gtopt/inertia_zone_lp.hpp>
@@ -60,6 +62,7 @@
 #include <gtopt/solver_options.hpp>
 #include <gtopt/system.hpp>
 #include <gtopt/system_context.hpp>
+#include <gtopt/thermal_node_lp.hpp>
 #include <gtopt/thermal_storage_lp.hpp>
 #include <gtopt/turbine_lp.hpp>
 #include <gtopt/user_constraint_lp.hpp>
@@ -99,8 +102,11 @@ static_assert(AddToLP<GeneratorProfileLP>);
 static_assert(AddToLP<DemandProfileLP>);
 static_assert(AddToLP<CapacityProfileLP>);
 static_assert(AddToLP<BatteryLP>);
+static_assert(AddToLP<ThermalNodeLP>);
 static_assert(AddToLP<ThermalStorageLP>);
+static_assert(AddToLP<HydrogenNodeLP>);
 static_assert(AddToLP<HydrogenStorageLP>);
+static_assert(AddToLP<AmmoniaNodeLP>);
 static_assert(AddToLP<AmmoniaStorageLP>);
 static_assert(AddToLP<ConverterLP>);
 static_assert(AddToLP<ReserveZoneLP>);
@@ -263,8 +269,11 @@ public:
                                    Collection<DemandProfileLP>,
                                    Collection<CapacityProfileLP>,
                                    Collection<BatteryLP>,
+                                   Collection<ThermalNodeLP>,
                                    Collection<ThermalStorageLP>,
+                                   Collection<HydrogenNodeLP>,
                                    Collection<HydrogenStorageLP>,
+                                   Collection<AmmoniaNodeLP>,
                                    Collection<AmmoniaStorageLP>,
                                    Collection<ReserveZoneLP>,
                                    Collection<ReserveProvisionLP>,

--- a/include/gtopt/thermal_node_lp.hpp
+++ b/include/gtopt/thermal_node_lp.hpp
@@ -1,0 +1,73 @@
+/**
+ * @file      thermal_node_lp.hpp
+ * @brief     LP wrapper for ``ThermalNode`` — carrier-side balance row
+ * @date      Sat May 23 2026
+ * @author    marcelo
+ * @copyright BSD-3-Clause
+ *
+ * Peer of ``BusLP`` and ``JunctionLP`` for the thermal carrier
+ * (MWh_th).  Creates one balance row per (scenario, stage, block);
+ * downstream elements (``ThermalStorageLP``, future
+ * ``ThermalGenerator`` / ``ThermalDemand`` / cross-carrier
+ * ``Converter``) stamp their flow coefficients into the row.
+ *
+ * Sign convention (mirrors BusLP):
+ *   * +1 × (injection into the node)
+ *   * −1 × (withdrawal from the node)
+ *
+ * For ``ThermalStorage``: charging (finp) pulls heat from the node
+ * (coefficient −1) — like a Demand on a Bus; discharging (fout)
+ * injects heat (coefficient +1) — like a Generator on a Bus.
+ *
+ * @see junction_lp.hpp     water-carrier analog (with optional drain)
+ * @see thermal_node.hpp    data struct
+ */
+
+#pragma once
+
+#include <gtopt/object_lp.hpp>
+#include <gtopt/single_id.hpp>
+#include <gtopt/system_context.hpp>
+#include <gtopt/thermal_node.hpp>
+#include <gtopt/utils.hpp>
+
+namespace gtopt
+{
+
+class ThermalNodeLP : public ObjectLP<ThermalNode>
+{
+public:
+  static constexpr std::string_view BalanceName {"balance"};
+
+  explicit ThermalNodeLP(const ThermalNode& ptn,
+                         [[maybe_unused]] const InputContext& ic)
+      : ObjectLP<ThermalNode>(ptn)
+  {
+  }
+
+  [[nodiscard]] constexpr auto&& thermal_node(this auto&& self) noexcept
+  {
+    return self.object();
+  }
+
+  bool add_to_lp(const SystemContext& sc,
+                 const ScenarioLP& scenario,
+                 const StageLP& stage,
+                 LinearProblem& lp);
+
+  bool add_to_output(OutputContext& out) const;
+
+  [[nodiscard]] const auto& balance_rows_at(const ScenarioLP& scenario,
+                                            const StageLP& stage) const
+  {
+    return balance_rows.at({scenario.uid(), stage.uid()});
+  }
+
+private:
+  STBIndexHolder<RowIndex> balance_rows;
+};
+
+using ThermalNodeLPId = ObjectId<class ThermalNodeLP>;
+using ThermalNodeLPSId = ObjectSingleId<class ThermalNodeLP>;
+
+}  // namespace gtopt

--- a/source/ammonia_node_lp.cpp
+++ b/source/ammonia_node_lp.cpp
@@ -1,0 +1,59 @@
+/**
+ * @file      ammonia_node_lp.cpp
+ * @brief     Implementation of AmmoniaNodeLP balance row
+ * @date      Sat May 23 2026
+ * @author    marcelo
+ * @copyright BSD-3-Clause
+ */
+
+#include <gtopt/ammonia_node_lp.hpp>
+#include <gtopt/linear_problem.hpp>
+#include <gtopt/output_context.hpp>
+#include <gtopt/sparse_row.hpp>
+#include <gtopt/system_context.hpp>
+
+namespace gtopt
+{
+
+bool AmmoniaNodeLP::add_to_lp([[maybe_unused]] const SystemContext& sc,
+                              const ScenarioLP& scenario,
+                              const StageLP& stage,
+                              LinearProblem& lp)
+{
+  if (!is_active(stage)) {
+    return true;
+  }
+
+  const auto& blocks = stage.blocks();
+  if (blocks.empty()) {
+    return false;
+  }
+
+  BIndexHolder<RowIndex> brows;
+  map_reserve(brows, blocks.size());
+
+  for (auto&& block : blocks) {
+    const auto buid = block.uid();
+    auto brow = SparseRow {
+        .class_name = Element::class_name.full_name(),
+        .constraint_name = BalanceName,
+        .variable_uid = uid(),
+        .context = make_block_context(scenario.uid(), stage.uid(), block.uid()),
+    };
+    brows[buid] = lp.add_row(std::move(brow));
+  }
+
+  const auto st_key = std::tuple {scenario.uid(), stage.uid()};
+  balance_rows[st_key] = std::move(brows);
+
+  return true;
+}
+
+bool AmmoniaNodeLP::add_to_output(OutputContext& out) const
+{
+  static constexpr std::string_view cname = Element::class_name.full_name();
+  out.add_row_dual(cname, BalanceName, id(), balance_rows);
+  return true;
+}
+
+}  // namespace gtopt

--- a/source/ammonia_storage_lp.cpp
+++ b/source/ammonia_storage_lp.cpp
@@ -9,6 +9,7 @@
  * Same LP shape; only class-name labels and the data struct differ.
  */
 
+#include <gtopt/ammonia_node_lp.hpp>
 #include <gtopt/ammonia_storage_lp.hpp>
 #include <gtopt/linear_problem.hpp>
 #include <gtopt/output_context.hpp>
@@ -114,6 +115,26 @@ bool AmmoniaStorageLP::add_to_lp(SystemContext& sc,
   const auto st_key = std::tuple {scenario.uid(), stage.uid()};
   finp_cols[st_key] = std::move(finps);
   fout_cols[st_key] = std::move(fouts);
+
+  // Stamp into the AmmoniaNode balance row if an ammonia_node ref is
+  // set.  Sign convention (mirrors BusLP):
+  //   * finp (charging the NH₃ tank) pulls NH₃ from the node    → −1
+  //   * fout (discharging the NH₃ tank) injects NH₃ to the node → +1
+  if (const auto& an_ref = ammonia_storage().ammonia_node; an_ref.has_value()) {
+    const auto& an_lp =
+        sc.element<AmmoniaNodeLP>(AmmoniaNodeLPSId {an_ref.value()});
+    if (an_lp.is_active(stage)) {
+      const auto& brows = an_lp.balance_rows_at(scenario, stage);
+      const auto& finps_at = finp_cols.at(st_key);
+      const auto& fouts_at = fout_cols.at(st_key);
+      for (auto&& block : blocks) {
+        const auto buid = block.uid();
+        auto& brow = lp.row_at(brows.at(buid));
+        brow[finps_at.at(buid)] = -1.0;
+        brow[fouts_at.at(buid)] = +1.0;
+      }
+    }
+  }
 
   sc.add_ampl_variable(
       ampl_name, uid(), ChargeName, scenario, stage, finp_cols.at(st_key));

--- a/source/hydrogen_node_lp.cpp
+++ b/source/hydrogen_node_lp.cpp
@@ -1,0 +1,59 @@
+/**
+ * @file      hydrogen_node_lp.cpp
+ * @brief     Implementation of HydrogenNodeLP balance row
+ * @date      Sat May 23 2026
+ * @author    marcelo
+ * @copyright BSD-3-Clause
+ */
+
+#include <gtopt/hydrogen_node_lp.hpp>
+#include <gtopt/linear_problem.hpp>
+#include <gtopt/output_context.hpp>
+#include <gtopt/sparse_row.hpp>
+#include <gtopt/system_context.hpp>
+
+namespace gtopt
+{
+
+bool HydrogenNodeLP::add_to_lp([[maybe_unused]] const SystemContext& sc,
+                               const ScenarioLP& scenario,
+                               const StageLP& stage,
+                               LinearProblem& lp)
+{
+  if (!is_active(stage)) {
+    return true;
+  }
+
+  const auto& blocks = stage.blocks();
+  if (blocks.empty()) {
+    return false;
+  }
+
+  BIndexHolder<RowIndex> brows;
+  map_reserve(brows, blocks.size());
+
+  for (auto&& block : blocks) {
+    const auto buid = block.uid();
+    auto brow = SparseRow {
+        .class_name = Element::class_name.full_name(),
+        .constraint_name = BalanceName,
+        .variable_uid = uid(),
+        .context = make_block_context(scenario.uid(), stage.uid(), block.uid()),
+    };
+    brows[buid] = lp.add_row(std::move(brow));
+  }
+
+  const auto st_key = std::tuple {scenario.uid(), stage.uid()};
+  balance_rows[st_key] = std::move(brows);
+
+  return true;
+}
+
+bool HydrogenNodeLP::add_to_output(OutputContext& out) const
+{
+  static constexpr std::string_view cname = Element::class_name.full_name();
+  out.add_row_dual(cname, BalanceName, id(), balance_rows);
+  return true;
+}
+
+}  // namespace gtopt

--- a/source/hydrogen_storage_lp.cpp
+++ b/source/hydrogen_storage_lp.cpp
@@ -11,6 +11,7 @@
  * types differ.
  */
 
+#include <gtopt/hydrogen_node_lp.hpp>
 #include <gtopt/hydrogen_storage_lp.hpp>
 #include <gtopt/linear_problem.hpp>
 #include <gtopt/output_context.hpp>
@@ -117,6 +118,27 @@ bool HydrogenStorageLP::add_to_lp(SystemContext& sc,
   const auto st_key = std::tuple {scenario.uid(), stage.uid()};
   finp_cols[st_key] = std::move(finps);
   fout_cols[st_key] = std::move(fouts);
+
+  // Stamp into the HydrogenNode balance row if a hydrogen_node ref is
+  // set.  Sign convention (mirrors BusLP):
+  //   * finp (charging the H₂ store) pulls H₂ from the node    → −1
+  //   * fout (discharging the H₂ store) injects H₂ to the node → +1
+  if (const auto& hn_ref = hydrogen_storage().hydrogen_node; hn_ref.has_value())
+  {
+    const auto& hn_lp =
+        sc.element<HydrogenNodeLP>(HydrogenNodeLPSId {hn_ref.value()});
+    if (hn_lp.is_active(stage)) {
+      const auto& brows = hn_lp.balance_rows_at(scenario, stage);
+      const auto& finps_at = finp_cols.at(st_key);
+      const auto& fouts_at = fout_cols.at(st_key);
+      for (auto&& block : blocks) {
+        const auto buid = block.uid();
+        auto& brow = lp.row_at(brows.at(buid));
+        brow[finps_at.at(buid)] = -1.0;
+        brow[fouts_at.at(buid)] = +1.0;
+      }
+    }
+  }
 
   sc.add_ampl_variable(
       ampl_name, uid(), ChargeName, scenario, stage, finp_cols.at(st_key));

--- a/source/system_lp.cpp
+++ b/source/system_lp.cpp
@@ -528,10 +528,16 @@ void create_collections(const auto& system_context,
       make_collection<CapacityProfileLP>(ic, sys.capacity_profile_array);
   std::get<Collection<BatteryLP>>(colls) =
       make_collection<BatteryLP>(ic, sys.battery_array);
+  std::get<Collection<ThermalNodeLP>>(colls) =
+      make_collection<ThermalNodeLP>(ic, sys.thermal_node_array);
   std::get<Collection<ThermalStorageLP>>(colls) =
       make_collection<ThermalStorageLP>(ic, sys.thermal_storage_array);
+  std::get<Collection<HydrogenNodeLP>>(colls) =
+      make_collection<HydrogenNodeLP>(ic, sys.hydrogen_node_array);
   std::get<Collection<HydrogenStorageLP>>(colls) =
       make_collection<HydrogenStorageLP>(ic, sys.hydrogen_storage_array);
+  std::get<Collection<AmmoniaNodeLP>>(colls) =
+      make_collection<AmmoniaNodeLP>(ic, sys.ammonia_node_array);
   std::get<Collection<AmmoniaStorageLP>>(colls) =
       make_collection<AmmoniaStorageLP>(ic, sys.ammonia_storage_array);
   std::get<Collection<ReserveZoneLP>>(colls) =
@@ -641,8 +647,11 @@ void register_element_names(SimulationLP& sim, const Array& arr)
 void register_all_ampl_element_names(SimulationLP& sim, const System& sys)
 {
   register_element_names<BatteryLP>(sim, sys.battery_array);
+  register_element_names<ThermalNodeLP>(sim, sys.thermal_node_array);
   register_element_names<ThermalStorageLP>(sim, sys.thermal_storage_array);
+  register_element_names<HydrogenNodeLP>(sim, sys.hydrogen_node_array);
   register_element_names<HydrogenStorageLP>(sim, sys.hydrogen_storage_array);
+  register_element_names<AmmoniaNodeLP>(sim, sys.ammonia_node_array);
   register_element_names<AmmoniaStorageLP>(sim, sys.ammonia_storage_array);
   register_element_names<BusLP>(sim, sys.bus_array);
   register_element_names<ConverterLP>(sim, sys.converter_array);

--- a/source/thermal_node_lp.cpp
+++ b/source/thermal_node_lp.cpp
@@ -1,0 +1,59 @@
+/**
+ * @file      thermal_node_lp.cpp
+ * @brief     Implementation of ThermalNodeLP balance row
+ * @date      Sat May 23 2026
+ * @author    marcelo
+ * @copyright BSD-3-Clause
+ */
+
+#include <gtopt/linear_problem.hpp>
+#include <gtopt/output_context.hpp>
+#include <gtopt/sparse_row.hpp>
+#include <gtopt/system_context.hpp>
+#include <gtopt/thermal_node_lp.hpp>
+
+namespace gtopt
+{
+
+bool ThermalNodeLP::add_to_lp([[maybe_unused]] const SystemContext& sc,
+                              const ScenarioLP& scenario,
+                              const StageLP& stage,
+                              LinearProblem& lp)
+{
+  if (!is_active(stage)) {
+    return true;
+  }
+
+  const auto& blocks = stage.blocks();
+  if (blocks.empty()) {
+    return false;
+  }
+
+  BIndexHolder<RowIndex> brows;
+  map_reserve(brows, blocks.size());
+
+  for (auto&& block : blocks) {
+    const auto buid = block.uid();
+    auto brow = SparseRow {
+        .class_name = Element::class_name.full_name(),
+        .constraint_name = BalanceName,
+        .variable_uid = uid(),
+        .context = make_block_context(scenario.uid(), stage.uid(), block.uid()),
+    };
+    brows[buid] = lp.add_row(std::move(brow));
+  }
+
+  const auto st_key = std::tuple {scenario.uid(), stage.uid()};
+  balance_rows[st_key] = std::move(brows);
+
+  return true;
+}
+
+bool ThermalNodeLP::add_to_output(OutputContext& out) const
+{
+  static constexpr std::string_view cname = Element::class_name.full_name();
+  out.add_row_dual(cname, BalanceName, id(), balance_rows);
+  return true;
+}
+
+}  // namespace gtopt

--- a/source/thermal_storage_lp.cpp
+++ b/source/thermal_storage_lp.cpp
@@ -12,6 +12,7 @@
 
 #include <gtopt/linear_problem.hpp>
 #include <gtopt/output_context.hpp>
+#include <gtopt/thermal_node_lp.hpp>
 #include <gtopt/thermal_storage_lp.hpp>
 
 namespace gtopt
@@ -120,6 +121,26 @@ bool ThermalStorageLP::add_to_lp(SystemContext& sc,
   const auto st_key = std::tuple {scenario.uid(), stage.uid()};
   finp_cols[st_key] = std::move(finps);
   fout_cols[st_key] = std::move(fouts);
+
+  // Stamp into the ThermalNode balance row if a thermal_node ref is
+  // set.  Sign convention (mirrors BusLP):
+  //   * finp (charging the TES) pulls heat from the node    → −1
+  //   * fout (discharging the TES) injects heat to the node → +1
+  if (const auto& tn_ref = thermal_storage().thermal_node; tn_ref.has_value()) {
+    const auto& tn_lp =
+        sc.element<ThermalNodeLP>(ThermalNodeLPSId {tn_ref.value()});
+    if (tn_lp.is_active(stage)) {
+      const auto& brows = tn_lp.balance_rows_at(scenario, stage);
+      const auto& finps_at = finp_cols.at(st_key);
+      const auto& fouts_at = fout_cols.at(st_key);
+      for (auto&& block : blocks) {
+        const auto buid = block.uid();
+        auto& brow = lp.row_at(brows.at(buid));
+        brow[finps_at.at(buid)] = -1.0;
+        brow[fouts_at.at(buid)] = +1.0;
+      }
+    }
+  }
 
   sc.add_ampl_variable(
       ampl_name, uid(), ChargeName, scenario, stage, finp_cols.at(st_key));

--- a/test/source/test_hydrogen_ammonia_lp.cpp
+++ b/test/source/test_hydrogen_ammonia_lp.cpp
@@ -104,16 +104,19 @@ TEST_CASE(
       {
           .uid = Uid {1},
           .name = "salt_cavern",
-          .active = false,  // Held inactive: HydrogenNodeLP not yet wired.
+          // ACTIVE: finp/fout now stamped into HydrogenNodeLP balance row.
           .hydrogen_node = SingleId {Uid {11}},
           .input_efficiency = 0.95,
           .output_efficiency = 0.99,
-          .annual_loss = 0.005,
+          // annual_loss intentionally unset: with eini == efin and no
+          // external source/sink, any self-discharge makes SoC drift below
+          // efin and the LP becomes primal-infeasible.
           .emin = 50000.0,
           .emax = 200000.0,
           .eini = 100000.0,
-          .efin = 80000.0,
-          .capacity = 200000.0,
+          .efin = 100000.0,  // Same as eini — no external source/sink yet,
+                             // so the LP can't move H₂ in/out of the cavern.
+          .capacity = 200000.0,  // ≥ eini so SoC fits inside the cap.
           .use_state_variable = true,
           .daily_cycle = false,
       },
@@ -132,13 +135,13 @@ TEST_CASE(
       {
           .uid = Uid {1},
           .name = "nh3_tank",
-          .active = false,  // Held inactive: AmmoniaNodeLP not yet wired.
+          // ACTIVE: finp/fout now stamped into AmmoniaNodeLP balance row.
           .ammonia_node = SingleId {Uid {22}},
-          .annual_loss = 0.025,
+          // annual_loss intentionally unset (same rationale as H₂ above).
           .emin = 0.0,
           .emax = 310000.0,
           .eini = 155000.0,
-          .efin = 100000.0,
+          .efin = 155000.0,  // Same as eini — no external source/sink yet.
           .capacity = 310000.0,
           .use_state_variable = true,
           .daily_cycle = false,

--- a/test/source/test_thermal_storage_lp.cpp
+++ b/test/source/test_thermal_storage_lp.cpp
@@ -1,23 +1,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
-// Smoke integration test for the Carrier + ThermalNode +
-// ThermalStorage type-safe registration path.  Builds a complete
-// ``System`` with the new arrays, runs LP assembly via ``SystemLP``,
-// and verifies:
-//   * the System parses + holds ThermalNode + ThermalStorage arrays,
-//   * ``ThermalStorageLP`` is registered in the LP element collections,
-//   * the LP assembles without crashing,
-//   * the bus-only side (Bus + Generator + Demand) solves to the
-//     expected dispatch cost on its own — i.e. the new TES path does
-//     not break the existing LP topology.
-//
-// The full thermal-side LP (solar field generator + power-block
-// converter on a ThermalNode-aware balance row) lands when
-// ``ThermalNodeLP`` is added — see the CSP plan for the next milestone.
-// Until then the ThermalStorage element is held back from LP assembly
-// by leaving its ``active`` field unset on a non-default-active
-// timeline; if that escape hatch is needed in the future, set
-// ``active = false`` explicitly.
+// Integration tests for ThermalNodeLP + ThermalStorageLP wiring:
+//   * Smoke: System registers ThermalNode + ThermalStorage, LP
+//     assembles and solves, bus-side dispatch cost matches.
+//   * Balance row: ThermalStorageLP stamps finp (−1) / fout (+1) into
+//     the ThermalNodeLP balance row.  With no external source/sink at
+//     the node and no charge/discharge cost, the LP collapses
+//     finp = fout = 0 and the dual is undetermined; we just verify
+//     the cols are clamped at zero.
 
 #include <doctest/doctest.h>
 #include <gtopt/linear_interface.hpp>
@@ -113,16 +103,15 @@ TEST_CASE(
           },
       },
   };
-  // ThermalStorage element is held INACTIVE on this milestone — the
-  // thermal-side balance row (ThermalNodeLP) doesn't exist yet, so an
-  // active TES would leave finp/fout columns unbound and the LP would
-  // be dual-infeasible.  Marking it inactive exercises the parse +
-  // registration path without polluting the LP.
+  // ThermalStorage is now ACTIVE: finp/fout cols are stamped into the
+  // ThermalNodeLP balance row (−1 charge / +1 discharge).  With no
+  // other element on the thermal node, the balance row sum must equal
+  // zero in every block, so the LP will set finp[b] = fout[b] = 0 in
+  // every block.  eini = efin = 200 satisfies the SoC carry trivially.
   sys.thermal_storage_array = {
       {
           .uid = Uid {1},
           .name = "tes1",
-          .active = false,
           .thermal_node = SingleId {Uid {7}},
           .input_efficiency = 0.98,
           .output_efficiency = 0.98,
@@ -130,7 +119,8 @@ TEST_CASE(
           .emax = 500.0,
           .eini = 200.0,
           .efin = 200.0,
-          .capacity = 100.0,
+          .capacity = 500.0,  // Installed energy capacity (MWh_th) — must
+                              // be ≥ eini so the SoC fits.
           .use_state_variable = true,
           .daily_cycle = false,
       },
@@ -166,4 +156,19 @@ TEST_CASE(
   // 1000 → 5.0.
   const auto obj = li.get_obj_value_raw();
   CHECK(obj == doctest::Approx(5.0).epsilon(0.01));
+
+  // The balance row at the thermal node forces finp[b] = fout[b] for
+  // every block.  With no external source/sink and no charge/discharge
+  // cost, the LP collapses both to zero.
+  const auto& scenarios = system_lp.scene().scenarios();
+  const auto& stages = system_lp.phase().stages();
+  const auto& finps = tes.finp_cols_at(scenarios[0], stages[0]);
+  const auto& fouts = tes.fout_cols_at(scenarios[0], stages[0]);
+  const auto sol = li.get_col_sol();
+  for (const auto& [buid, col] : finps) {
+    CHECK(sol[col] == doctest::Approx(0.0).epsilon(1e-6));
+  }
+  for (const auto& [buid, col] : fouts) {
+    CHECK(sol[col] == doctest::Approx(0.0).epsilon(1e-6));
+  }
 }


### PR DESCRIPTION
## Summary

Builds on PR #483 by adding the carrier-side balance-row LP classes:

- `ThermalNodeLP` (MWh_th)
- `HydrogenNodeLP` (MWh_LHV)
- `AmmoniaNodeLP` (MWh_LHV)

Each class mirrors `JunctionLP`: one balance row per (scenario, stage, block) at the typed node, no drain (yet). The storage classes (`ThermalStorageLP`, `HydrogenStorageLP`, `AmmoniaStorageLP`) now stamp `finp` (−1, charging pulls from node) and `fout` (+1, discharging injects into node) into the parent node's balance row — sign convention matches BusLP.

## Test plan
- [x] Smoke integration tests activated (no more `active = false` on storages)
- [x] New balance-row enforcement check: with no source/sink at the thermal node, the LP collapses finp[b] = fout[b] = 0
- [x] All 29 carrier-related tests pass (CSP + H₂ + NH₃ + Carrier enum)
- [x] Full 3798-case C++ unit suite green (no regressions)
- [x] Node LPs ordered BEFORE their storages in `lp_element_types_t` and `collections_t` so balance rows are created first

## Next milestone

Add Generator / Demand / Converter on these typed nodes so the LP can actually move energy through them — e.g. solar field on `ThermalNode`, electrolyser bridging `Bus → HydrogenNode`, Haber-Bosch bridging `HydrogenNode → AmmoniaNode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)