### PR TITLE
feat(fuel): Fuel.max_offtake_per_block + plexos2gtopt TJ→GJ scaling

### DIFF
--- a/include/gtopt/fuel.hpp
+++ b/include/gtopt/fuel.hpp
@@ -185,6 +185,32 @@ struct Fuel
   /// HARD.  Mirrors the `Reservoir.efin_cost` /
   /// `EmissionZone.cap_cost` convention.
   OptTRealFieldSched max_offtake_cost {};
+
+  /// When `true`, enforce the offtake cap **per block** instead of
+  /// summed over the stage.  The per-stage cap `max_offtake` is
+  /// pro-rated by each block's share of stage duration:
+  ///
+  ///   block_cap_b = max_offtake(s) · duration_b / Σ_b duration_b
+  ///
+  /// and `FuelLP` creates one row per (scenario, stage, block):
+  ///
+  ///   Σ_g (heat_rate_g(s, b) · gen_g(s, t, b) · duration_b) ≤ block_cap_b
+  ///
+  /// Mirrors PLEXOS's per-period `FueMaxOffWeek_<fuel>` semantics:
+  /// the weekly cap is enforced as a per-hour rate distributed
+  /// uniformly across the week's hours, forcing the LP to spread
+  /// offtake rather than front-loading it.  This is TIGHTER than
+  /// the default per-stage sum — the per-stage sum would let the LP
+  /// pile cheap-fuel dispatch into a few hours, the per-block view
+  /// would not.
+  ///
+  /// When `false` / unset (default), the legacy per-stage sum
+  /// behaviour applies: a single row per (scenario, stage) with the
+  /// full `max_offtake(s)` on the right-hand side.  Soft-cap slack
+  /// (`max_offtake_cost`) is supported in both modes — for per-block
+  /// the slack is shared across the per-block rows via a single
+  /// stage-scoped column.
+  OptBool max_offtake_per_block {};
 };
 
 }  // namespace gtopt

--- a/include/gtopt/fuel_lp.hpp
+++ b/include/gtopt/fuel_lp.hpp
@@ -98,9 +98,19 @@ private:
   OptTRealSched max_offtake_cost_;
 
   /// Per-(scenario, stage) cap row + optional slack column.  Empty
-  /// when `max_offtake` is unset for every (scenario, stage).
+  /// when `max_offtake` is unset for every (scenario, stage), or
+  /// when the per-block path is selected via
+  /// `Fuel.max_offtake_per_block = true`.
   STIndexHolder<RowIndex> max_offtake_rows_;
   STIndexHolder<ColIndex> max_offtake_slack_cols_;
+
+  /// Per-(scenario, stage, block) cap rows + optional slack columns.
+  /// Populated only when `Fuel.max_offtake_per_block = true` —
+  /// mirrors PLEXOS's per-period `FueMaxOffWeek_<fuel>` semantics
+  /// by pro-rating the stage cap by each block's share of total
+  /// stage duration.
+  STBIndexHolder<RowIndex> max_offtake_block_rows_;
+  STBIndexHolder<ColIndex> max_offtake_block_slack_cols_;
 };
 
 /// SingleId-style reference into `Collection<FuelLP>`.  Used by

--- a/include/gtopt/json/json_fuel.hpp
+++ b/include/gtopt/json/json_fuel.hpp
@@ -58,7 +58,8 @@ struct json_data_contract<Fuel>
                         jvtl_TRealFieldSched>,
       json_variant_null<"max_offtake_cost",
                         OptTRealFieldSched,
-                        jvtl_TRealFieldSched>>;
+                        jvtl_TRealFieldSched>,
+      json_bool_null<"max_offtake_per_block", OptBool>>;
 
   constexpr static auto to_json_data(Fuel const& obj)
   {
@@ -71,7 +72,8 @@ struct json_data_contract<Fuel>
                                  obj.upstream_emission_factor,
                                  obj.emission_factors,
                                  obj.max_offtake,
-                                 obj.max_offtake_cost);
+                                 obj.max_offtake_cost,
+                                 obj.max_offtake_per_block);
   }
 };
 

--- a/scripts/plexos2gtopt/gtopt_writer.py
+++ b/scripts/plexos2gtopt/gtopt_writer.py
@@ -683,6 +683,15 @@ def build_fuel_array(fuels: tuple[FuelSpec, ...]) -> list[dict[str, Any]]:
         # would have over-priced the band's marginal cost).
         if fuel.max_offtake is not None:
             entry["max_offtake"] = fuel.max_offtake
+            # PLEXOS enforces FueMaxOffWeek_<fuel> per period (the
+            # weekly cap distributed as a uniform per-hour rate),
+            # not as a per-stage sum.  Setting
+            # max_offtake_per_block = true makes gtopt's FuelLP
+            # build one cap row per (scenario, stage, block),
+            # pro-rating the weekly cap by block duration share —
+            # matching the PLEXOS semantics.  See the module-level
+            # comment in parsers.py for the unit + semantics detail.
+            entry["max_offtake_per_block"] = True
         out.append(entry)
     return out
 

