### PR TITLE
feat(plexos2gtopt): extract weekly fuel offtake caps → gtopt Fuel.max_offtake

### DIFF
--- a/scripts/plexos2gtopt/entities.py
+++ b/scripts/plexos2gtopt/entities.py
@@ -97,6 +97,14 @@ class FuelSpec:
     heat_content: float = 0.0
     co2_rate: float = 0.0
     co2_upstream_rate: float = 0.0
+    #: Weekly fuel offtake cap from ``Fuel_MaxOfftakeWeek.csv`` (one
+    #: scalar per fuel, for the week containing the bundle's
+    #: reference date).  Mirrors the PLEXOS ``FueMaxOffWeek_<fuel>``
+    #: Constraint object.  ``None`` when no row applies (e.g. the
+    #: fuel ships in the CSV with VALUE = 0 on the binding week — a
+    #: legitimate "shut" signal — distinct from "not in the CSV at
+    #: all", which means the cap is irrelevant for the bundle).
+    max_offtake: float | None = None
 
 
 @dataclass(frozen=True)

--- a/scripts/plexos2gtopt/gtopt_writer.py
+++ b/scripts/plexos2gtopt/gtopt_writer.py
@@ -652,6 +652,16 @@ def build_fuel_array(fuels: tuple[FuelSpec, ...]) -> list[dict[str, Any]]:
             if fuel.co2_upstream_rate != 0.0:
                 factor["upstream"] = fuel.co2_upstream_rate
             entry["emission_factors"] = [factor]
+        # Weekly offtake cap — mirrors PLEXOS ``FueMaxOffWeek_<fuel>``
+        # Constraint.  ``None`` means the fuel is absent from
+        # ``Fuel_MaxOfftakeWeek.csv`` (no cap binds this bundle).
+        # Explicit 0.0 IS emitted so PLEXOS's "shut on this week"
+        # signal carries through — the gtopt Fuel.max_offtake row
+        # then forces every generator on this fuel to dispatch 0
+        # within the stage (cheaper than the legacy band-aid that
+        # would have over-priced the band's marginal cost).
+        if fuel.max_offtake is not None:
+            entry["max_offtake"] = fuel.max_offtake
         out.append(entry)
     return out
 

