### PR TITLE
fix: emit Generator.fuel + heat_rate explicitly + tolerant FuelLP gen-cols lookup

### DIFF
--- a/scripts/plexos2gtopt/gtopt_writer.py
+++ b/scripts/plexos2gtopt/gtopt_writer.py
@@ -254,8 +254,29 @@ def build_generator_array(
             entry["pmax_segments"] = list(gen.pmax_segments)
             entry["heat_rate_segments"] = list(segments_scaled)
             entry["gcost"] = gen.vom_charge + gen.fuel_transport
+        elif primary_fuel is not None and gen.heat_rate > 0.0:
+            # Scalar path WITH a known Fuel + heat_rate — emit the
+            # explicit FK so gtopt's `FuelLP::add_to_lp` can find
+            # this generator when building the per-stage offtake
+            # cap row (PR #487 + #489).  gtopt computes
+            #
+            #   effective_gcost = fuel.price × heat_rate + gcost
+            #
+            # at LP-build, so we pass the *non-fuel* part of the
+            # variable cost as ``gcost`` and let gtopt resolve the
+            # fuel-price contribution from the Fuel element.  The
+            # numerical result is identical to the legacy
+            # pre-baked path below.
+            entry["fuel"] = primary_fuel
+            entry["heat_rate"] = gen.heat_rate
+            entry["gcost"] = gen.vom_charge + gen.fuel_transport
         else:
-            # Scalar path: pre-baked gcost coefficient.
+            # Legacy baked-gcost path: no Fuel FK (renewables, units
+            # without a Fuel membership in PLEXOS, virtual gens).
+            # Everything is collapsed into a single scalar coefficient
+            # on `generation` — the Fuel.max_offtake cap row will not
+            # apply to these gens, which is correct: they don't draw
+            # from a constrained fuel band.
             gcost = gen.heat_rate * primary_price + gen.vom_charge + gen.fuel_transport
             entry["gcost"] = gcost
         # When the per-hour rating profile actually varies (renewable

--- a/scripts/plexos2gtopt/tests/test_writer.py
+++ b/scripts/plexos2gtopt/tests/test_writer.py
@@ -24,7 +24,18 @@ from plexos2gtopt.gtopt_writer import (
 
 
 def test_generator_gcost_thermal() -> None:
-    """P3: thermal cost = heat_rate × fuel_price + vom_charge."""
+    """Thermal generator with a Fuel FK + heat_rate: emit the FK + the
+    NON-FUEL part of variable cost as ``gcost``.
+
+    gtopt computes ``effective_gcost = fuel.price × heat_rate + gcost``
+    at LP-build (Generator + FuelLP coupling).  Pre-baking
+    ``heat_rate × price`` into ``gcost`` here would double-count once
+    gtopt resolves the fuel and would also hide the Fuel FK that
+    ``FuelLP.max_offtake`` needs to find the generator at cap-row
+    build time.  Numerical result is identical (0.25 × 1500 + 8 = 383
+    at LP solve), but the JSON now carries ``fuel`` + ``heat_rate``
+    explicitly.
+    """
     fuels = (FuelSpec(object_id=1, name="diesel", price=1500.0),)
     gens = (
         GeneratorSpec(
@@ -38,8 +49,11 @@ def test_generator_gcost_thermal() -> None:
         ),
     )
     out = build_generator_array(gens, fuels)
-    # 0.25 * 1500 + 8 = 383
-    assert out[0]["gcost"] == 383.0
+    assert out[0]["fuel"] == "diesel"
+    assert out[0]["heat_rate"] == 0.25
+    # gcost is the non-fuel adder only (VOM + transport).  Fuel cost
+    # is recovered as `fuel.price × heat_rate` at LP-build.
+    assert out[0]["gcost"] == 8.0
 
 
 def test_generator_gcost_renewable() -> None:
@@ -371,6 +385,49 @@ def test_fuel_max_offtake_absent_when_none() -> None:
     )
     out = build_fuel_array(fuels)
     assert "max_offtake" not in out[0]
+
+
+def test_thermal_generator_emits_fuel_fk_for_offtake_cap_binding() -> None:
+    """End-to-end coupling: a thermal generator must emit ``fuel`` +
+    ``heat_rate`` so gtopt's ``FuelLP.max_offtake`` cap row can find
+    it at LP-build.
+
+    Pre-PR-#489 the writer pre-baked ``heat_rate × price`` into
+    ``gcost`` and dropped the Fuel FK — which made the cap row
+    silently empty (no generator coupled to the Fuel) and the
+    feature ineffective.
+    """
+    fuels = (
+        FuelSpec(
+            object_id=1,
+            name="Gas_Quintero_A",
+            price=10.0,
+            max_offtake=5000.0,
+        ),
+    )
+    gens = (
+        GeneratorSpec(
+            object_id=10,
+            name="Quintero_1A",
+            bus_name="b1",
+            pmax=200.0,
+            heat_rate=2.0,
+            vom_charge=1.5,
+            fuel_transport=0.3,
+            fuel_names=("Gas_Quintero_A",),
+        ),
+    )
+    gen_out = build_generator_array(gens, fuels)
+    # Fuel FK + heat_rate explicit on the generator entry.
+    assert gen_out[0]["fuel"] == "Gas_Quintero_A"
+    assert gen_out[0]["heat_rate"] == 2.0
+    # Non-fuel cost only.
+    assert gen_out[0]["gcost"] == 1.5 + 0.3
+    # Fuel side ships the cap; gtopt will sum the heat_rate-weighted
+    # generation across this gen (and any others with the same fuel)
+    # and bound by `max_offtake`.
+    fuel_out = build_fuel_array(fuels)
+    assert fuel_out[0]["max_offtake"] == 5000.0
 
 
 # ---------------------------------------------------------------------------

--- a/source/fuel_lp.cpp
+++ b/source/fuel_lp.cpp
@@ -107,7 +107,13 @@ bool FuelLP::add_to_lp(const SystemContext& sc,
     if (!gen.is_active(stage)) {
       continue;
     }
-    const auto& gcols = gen.generation_cols_at(scenario, stage);
+    // Use the tolerant accessor — `generation_cols_at` throws
+    // `flat_map::at` when every block of (scenario, stage) was
+    // skipped by GeneratorLP's zero-pmax P1 optimisation (the outer
+    // key is then absent).  `lookup_generation_cols` returns an
+    // empty inner map in that case, which the per-block loop below
+    // handles correctly via the `gcols.find(buid)` check.
+    const auto& gcols = gen.lookup_generation_cols(scenario, stage);
     for (const auto& block : blocks) {
       const auto buid = block.uid();
       const auto hr = gen.param_heat_rate(stage_uid, buid).value_or(0.0);


### PR DESCRIPTION
## Summary

Two-part fix completing the end-to-end PLEXOS `FueMaxOffWeek_<fuel>` reproduction (gtopt PR #487 + plexos2gtopt PR #489):

### 1. `fix(fuel_lp)`: tolerant `lookup_generation_cols`

`GeneratorLP`'s zero-pmax P1 optimisation strips `(scenario, stage)` keys from `generation_cols` for gens with pmax=0 across the whole stage — the CEN PCP daily bundle has 44+ such gens (the `_GNL_INF` sentinel variants). `FuelLP::add_to_lp` was using `generation_cols_at` which throws `flat_map::at` on missing keys, killing LP assembly:

```
Error adding Fuel uid=131 to LP (scenario=1, stage=1): flat_map::at
```

Switched to `lookup_generation_cols(scenario, stage)`, the tolerant accessor that returns an empty inner map on missing keys.

### 2. `feat(plexos2gtopt/writer)`: emit `Generator.fuel` + `heat_rate` explicitly

Pre-PR-#489 the writer pre-baked the fuel cost into `Generator.gcost` and dropped the Fuel FK on the JSON. That made the new `Fuel.max_offtake` cap row silently empty — `FuelLP::add_to_lp` filters generators by `Generator.fuel == this_fuel`, and with no fuel FK on the JSON no generator ever matched.

Now the scalar-cost path emits `fuel` + `heat_rate` when both are known, and `gcost` carries only the non-fuel adder (VOM + transport). gtopt computes `effective_gcost = fuel.price × heat_rate + gcost` at LP-build — mathematically identical dispatch, but the cap row can now find generators.

The legacy baked-gcost fallback is retained for generators without a Fuel FK (renewables, virtual gens, 118-Bus academic cases). Numerical result is identical for both paths.

## End-to-end validation on CEN PCP DATOS20260422 (single-bus, 24h)

| Metric | Before (PR #489 only) | After (this PR) |
|---|---|---|
| Generators with `fuel` FK | 0 / 1732 | 673 / 1732 |
| `Fuel/max_offtake_dual.parquet` | absent | 27 binding caps |
| LP status | optimal | optimal |
| LP kappa | 5.66e7 | 9.44e6 ↓ |
| LP obj cost (scaled) | $2.85M | $6.68M (↑ 2.3×) |

The 2.3× cost jump reflects the displacement of zero-priced fuel bands (previously free-fuel arbitrage on `KELAR-TG1+TG2+TV_GN_B` / `MEJILLONES_3-TG+TV_GN_C` / `COCHRANE_*_GN_D`) by the real PLEXOS contract caps from `Fuel_MaxOfftakeWeek.csv`. All 27 active caps bind (non-zero dual).

## Test plan
- [x] All 5 `Fuel.max_offtake` C++ tests pass
- [x] 21/22 plexos2gtopt writer tests pass (1 unrelated pre-existing failure)
- [x] End-to-end CEN PCP run: status=optimal, kappa=9.44e6, 27 binding caps
- [x] `ruff format` + `ruff check` clean
- [x] `pylint` introduces no new C/R/W/E/F messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)