--- a/scripts/plexos2gtopt/parsers.py
+++ b/scripts/plexos2gtopt/parsers.py
@@ -655,7 +655,7 @@ def _extract_fuel_co2_membership_rates(
 #  ``_extract_fuel_max_offtake_week`` below.
 
 
-#: PLEXOS-CEN FueMaxOffWeek_* — units + semantics caveat.
+#: PLEXOS-CEN FueMaxOffWeek_* — units + semantics.
 #:
 #: 1. **Units**: ``Fuel_MaxOfftakeWeek.csv`` ships the cap in
 #:    **TJ/week**, while ``Gen_HeatRate.csv`` ships heat rates in
@@ -663,30 +663,21 @@ def _extract_fuel_co2_membership_rates(
 #:    the constraint's t_data RHS = CSV × 1000 = total weekly cap
 #:    in GJ (for ``FueMaxOffWeek_Gas_NuevaRenca_GN_A``: CSV 9.8 TJ
 #:    matches the per-period RHS 58.33 GJ × 168 hours = 9800 GJ).
+#:    → we multiply the CSV value by ``_TJ_TO_GJ`` (1000) when
+#:    emitting to gtopt so the cap units match the LHS basis.
 #:
-#: 2. **Semantics**: PLEXOS enforces the cap **per period**
-#:    (per-hour rate `= CSV / 168 hours`, scaled by period duration),
-#:    NOT as a sum over the week.  gtopt's ``Fuel.max_offtake`` row
-#:    enforces a per-stage SUM (one row per (scenario, stage)).
-#:    Per-stage sum is LOOSER than per-period rate — under
-#:    per-period the LP must spread offtake uniformly; under
-#:    per-stage the LP can front-load cheap-fuel dispatch.
-#:
-#: Empirical: passing the CSV value through as-is (no TJ → GJ
-#: conversion) gives a cap that's 1000× tighter than the "real"
-#: weekly cap but accidentally matches PLEXOS dispatch within
-#: +4.4% on the 7-day CEN PCP bundle — the per-stage sum on the
-#: under-scaled cap binds similarly to PLEXOS's per-period rate on
-#: the correctly-scaled cap.  Applying the units-correct ×1000
-#: scaling makes the cap units right but lets the LP dispatch 28%
-#: cheaper than PLEXOS because the per-stage relaxation is too
-#: loose.
-#:
-#: Until gtopt grows a per-block ``Fuel.max_offtake`` option
-#: (``FuelLP`` would build one row per (scenario, stage, block)
-#: instead of one per (scenario, stage)), we ship the CSV value
-#: as-is and accept the +4.4% gap as the practical reproduction
-#: quality.  The per-block cap row is the cleaner long-term fix.
+#: 2. **Semantics**: PLEXOS enforces the cap **per period** (the
+#:    weekly cap distributed as a uniform per-hour rate, then
+#:    multiplied by each period's duration).  Evidence: the
+#:    constraint's RHS in t_data ships uniformly as 58.33 across
+#:    all 111 periods, and Activity_p values per period vary but
+#:    never exceed RHS_p — consistent with `Activity_p ≤ RHS_p`
+#:    per-period enforcement.
+#:    → we set ``Fuel.max_offtake_per_block = True`` so gtopt's
+#:    ``FuelLP`` builds one cap row per (scenario, stage, block),
+#:    pro-rating the weekly cap by block duration share.  Matches
+#:    PLEXOS's per-period semantics.
+_TJ_TO_GJ = 1000.0
 
 
 def _extract_fuel_max_offtake_week(bundle: PlexosBundle) -> dict[str, float]:
@@ -700,20 +691,20 @@ def _extract_fuel_max_offtake_week(bundle: PlexosBundle) -> dict[str, float]:
     day-0), which for a Saturday-starting week is the one whose
     start precedes the bundle's reference date.
 
-    The CSV value is passed through as-is.  See the module-level
-    comment above this function for the TJ-vs-GJ unit caveat and
-    the per-stage-sum-vs-per-period-rate semantics gap, which
-    empirically cancel out to a +4.4% dispatch-cost gap on the CEN
-    PCP 7-day bundle.
+    The CSV value is in **TJ/week** and is scaled to **GJ/week**
+    via ``_TJ_TO_GJ`` so the cap units match the per-block LHS
+    basis (heat_rate × MWh, where PLEXOS heat_rate is in GJ/MWh).
 
-    Returns a ``{name: cap}`` dict.  Fuels NOT in the CSV are simply
-    absent from the dict (= no cap).  Fuels with an explicit 0 cap
-    ARE in the dict with value 0.0 — PLEXOS uses this to "shut" a
-    band on a given week.
+    Returns a ``{name: cap_GJ_per_week}`` dict.  Fuels NOT in the
+    CSV are simply absent from the dict (= no cap).  Fuels with an
+    explicit 0 cap ARE in the dict with value 0.0 — PLEXOS uses
+    this to "shut" a band on a given week.
 
     Mirrors the PLEXOS ``FueMaxOffWeek_<fuel>`` Constraint object;
     the daily ``Fuel_MaxOfftakeDay.csv`` (e.g. Diesel) ships the
-    same shape and is consumed by the analogous helper.
+    same shape and is consumed by the analogous helper.  PLEXOS
+    enforces the cap **per period** — gtopt mirrors this via
+    ``Fuel.max_offtake_per_block = True`` on the writer side.
     """
     csv_name = "Fuel_MaxOfftakeWeek.csv"
     if not bundle.has(csv_name):
@@ -723,7 +714,7 @@ def _extract_fuel_max_offtake_week(bundle: PlexosBundle) -> dict[str, float]:
     # week-start date, which on CEN PCP daily bundles is the binding
     # week containing the bundle's reference date.
     raw = read_long(bundle.csv(csv_name), periods=1, n_days=1)
-    return {name: vals[0] for name, vals in raw.items() if vals}
+    return {name: vals[0] * _TJ_TO_GJ for name, vals in raw.items() if vals}
 
 
 def extract_fuels(db: PlexosDb, bundle: PlexosBundle) -> tuple[FuelSpec, ...]:

--- a/scripts/plexos2gtopt/tests/test_parsers.py
+++ b/scripts/plexos2gtopt/tests/test_parsers.py
@@ -329,21 +329,24 @@ def test_extract_fuels_max_offtake_week_binding_week(tmp_path: Path) -> None:
 
     Mirrors PLEXOS's ``FueMaxOffWeek_<fuel>`` Constraint pattern.
 
-    The CSV value is passed through as-is — see the parsers.py
-    module-level caveat about the TJ-vs-GJ unit gap and the
-    per-stage-sum-vs-per-period-rate semantics that empirically
-    cancel out to a +4.4% dispatch-cost gap on CEN PCP.
+    The CSV value is in **TJ/week** and is scaled to **GJ/week**
+    by the ``_TJ_TO_GJ`` factor (= 1000) so the cap units match
+    the per-block LHS basis (heat_rate × MWh in GJ).  Verified
+    against PLEXOS solution `.accdb`:
+    ``FueMaxOffWeek_Gas_NuevaRenca_GN_A`` ships 9.8 TJ in the CSV
+    and 58.33 GJ × 168 hours = 9800 GJ in the constraint's t_data.
     """
     bundle, xml_path = _build_bundle(tmp_path)
     _write_csv(
         tmp_path,
         "Fuel_MaxOfftakeWeek.csv",
         "NAME,YEAR,MONTH,DAY,PERIOD,VALUE\n"
-        "diesel,2026,4,16,1,5000.0\n"  # ← binding week
+        "diesel,2026,4,16,1,5.0\n"  # ← binding week (5 TJ)
         "diesel,2026,4,23,1,1.0\n",  # ← ignored (next week)
     )
     db = load_xml(xml_path)
     fuels = extract_fuels(db, bundle)
+    # 5.0 TJ × 1000 = 5000 GJ (unit matching the gtopt FuelLP basis).
     assert fuels[0].max_offtake == 5000.0
 
 

--- a/scripts/plexos2gtopt/tests/test_writer.py
+++ b/scripts/plexos2gtopt/tests/test_writer.py
@@ -338,10 +338,12 @@ def test_fuel_emission_factors_upstream_only() -> None:
 
 
 def test_fuel_max_offtake_emitted_when_set() -> None:
-    """``FuelSpec.max_offtake`` > 0 lands on the JSON as ``max_offtake``.
+    """``FuelSpec.max_offtake`` > 0 lands on the JSON as ``max_offtake``
+    + ``max_offtake_per_block: true`` (PLEXOS per-period semantics).
 
-    The weekly cap (m³ or MMBtu / week) caps total stage consumption
-    once gtopt's FuelLP::add_to_lp builds the per-stage row.
+    The weekly cap (GJ/week after the TJ→GJ scaling on the parser
+    side) is pro-rated by block duration in gtopt's FuelLP — one
+    cap row per (scenario, stage, block).
     """
     fuels = (
         FuelSpec(
@@ -353,6 +355,7 @@ def test_fuel_max_offtake_emitted_when_set() -> None:
     )
     out = build_fuel_array(fuels)
     assert out[0]["max_offtake"] == 5000.0
+    assert out[0]["max_offtake_per_block"] is True
 
 
 def test_fuel_max_offtake_explicit_zero_propagates() -> None:
@@ -360,6 +363,8 @@ def test_fuel_max_offtake_explicit_zero_propagates() -> None:
 
     Distinct from ``None``: the LP must dispatch 0 on every
     generator referencing this fuel within the stage.
+    ``max_offtake_per_block`` is also set so the per-block cap
+    is 0 across every block (consistent with the "shut" semantic).
     """
     fuels = (
         FuelSpec(
@@ -371,10 +376,11 @@ def test_fuel_max_offtake_explicit_zero_propagates() -> None:
     )
     out = build_fuel_array(fuels)
     assert out[0]["max_offtake"] == 0.0
+    assert out[0]["max_offtake_per_block"] is True
 
 
 def test_fuel_max_offtake_absent_when_none() -> None:
-    """``max_offtake == None`` omits the field (no cap binds)."""
+    """``max_offtake == None`` omits both fields (no cap binds)."""
     fuels = (
         FuelSpec(
             object_id=3,
@@ -385,6 +391,7 @@ def test_fuel_max_offtake_absent_when_none() -> None:
     )
     out = build_fuel_array(fuels)
     assert "max_offtake" not in out[0]
+    assert "max_offtake_per_block" not in out[0]
 
 
 def test_thermal_generator_emits_fuel_fk_for_offtake_cap_binding() -> None:

--- a/source/fuel_lp.cpp
+++ b/source/fuel_lp.cpp
@@ -10,18 +10,23 @@
  * resolved schedules via the `param_*` accessors.
  *
  * When `Fuel.max_offtake` is set for a (scenario, stage), `add_to_lp`
- * walks every active `GeneratorLP` whose `Generator.fuel == this_fuel`,
- * collects its per-block generation cols + heat rates, and stamps a
- * single cap row:
+ * walks every active `GeneratorLP` whose `Generator.fuel == this_fuel`
+ * and creates a cap row.  Two modes are supported:
  *
- *   Σ_g (heat_rate_g(s, b) · gen_g(s, t, b) · dur_b) ≤ max_offtake(s)
+ *   * default (per-stage SUM):
+ *       Σ_b Σ_g (heat_rate · gen · dur_b)  ≤  max_offtake(s)
+ *     — one row per (scenario, stage).
  *
- * Optionally a slack column priced at `max_offtake_cost(s)` is added
- * with coefficient −1 so the cap can be violated at a per-unit price.
+ *   * `Fuel.max_offtake_per_block = true` (per-block, mirrors PLEXOS):
+ *       Σ_g (heat_rate · gen · dur_b)  ≤  max_offtake(s) · dur_b / Σ dur
+ *     — one row per (scenario, stage, block); the per-stage cap is
+ *     pro-rated by block duration.  Equivalent to enforcing a uniform
+ *     per-hour rate cap `= max_offtake / Σ dur`, matching the PLEXOS
+ *     `FueMaxOffWeek_<fuel>` Constraint's per-period semantics.
  *
- * Mirrors PLEXOS's `FueMaxOffWeek_<fuel>` Constraint objects, which
- * sum heat-rate-weighted dispatch across every generator on a given
- * fuel band.
+ * Optional slack column priced at `max_offtake_cost(s)` is added with
+ * coefficient −1 so the cap can be violated at a per-unit price.  In
+ * per-block mode each block has its own slack column.
  */
 
 #include <gtopt/cost_helper.hpp>
@@ -56,6 +61,58 @@ FuelLP::FuelLP(const Fuel& fuel, const InputContext& ic)
 {
 }
 
+namespace
+{
+
+/// Per-generator (gen_col → coefficient) map indexed by block, built
+/// in one walk over `sc.elements<GeneratorLP>()`.  Used by both the
+/// per-stage SUM path and the per-block path.
+[[nodiscard]] BIndexHolder<std::vector<std::pair<ColIndex, double>>>
+collect_gen_coefficients(const SystemContext& sc,
+                         const FuelLP& this_fuel,
+                         const ScenarioLP& scenario,
+                         const StageLP& stage)
+{
+  BIndexHolder<std::vector<std::pair<ColIndex, double>>> per_block;
+  const auto stage_uid = stage.uid();
+
+  for (const auto& gen : sc.elements<GeneratorLP>()) {
+    const auto& fuel_ref = gen.generator().fuel;
+    if (!fuel_ref.has_value()) {
+      continue;
+    }
+    const auto& gfuel = sc.element<FuelLP>(FuelLPSId {fuel_ref.value()});
+    if (gfuel.uid() != this_fuel.uid()) {
+      continue;
+    }
+    if (!gen.is_active(stage)) {
+      continue;
+    }
+    // Tolerant accessor — see `lookup_generation_cols` in
+    // GeneratorLP for why this is preferred over `generation_cols_at`.
+    const auto& gcols = gen.lookup_generation_cols(scenario, stage);
+    for (const auto& block : stage.blocks()) {
+      const auto buid = block.uid();
+      const auto hr = gen.param_heat_rate(stage_uid, buid).value_or(0.0);
+      if (hr <= 0.0) {
+        continue;
+      }
+      const auto it = gcols.find(buid);
+      if (it == gcols.end()) {
+        continue;
+      }
+      // coefficient = heat_rate × block_duration so the LHS
+      // (sum of coef × gen_col) evaluates to fuel-units when gen is
+      // in MW.  Matches the unit basis of `max_offtake`.
+      per_block[buid].emplace_back(it->second, hr * block.duration());
+    }
+  }
+
+  return per_block;
+}
+
+}  // namespace
+
 bool FuelLP::add_to_lp(const SystemContext& sc,
                        const ScenarioLP& scenario,
                        const StageLP& stage,
@@ -81,108 +138,160 @@ bool FuelLP::add_to_lp(const SystemContext& sc,
   const auto scen_uid = scenario.uid();
   const auto stage_ctx = make_stage_context(scen_uid, stage_uid);
 
-  SparseRow cap_row {
-      .class_name = cname,
-      .constraint_name = MaxOfftakeName,
-      .variable_uid = uid(),
-      .context = stage_ctx,
-  };
-
-  // Walk every GeneratorLP referencing this Fuel.  GeneratorLP runs
-  // BEFORE FuelLP in lp_element_types_t, so generation_cols_at() is
-  // already populated.
-  std::size_t coupled = 0;
-  for (const auto& gen : sc.elements<GeneratorLP>()) {
-    const auto& fuel_ref = gen.generator().fuel;
-    if (!fuel_ref.has_value()) {
-      continue;
-    }
-    // Resolve the Fuel reference (Uid or Name) to a uid.  Generator
-    // → Fuel is a SingleId so it may be either form; sc.element<>
-    // already normalises both shapes, so we use that for robustness.
-    const auto& gfuel = sc.element<FuelLP>(FuelLPSId {fuel_ref.value()});
-    if (gfuel.uid() != uid()) {
-      continue;
-    }
-    if (!gen.is_active(stage)) {
-      continue;
-    }
-    // Use the tolerant accessor — `generation_cols_at` throws
-    // `flat_map::at` when every block of (scenario, stage) was
-    // skipped by GeneratorLP's zero-pmax P1 optimisation (the outer
-    // key is then absent).  `lookup_generation_cols` returns an
-    // empty inner map in that case, which the per-block loop below
-    // handles correctly via the `gcols.find(buid)` check.
-    const auto& gcols = gen.lookup_generation_cols(scenario, stage);
-    for (const auto& block : blocks) {
-      const auto buid = block.uid();
-      const auto hr = gen.param_heat_rate(stage_uid, buid).value_or(0.0);
-      if (hr <= 0.0) {
-        continue;
-      }
-      const auto it = gcols.find(buid);
-      if (it == gcols.end()) {
-        continue;
-      }
-      // Σ (heat_rate · gen · dur) ≤ max_offtake.  Heat rate is in
-      // fuel-units / MWh; generation is MW; duration is hours →
-      // contribution is fuel-units, matching the cap's units.
-      const double existing = cap_row[it->second];
-      cap_row[it->second] = existing + (hr * block.duration());
-    }
-    ++coupled;
-  }
-
-  if (coupled == 0) {
+  // Walk generators once; reuse the (col → coefficient) map for
+  // either cap mode.  GeneratorLP runs BEFORE FuelLP in
+  // `lp_element_types_t`, so generation_cols_at() is already
+  // populated.
+  const auto gen_coefs = collect_gen_coefficients(sc, *this, scenario, stage);
+  if (gen_coefs.empty()) {
     // No active generators reference this fuel at this stage — the
-    // cap is trivially satisfied; skip the row to keep the LP sparse.
+    // cap is trivially satisfied; skip rows to keep the LP sparse.
     return true;
   }
 
-  // Optional slack column for soft cap.  Priced at max_offtake_cost
-  // via the 2-arg `cost_factor(prob, disc)` overload (duration
-  // defaults to 1.0) — NOT `scenario_stage_ecost`, which would
-  // additionally multiply by `stage.duration()`.  Both the slack
-  // column (fuel-units total) and `max_offtake_cost` ($/fuel-unit)
-  // are stage-quantities, not rates; multiplying by duration would
-  // over-count the penalty by the stage length (silently invisible
-  // for 1-hour single-block stages, real bug for multi-hour stages).
-  if (const auto cost = param_max_offtake_cost(stage_uid); cost && *cost > 0.0)
-  {
-    const auto slack_cost = *cost
-        * CostHelper::cost_factor(scenario.probability_factor(),
-                                  stage.discount_factor());
-    const auto slack_col = lp.add_col(SparseCol {
-        .lowb = 0.0,
-        .cost = slack_cost,
+  // Slack cost (used in both modes if max_offtake_cost is set).
+  // Multiply by `cost_factor(prob, disc)` — the 2-arg overload with
+  // duration defaulting to 1.0 — so the slack-cost coefficient stays
+  // in $/fuel-unit terms.  Using `scenario_stage_ecost` here would
+  // additionally multiply by `stage.duration()`, over-penalising
+  // multi-hour stages because the slack is a stage-total quantity
+  // (not a per-time rate).
+  const auto stage_cost = param_max_offtake_cost(stage_uid);
+  const double slack_cost_per_unit = (stage_cost && *stage_cost > 0.0)
+      ? *stage_cost
+          * CostHelper::cost_factor(scenario.probability_factor(),
+                                    stage.discount_factor())
+      : 0.0;
+
+  const bool per_block = fuel().max_offtake_per_block.value_or(false);
+
+  if (per_block) {
+    // ── Per-block mode ────────────────────────────────────────────────
+    // Pro-rate the stage cap by each block's share of stage duration
+    // — equivalent to enforcing a uniform per-hour rate cap
+    // `max_offtake / total_duration`.  Mirrors PLEXOS's per-period
+    // `FueMaxOffWeek_<fuel>` semantics.
+    double total_duration = 0.0;
+    for (const auto& block : blocks) {
+      total_duration += block.duration();
+    }
+    if (total_duration <= 0.0) {
+      return true;
+    }
+
+    BIndexHolder<RowIndex> brows;
+    BIndexHolder<ColIndex> bslacks;
+    map_reserve(brows, blocks.size());
+    if (slack_cost_per_unit > 0.0) {
+      map_reserve(bslacks, blocks.size());
+    }
+
+    for (const auto& block : blocks) {
+      const auto buid = block.uid();
+      const auto coefs_it = gen_coefs.find(buid);
+      if (coefs_it == gen_coefs.end() || coefs_it->second.empty()) {
+        // No generator coefficient on this block — skip the row to
+        // keep the LP sparse.  The remaining blocks still get their
+        // cap rows; the missing block is effectively "uncapped" but
+        // also "no consumption", so the constraint is trivially met.
+        continue;
+      }
+      const auto block_ctx = make_block_context(scen_uid, stage_uid, buid);
+      SparseRow brow {
+          .class_name = cname,
+          .constraint_name = MaxOfftakeName,
+          .variable_uid = uid(),
+          .context = block_ctx,
+      };
+      for (const auto& [gcol, coef] : coefs_it->second) {
+        const double existing = brow[gcol];
+        brow[gcol] = existing + coef;
+      }
+      if (slack_cost_per_unit > 0.0) {
+        const auto slack_col = lp.add_col(SparseCol {
+            .lowb = 0.0,
+            .cost = slack_cost_per_unit,
+            .class_name = cname,
+            .variable_name = MaxOfftakeSlackName,
+            .variable_uid = uid(),
+            .context = block_ctx,
+        });
+        brow[slack_col] = -1.0;
+        bslacks[buid] = slack_col;
+      }
+      const double block_cap = *stage_cap * block.duration() / total_duration;
+      brows[buid] = lp.add_row(std::move(brow).less_equal(block_cap));
+    }
+
+    const auto st_key = std::tuple {scen_uid, stage_uid};
+    if (!brows.empty()) {
+      max_offtake_block_rows_[st_key] = std::move(brows);
+    }
+    if (!bslacks.empty()) {
+      max_offtake_block_slack_cols_[st_key] = std::move(bslacks);
+    }
+  } else {
+    // ── Per-stage SUM mode (default) ──────────────────────────────────
+    SparseRow cap_row {
         .class_name = cname,
-        .variable_name = MaxOfftakeSlackName,
+        .constraint_name = MaxOfftakeName,
         .variable_uid = uid(),
         .context = stage_ctx,
-    });
-    cap_row[slack_col] = -1.0;
-    max_offtake_slack_cols_[{scen_uid, stage_uid}] = slack_col;
-  }
+    };
+    for (const auto& block : blocks) {
+      const auto coefs_it = gen_coefs.find(block.uid());
+      if (coefs_it == gen_coefs.end()) {
+        continue;
+      }
+      for (const auto& [gcol, coef] : coefs_it->second) {
+        const double existing = cap_row[gcol];
+        cap_row[gcol] = existing + coef;
+      }
+    }
 
-  max_offtake_rows_[{scen_uid, stage_uid}] =
-      lp.add_row(std::move(cap_row).less_equal(*stage_cap));
+    if (slack_cost_per_unit > 0.0) {
+      const auto slack_col = lp.add_col(SparseCol {
+          .lowb = 0.0,
+          .cost = slack_cost_per_unit,
+          .class_name = cname,
+          .variable_name = MaxOfftakeSlackName,
+          .variable_uid = uid(),
+          .context = stage_ctx,
+      });
+      cap_row[slack_col] = -1.0;
+      max_offtake_slack_cols_[{scen_uid, stage_uid}] = slack_col;
+    }
+    max_offtake_rows_[{scen_uid, stage_uid}] =
+        lp.add_row(std::move(cap_row).less_equal(*stage_cap));
+  }
 
   return true;
 }
 
 bool FuelLP::add_to_output(OutputContext& out) const
 {
-  if (max_offtake_rows_.empty()) {
+  if (max_offtake_rows_.empty() && max_offtake_block_rows_.empty()) {
     return true;
   }
 
   static constexpr std::string_view cname = Element::class_name.full_name();
   const auto pid = id();
 
-  out.add_row_dual(cname, MaxOfftakeName, pid, max_offtake_rows_);
+  if (!max_offtake_rows_.empty()) {
+    out.add_row_dual(cname, MaxOfftakeName, pid, max_offtake_rows_);
+  }
   if (!max_offtake_slack_cols_.empty()) {
     out.add_col_sol(cname, MaxOfftakeSlackName, pid, max_offtake_slack_cols_);
     out.add_col_cost(cname, MaxOfftakeSlackName, pid, max_offtake_slack_cols_);
+  }
+  if (!max_offtake_block_rows_.empty()) {
+    out.add_row_dual(cname, MaxOfftakeName, pid, max_offtake_block_rows_);
+  }
+  if (!max_offtake_block_slack_cols_.empty()) {
+    out.add_col_sol(
+        cname, MaxOfftakeSlackName, pid, max_offtake_block_slack_cols_);
+    out.add_col_cost(
+        cname, MaxOfftakeSlackName, pid, max_offtake_block_slack_cols_);
   }
   return true;
 }

--- a/test/source/test_fuel_offtake.cpp
+++ b/test/source/test_fuel_offtake.cpp
@@ -241,3 +241,86 @@ TEST_CASE(
   const auto obj = li.get_obj_value_raw();
   CHECK(obj == doctest::Approx(2.0).epsilon(0.01));
 }
+
+TEST_CASE(  // NOLINT
+    "Fuel.max_offtake_per_block: per-block enforcement vs per-stage sum")
+{
+  using namespace test_fuel_offtake;
+  // Same single-fuel system as the basic hard-cap test but with
+  // demand SPIKED in block 0 to verify the per-block enforcement.
+  //
+  // System layout:
+  //   block 0: demand = 100 MW × 1h = 100 MWh  (spike)
+  //   block 1: demand =   0 MW × 1h =   0 MWh  (quiet)
+  //
+  // With heat_rate = 2 MMBtu/MWh, full demand needs 200 MMBtu
+  // total — 200 in block 0, 0 in block 1.
+  //
+  // Per-stage SUM cap (max_offtake = 120, per_block = false):
+  //   Σ_b (2 × gen × 1h) ≤ 120 → gen_0 + gen_1 ≤ 60 MWh
+  //   LP picks gen_0 = 60, gen_1 = 0 (all in block 0).
+  //   gen_0 = 60 → block-0 demand short by 40 MWh → fail_cost
+  //   = 40 × 1000 = $40 000 → 40.0 scaled.
+  //   gen_cost = 60 × 2 × 10 = $1200 → 1.2.  Total ≈ 41.2.
+  //
+  // Per-block cap (max_offtake = 120, per_block = true):
+  //   For block 0: 2 × gen_0 × 1 ≤ 120/2 = 60 → gen_0 ≤ 30 MWh
+  //   For block 1: 2 × gen_1 × 1 ≤  60 → gen_1 ≤ 30 MWh
+  //   Block 0 demand 100, block 1 demand 0 → gen_0 = 30 (cap
+  //   limited), block-0 unserved = 70 MWh; gen_1 = 0.
+  //   gen_cost = 30 × 2 × 10 = $600 → 0.6.
+  //   fail   = 70 × 1000     = $70 000 → 70.0.  Total ≈ 70.6.
+  //
+  // Per-block is TIGHTER than per-stage sum.  This test verifies
+  // that the per-block path actually constrains tighter than the
+  // sum path on a peak-block scenario.
+  System sys = make_single_fuel_system(120.0);
+  // Spike block 0 to 100 MW, idle block 1, via per-(stage, block)
+  // `lmax`.  Keep `capacity` at 100 MW so the synthetic
+  // ``demand_lp`` upper bound doesn't shrink the per-block lmax.
+  sys.demand_array[0].capacity = 100.0;
+  // OptTBRealFieldSched accepts a [[stage_blocks]] 2-D matrix:
+  // outer = stages (1), inner = blocks (2).
+  sys.demand_array[0].lmax =
+      OptTBRealFieldSched {std::vector<std::vector<Real>> {{100.0, 0.0}}};
+
+  SUBCASE("per-stage SUM (default): LP fronts-loads dispatch in block 0")
+  {
+    sys.fuel_array[0].max_offtake_per_block = false;
+    const auto simulation = make_2block_simulation();
+    PlanningOptions popts;
+    popts.model_options.demand_fail_cost = 1000.0;
+    const PlanningOptionsLP options(popts);
+    SimulationLP simulation_lp(simulation, options);
+    SystemLP system_lp(sys, simulation_lp);
+
+    auto&& li = system_lp.linear_interface();
+    const auto result = li.resolve();
+    REQUIRE(result.has_value());
+    CHECK(result.value() == 0);
+    // 60 MWh × 2 × 10 = $1200 ; (100-60) × 1000 = $40 000
+    // → 41.2 scaled.
+    const auto obj = li.get_obj_value_raw();
+    CHECK(obj == doctest::Approx(41.2).epsilon(0.01));
+  }
+
+  SUBCASE("per-block TRUE: cap pro-rated by block duration, tighter")
+  {
+    sys.fuel_array[0].max_offtake_per_block = true;
+    const auto simulation = make_2block_simulation();
+    PlanningOptions popts;
+    popts.model_options.demand_fail_cost = 1000.0;
+    const PlanningOptionsLP options(popts);
+    SimulationLP simulation_lp(simulation, options);
+    SystemLP system_lp(sys, simulation_lp);
+
+    auto&& li = system_lp.linear_interface();
+    const auto result = li.resolve();
+    REQUIRE(result.has_value());
+    CHECK(result.value() == 0);
+    // gen_0 capped at 30 MWh → 100-30 = 70 MWh unserved in block 0.
+    // 30 × 2 × 10 = $600 ; 70 × 1000 = $70 000 → 70.6 scaled.
+    const auto obj = li.get_obj_value_raw();
+    CHECK(obj == doctest::Approx(70.6).epsilon(0.01));
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the documentation-only PR #491 with the proper fix the user asked for: **per-block enforcement** on `Fuel.max_offtake` + **correct TJ→GJ unit scaling** on the plexos2gtopt side.

### gtopt C++ side

Adds `Fuel.max_offtake_per_block: OptBool` (default false, = legacy per-stage SUM behaviour). When `true`:

```
block_cap_b = max_offtake(s) · duration_b / Σ_b duration_b
per-block row: Σ_g (heat_rate · gen · duration_b) ≤ block_cap_b
```

One row per (scenario, stage, block) — mirrors PLEXOS's `FueMaxOffWeek_<fuel>` Constraint semantics where the weekly cap is enforced as a uniform per-hour rate, then multiplied by each block's duration.

Implementation:
- Refactored `FuelLP::add_to_lp` into a shared `collect_gen_coefficients` helper + per-block / per-stage branches.
- Per-block path supports soft-cap slack: one slack column per (scenario, stage, block).
- `add_to_output` emits whichever storage is populated.

### plexos2gtopt side

- Parser multiplies `Fuel_MaxOfftakeWeek.csv` value by 1000 (TJ → GJ correct conversion).
- Writer emits `Fuel.max_offtake_per_block: true` so gtopt uses PLEXOS-matching per-period semantics.

## PLEXOS evidence for per-period enforcement

From `Model PRGdia_Full_Definitivo Solution.accdb`:
- `FueMaxOffWeek_Gas_NuevaRenca_GN_A` constraint RHS in t_data ships uniformly as **58.33 GJ across all 111 periods**.
- Per-period `Activity` values vary (0 - 54.20 GJ) and **never exceed RHS_p** — consistent with `Activity_p ≤ RHS_p` enforced per period.
- 58.33 GJ × 168 hours = 9800 GJ = CSV value (9.8 TJ) × 1000.

## End-to-end validation on CEN PCP DATOS20260422 (7-day, single-bus)

| Version | gtopt $ | vs PLEXOS pid-119 ($16.12M) | vs PLEXOS Σ gen×srmc×dt ($22.79M) |
|---|---|---|---|
| PR #491 (CSV as-is, per-stage SUM) | $23.80M | +47.6% | +4.4% |
| PR #490 + CSV×1000, per-stage SUM | $16.38M | +1.6% | -28.1% |
| **This PR (CSV×1000 + per-block)** | **$16.87M** | **+4.7%** | -26.0% |

The new headline number: **gtopt within +4.7% of the PLEXOS LP-band-integrated baseline** (pid-119) — close to the expected LP-vs-MIP gap.

The remaining `gtopt vs Σ gen×srmc×dt` -26% gap reflects **multi-band fuel substitution** in PLEXOS (one gen can mix consumption across multiple Fuel bands at different SRMCs); gtopt's single `Generator.fuel` FK cannot replicate that. Future enhancement: extend Generator to support a list of Fuel FKs.

## Test plan
- [x] All 5 existing C++ `Fuel.max_offtake` tests still pass (per-stage default unchanged)
- [x] New C++ test `Fuel.max_offtake_per_block: per-block enforcement vs per-stage sum` validates both modes on a peak-block scenario (per-block tighter than per-stage SUM)
- [x] All 19 plexos2gtopt fuel-related tests pass
- [x] End-to-end: gtopt within +4.7% of PLEXOS LP-band-integrated baseline on the CEN PCP weekly bundle
- [x] `ruff format` + `ruff check` clean
- [x] `pylint` introduces no new C/R/W/E/F messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)