--- a/scripts/plexos2gtopt/parsers.py
+++ b/scripts/plexos2gtopt/parsers.py
@@ -644,71 +644,50 @@ def _extract_fuel_co2_membership_rates(
     return out
 
 
-#: Regex peeling the trailing PLEXOS band suffix off a fuel name so
-#: sibling-band detection groups e.g. ``Gas_Kelar_GN_A``,
-#: ``Gas_Kelar_GN_B``, … under the same base ``Gas_Kelar_GN``.
-#: Recognised suffixes (in order tried): ``_INF`` / ``_GNL_INF`` /
-#: ``_GN_INF`` (PLEXOS "unlimited" sentinel), single-letter band IDs
-#: (``_A``…``_F``, ``_X``).
-_FUEL_BAND_SUFFIX_RE = re.compile(
-    r"_(?:GN_INF|GNL_INF|INF|[A-FX])$",
-)
+#  Retired 2026-05-23: `_patch_uncapped_zero_fuel_bands` + the
+#  `_FUEL_BAND_SUFFIX_RE` regex used to live here.  They were a
+#  band-aid for the missing ``FueMaxOffWeek_<fuel>`` constraints —
+#  promoting zero-priced fuel bands to a worst-case sibling price so
+#  the LP wouldn't discover them as free fuel arbitrage.  With
+#  ``Fuel.max_offtake`` (PR #487) we now read the real weekly caps
+#  from ``Fuel_MaxOfftakeWeek.csv`` and emit them as a per-stage cap
+#  row on the gtopt Fuel element.  See
+#  ``_extract_fuel_max_offtake_week`` below.
 
 
-def _patch_uncapped_zero_fuel_bands(prices: dict[str, list[float]]) -> None:
-    """In-place patch: zero-priced bands that have a priced sibling get
-    promoted to the MAX of the group's priced bands.
+def _extract_fuel_max_offtake_week(bundle: PlexosBundle) -> dict[str, float]:
+    """Read ``Fuel_MaxOfftakeWeek.csv`` → ``{fuel_name: cap_for_binding_week}``.
 
-    PLEXOS-CEN convention: a fuel "base" (e.g. ``Gas_Kelar_GN``) ships
-    multiple bands (``_A``, ``_B``, ``_C``, ``_D``) — sometimes only
-    one band carries a price and the others are explicit 0.  The
-    zero-priced bands ARE constrained on the PLEXOS side by
-    ``FueMaxOffWeek_<fuel>`` Constraint objects that live only in the
-    solution ``.accdb``, so plexos2gtopt's input-only parsing can't
-    see them.  Without that cap, the gtopt LP exploits the zero band
-    as free fuel.
+    Each row carries ``NAME,YEAR,MONTH,DAY,PERIOD,VALUE`` where the
+    ``(YEAR, MONTH, DAY)`` triple is the **week-start date** (PLEXOS
+    convention).  CEN PCP daily bundles ship 1-2 weekly rows per fuel
+    band — the binding week is the FIRST one seen in calendar order
+    (``read_long`` picks the lexically earliest ``(Y, M, D)`` as
+    day-0), which for a Saturday-starting week is the one whose
+    start precedes the bundle's reference date.
 
-    The heuristic here turns each unconstrained zero band into a
-    worst-case-priced band (the max of its priced siblings).  This
-    over-estimates cost on those bands but eliminates the
-    free-arbitrage shortcut that would otherwise dwarf PLEXOS's
-    operational dispatch cost on CEN PCP.
+    Returns a ``{name: cap}`` dict.  Fuels NOT in the CSV are simply
+    absent from the dict (= no cap).  Fuels with an explicit 0 cap
+    ARE in the dict with value 0.0 — PLEXOS uses this to "shut" a
+    band on a given week.
 
-    Patches only groups that have a MIX of zero and non-zero bands.
-    Wholly-zero groups (biomass / biogas / geothermal / ERNC) are
-    left alone — their explicit zero is the correct economic signal.
+    Mirrors the PLEXOS ``FueMaxOffWeek_<fuel>`` Constraint object;
+    the daily ``Fuel_MaxOfftakeDay.csv`` (e.g. Diesel) ships the
+    same shape and is consumed by the analogous helper.
+
+    The cap unit matches the fuel's price unit (``$/MMBtu`` or
+    ``$/m³``) so the gtopt ``Fuel.max_offtake`` row sums
+    heat-rate-weighted dispatch in the same basis.
     """
-    by_base: dict[str, list[str]] = {}
-    for name in prices:
-        base = _FUEL_BAND_SUFFIX_RE.sub("", name)
-        by_base.setdefault(base, []).append(name)
-
-    patched: list[tuple[str, float]] = []
-    for base, names in by_base.items():
-        if len(names) < 2:
-            continue
-        non_zero = [n for n in names if prices[n][0] > 0.0]
-        zero = [n for n in names if prices[n][0] == 0.0]
-        if not non_zero or not zero:
-            continue
-        cap_price = max(prices[n][0] for n in non_zero)
-        for name in zero:
-            old_vals = prices[name]
-            prices[name] = [cap_price] * len(old_vals)
-            patched.append((name, cap_price))
-
-    if patched:
-        # One INFO line per affected fuel keeps the patch auditable
-        # without flooding the log on bundles with many bands.
-        for name, cap in sorted(patched):
-            logger.info(
-                "patched uncapped zero-priced fuel %s → %.4f "
-                "(worst-case sibling price; PLEXOS caps live in .accdb "
-                "FueMaxOffWeek_* and aren't visible to input-only "
-                "parsing)",
-                name,
-                cap,
-            )
+    csv_name = "Fuel_MaxOfftakeWeek.csv"
+    if not bundle.has(csv_name):
+        return {}
+    # ``periods=1`` because PLEXOS ships PERIOD=1 for the whole week
+    # value; ``n_days=1`` keeps only the first (lexically earliest)
+    # week-start date, which on CEN PCP daily bundles is the binding
+    # week containing the bundle's reference date.
+    raw = read_long(bundle.csv(csv_name), periods=1, n_days=1)
+    return {name: vals[0] for name, vals in raw.items() if vals}
 
 
 def extract_fuels(db: PlexosDb, bundle: PlexosBundle) -> tuple[FuelSpec, ...]:
@@ -737,32 +716,13 @@ def extract_fuels(db: PlexosDb, bundle: PlexosBundle) -> tuple[FuelSpec, ...]:
         read_long(bundle.csv("Fuel_Price.csv")) if bundle.has("Fuel_Price.csv") else {}
     )
 
-    # Patch "uncapped zero-priced band" fuels.  PLEXOS-CEN ships
-    # multi-band fuel contracts (e.g. ``Gas_Kelar_GN_A/B/C/D``) where
-    # only band A carries a price and B/C/D are explicit 0.0 in
-    # ``Fuel_Price.csv``.  PLEXOS itself doesn't dispatch unlimited
-    # zero-price fuel because it carries weekly-offtake caps as
-    # ``FueMaxOffWeek_<fuel>`` Constraint objects — but those
-    # Constraints live only in the **solution** ``.accdb`` (not the
-    # input ``DBSEN_PRGDIARIO.xml``), so plexos2gtopt can't see them
-    # by parsing the input alone.  Without the cap, the gtopt LP
-    # discovers a "free fuel" arbitrage and dispatches the
-    # corresponding generator-variant (``KELAR-TG1+TG2+TV_GN_B``,
-    # ``MEJILLONES_3-TG+TV_GN_C``, ``COCHRANE_*_GN_D``, …) for
-    # ~150 GWh of zero-cost thermal generation, undercutting PLEXOS
-    # by ~$15M on the CEN PCP daily-week.  As a band-aid until proper
-    # ``FueMaxOff*`` constraint extraction is wired up (would need
-    # the .accdb at conversion time), promote each zero-priced band
-    # that has a priced sibling to the MAX of its priced siblings
-    # in the same fuel "base group" (same prefix sans trailing
-    # ``_<LETTER>`` band suffix).  This converts the band from a
-    # free-arbitrage option to a worst-case backup that the LP only
-    # uses when nothing cheaper is available — closer to PLEXOS's
-    # cap-constrained dispatch.  Confirmed-zero-price fuels
-    # (biomass / biogas / ERNC where the WHOLE group is zero) are
-    # untouched.
-    if prices:
-        _patch_uncapped_zero_fuel_bands(prices)
+    # Weekly offtake caps from ``Fuel_MaxOfftakeWeek.csv`` — the
+    # missing piece that PREVIOUSLY required the
+    # ``_patch_uncapped_zero_fuel_bands`` band-aid (now retired).
+    # PLEXOS's ``FueMaxOffWeek_<fuel>`` Constraint binds total weekly
+    # fuel consumption per band; gtopt's ``Fuel.max_offtake`` field
+    # (landed in PR #487) is the corresponding LP row.
+    max_offtake_week = _extract_fuel_max_offtake_week(bundle)
 
     membership_rates = _extract_fuel_co2_membership_rates(db)
     out: list[FuelSpec] = []
@@ -798,6 +758,11 @@ def extract_fuels(db: PlexosDb, bundle: PlexosBundle) -> tuple[FuelSpec, ...]:
         co2_rate = co2_mem if co2_mem != 0.0 else co2_direct
         co2_upstream_rate = co2_up_mem if co2_up_mem != 0.0 else co2_up_direct
 
+        # Weekly offtake cap for the binding week.  Absent from the
+        # CSV → ``None`` (no cap); explicit 0 in the CSV → 0.0
+        # (band shut on this week).
+        cap_week = max_offtake_week.get(fuel.name)
+
         out.append(
             FuelSpec(
                 object_id=fuel.object_id,
@@ -805,6 +770,7 @@ def extract_fuels(db: PlexosDb, bundle: PlexosBundle) -> tuple[FuelSpec, ...]:
                 price=price,
                 co2_rate=co2_rate,
                 co2_upstream_rate=co2_upstream_rate,
+                max_offtake=cap_week,
             )
         )
     return tuple(out)

--- a/scripts/plexos2gtopt/tests/test_parsers.py
+++ b/scripts/plexos2gtopt/tests/test_parsers.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 from plexos2gtopt.entities import BundleSpec
 from plexos2gtopt.parsers import (
-    _patch_uncapped_zero_fuel_bands,
     extract_batteries,
     extract_demands,
     extract_fuels,
@@ -317,6 +316,56 @@ def test_extract_fuels_skips_non_co2_emission(tmp_path: Path) -> None:
     fuels = extract_fuels(db, bundle)
     assert fuels[0].co2_rate == 0.0
     assert fuels[0].co2_upstream_rate == 0.0
+
+
+def test_extract_fuels_max_offtake_week_binding_week(tmp_path: Path) -> None:
+    """``Fuel_MaxOfftakeWeek.csv`` populates ``FuelSpec.max_offtake``.
+
+    Two week-start dates (Apr 16 and Apr 23) ship per fuel; the
+    binding week is the FIRST one seen by ``read_long`` (Apr 16 in
+    calendar order — the week containing the Apr 22 bundle date).
+    The Apr 23 row is ignored because it's outside the bundle's
+    1-day window.
+
+    Mirrors PLEXOS's ``FueMaxOffWeek_<fuel>`` Constraint pattern.
+    """
+    bundle, xml_path = _build_bundle(tmp_path)
+    _write_csv(
+        tmp_path,
+        "Fuel_MaxOfftakeWeek.csv",
+        "NAME,YEAR,MONTH,DAY,PERIOD,VALUE\n"
+        "diesel,2026,4,16,1,5000.0\n"  # ← binding week
+        "diesel,2026,4,23,1,1.0\n",  # ← ignored (next week)
+    )
+    db = load_xml(xml_path)
+    fuels = extract_fuels(db, bundle)
+    assert fuels[0].max_offtake == 5000.0
+
+
+def test_extract_fuels_max_offtake_week_absent(tmp_path: Path) -> None:
+    """No CSV → ``max_offtake = None`` (no cap binds)."""
+    bundle, xml_path = _build_bundle(tmp_path)
+    db = load_xml(xml_path)
+    fuels = extract_fuels(db, bundle)
+    assert fuels[0].max_offtake is None
+
+
+def test_extract_fuels_max_offtake_week_explicit_zero(tmp_path: Path) -> None:
+    """Explicit 0 in the CSV → ``max_offtake = 0.0`` (PLEXOS "shut").
+
+    Distinct from "absent" (= no cap).  An explicit-zero cap propagates
+    so the gtopt LP forces every generator on this fuel band to
+    dispatch 0 within the stage.
+    """
+    bundle, xml_path = _build_bundle(tmp_path)
+    _write_csv(
+        tmp_path,
+        "Fuel_MaxOfftakeWeek.csv",
+        "NAME,YEAR,MONTH,DAY,PERIOD,VALUE\ndiesel,2026,4,16,1,0\n",
+    )
+    db = load_xml(xml_path)
+    fuels = extract_fuels(db, bundle)
+    assert fuels[0].max_offtake == 0.0
 
 
 def test_extract_generators_with_costs(tmp_path: Path) -> None:
@@ -947,59 +996,6 @@ def test_extract_batteries_keeps_valid_pmin_end_to_end(tmp_path: Path) -> None:
     assert entry["pmin_charge"] == 1.0
     assert "pmin_discharge" not in entry
     assert entry["commitment"] is True
-
-
-# ---------------------------------------------------------------------------
-# T4: _patch_uncapped_zero_fuel_bands — mixed, all-zero, single-member
-# ---------------------------------------------------------------------------
-
-
-def test_patch_uncapped_zero_fuel_bands_mixed_group() -> None:
-    """Mixed group: zero-priced bands inherit the MAX priced sibling.
-
-    PLEXOS-CEN ships multi-band fuel contracts (``Gas_<base>_A/B/C/…``)
-    where only one band carries a price.  The zero bands ARE capped
-    by FueMaxOffWeek_* Constraints living in the solution .accdb,
-    invisible to input-only parsing — so the LP would otherwise
-    discover them as free fuel.  Patching them to the worst-case
-    sibling price closes the arbitrage.
-    """
-    prices: dict[str, list[float]] = {
-        "Gas_A": [100.0] * 24,
-        "Gas_B": [0.0] * 24,
-        "Gas_C": [0.0] * 24,
-    }
-    _patch_uncapped_zero_fuel_bands(prices)
-    # Priced band stays at its original value.
-    assert prices["Gas_A"][0] == 100.0
-    # Zero bands lifted to MAX priced sibling (100).
-    assert prices["Gas_B"][0] == 100.0
-    assert prices["Gas_C"][0] == 100.0
-    # The patch fills every period, not just period 1.
-    assert all(v == 100.0 for v in prices["Gas_B"])
-
-
-def test_patch_uncapped_zero_fuel_bands_wholly_zero_group() -> None:
-    """Wholly-zero groups (biomass / biogas / ERNC) are left alone.
-
-    The explicit zero IS the correct economic signal for true zero-
-    marginal-cost renewables; lifting them to a priced sibling would
-    invent fictional fuel cost.
-    """
-    prices: dict[str, list[float]] = {
-        "Bio_A": [0.0] * 24,
-        "Bio_B": [0.0] * 24,
-    }
-    _patch_uncapped_zero_fuel_bands(prices)
-    assert prices["Bio_A"] == [0.0] * 24
-    assert prices["Bio_B"] == [0.0] * 24
-
-
-def test_patch_uncapped_zero_fuel_bands_single_member_group() -> None:
-    """Single-member groups are never patched (no sibling to draw a price from)."""
-    prices: dict[str, list[float]] = {"Solo": [50.0] * 24}
-    _patch_uncapped_zero_fuel_bands(prices)
-    assert prices["Solo"] == [50.0] * 24
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/plexos2gtopt/tests/test_writer.py
+++ b/scripts/plexos2gtopt/tests/test_writer.py
@@ -319,6 +319,61 @@ def test_fuel_emission_factors_upstream_only() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Fuel.max_offtake (PLEXOS FueMaxOffWeek_* reproduction — PR #487)
+# ---------------------------------------------------------------------------
+
+
+def test_fuel_max_offtake_emitted_when_set() -> None:
+    """``FuelSpec.max_offtake`` > 0 lands on the JSON as ``max_offtake``.
+
+    The weekly cap (m³ or MMBtu / week) caps total stage consumption
+    once gtopt's FuelLP::add_to_lp builds the per-stage row.
+    """
+    fuels = (
+        FuelSpec(
+            object_id=1,
+            name="Gas_Quintero_A",
+            price=10.0,
+            max_offtake=5000.0,
+        ),
+    )
+    out = build_fuel_array(fuels)
+    assert out[0]["max_offtake"] == 5000.0
+
+
+def test_fuel_max_offtake_explicit_zero_propagates() -> None:
+    """``max_offtake == 0.0`` IS emitted (PLEXOS "shut" signal).
+
+    Distinct from ``None``: the LP must dispatch 0 on every
+    generator referencing this fuel within the stage.
+    """
+    fuels = (
+        FuelSpec(
+            object_id=2,
+            name="Gas_Quintero_B",
+            price=12.0,
+            max_offtake=0.0,
+        ),
+    )
+    out = build_fuel_array(fuels)
+    assert out[0]["max_offtake"] == 0.0
+
+
+def test_fuel_max_offtake_absent_when_none() -> None:
+    """``max_offtake == None`` omits the field (no cap binds)."""
+    fuels = (
+        FuelSpec(
+            object_id=3,
+            name="Gas_Quintero_C",
+            price=14.0,
+            max_offtake=None,
+        ),
+    )
+    out = build_fuel_array(fuels)
+    assert "max_offtake" not in out[0]
+
+
+# ---------------------------------------------------------------------------
 # Demand fcost (literature audit #3: per-Region VoLL → per-Demand fcost)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Companion to **gtopt PR #487** (`Fuel.max_offtake` C++ feature). Wires the actual PLEXOS data through:

1. **New parser**: `_extract_fuel_max_offtake_week(bundle)` reads `Fuel_MaxOfftakeWeek.csv` from the DATOS bundle and returns `{fuel_name: weekly_cap}` for the binding week (the first week-start date in calendar order — for CEN PCP daily bundles this is the week containing the bundle's reference date).
2. **`FuelSpec.max_offtake`** added to the entity.
3. **`extract_fuels`** populates the new field — absent fuels get `None` (no cap), explicit zeros propagate as `0.0` (PLEXOS "shut on this week" signal).
4. **`build_fuel_array`** emits the new JSON field when set.
5. **Retires** the legacy `_patch_uncapped_zero_fuel_bands` band-aid + its 3 unit tests + the `_FUEL_BAND_SUFFIX_RE` regex — the real cap row makes them obsolete (and would now over-price legitimately cheap-but-capped bands).

## Expected effect on the CEN PCP daily bundle (DATOS20260422)

The retired band-aid existed to mask a ~$15M / ~150 GWh free-fuel arbitrage on `KELAR-TG1+TG2+TV_GN_B` / `MEJILLONES_3-TG+TV_GN_C` / `COCHRANE_*_GN_D` (documented in the comment at the old `parsers.py:740-763`). With the real `Fuel.max_offtake` row enforced by gtopt's FuelLP, these bands now bind at the actual PLEXOS weekly caps. Should close the dispatch-cost gap vs. PLEXOS.

## Test plan
- [x] 6 new pytest cases (3 parser + 3 writer) covering set / explicit-zero / absent paths
- [x] All 18 fuel-related plexos2gtopt tests pass (`-k "fuel or max_offtake"`)
- [x] Full plexos2gtopt suite: 208 pass, 12 skipped, 1 pre-existing failure (`test_build_line_array_dlr_emits_matrix_and_loss_mode` — unrelated stale `nseg=2 vs 3` expectation from commit a4165e032)
- [x] `ruff format` + `ruff check` clean
- [x] `pylint` introduces no new C/R/W/E/F messages
- [x] End-to-end CEN PCP conversion + LP run will be validated by the next milestone (extending `compare_with_plexos.py` to diff per-fuel total offtake)

## Files changed
- `scripts/plexos2gtopt/entities.py` (+10 / -1)  — `FuelSpec.max_offtake`
- `scripts/plexos2gtopt/parsers.py` (+44 / -68) — new helper + band-aid removal
- `scripts/plexos2gtopt/gtopt_writer.py` (+10) — JSON emission
- `scripts/plexos2gtopt/tests/test_parsers.py` (+52 / -75) — 3 new tests, 3 removed
- `scripts/plexos2gtopt/tests/test_writer.py` (+50) — 3 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)