### PR TITLE
fix(webservice): GTOPT_EXTRA_ARGS env hook + force --write-out all in e2e

### DIFF
--- a/webservice/src/lib/jobs.ts
+++ b/webservice/src/lib/jobs.ts
@@ -147,10 +147,20 @@ export async function runGtopt(token: string): Promise<void> {
     log.warn(`Job ${token}: could not list input directory contents: ${err}`);
   }
 
+  // Optional whitespace-separated extra args appended to every gtopt
+  // invocation.  Used by `webservice/test/e2e_test.sh` to force
+  // `--write-out all` (so the c0 golden fixtures under
+  // `cases/c0/output/Demand/*_cost.csv` keep matching the lean default
+  // emit set, which only writes reduced costs for Generator+Line).
+  // Empty / unset means production behaviour is unchanged.
+  const extraArgs = (process.env.GTOPT_EXTRA_ARGS ?? "")
+    .split(/\s+/)
+    .filter((s) => s.length > 0);
+
   return new Promise<void>((resolve) => {
     const proc = spawn(
       gtoptBin,
-      [job.systemFile, "--set", `output_directory=${outputDir}`],
+      [job.systemFile, "--set", `output_directory=${outputDir}`, ...extraArgs],
       {
         cwd: inputDir,
         stdio: ["ignore", "pipe", "pipe"],

--- a/webservice/test/e2e_real_test.sh
+++ b/webservice/test/e2e_real_test.sh
@@ -105,7 +105,10 @@ LOG_DIR="$TEST_TMPDIR/logs"
 mkdir -p "$LOG_DIR"
 log "Starting web service on port $PORT with real gtopt binary..."
 cd "$WEBSERVICE_DIR"
+# See e2e_test.sh for rationale: force ``--write-out all`` so the c0
+# golden cost fixtures keep matching the gtopt lean default.
 GTOPT_BIN="$GTOPT_BIN" GTOPT_DATA_DIR="$TEST_TMPDIR/data" GTOPT_LOG_DIR="$LOG_DIR" \
+  GTOPT_EXTRA_ARGS="--write-out all" \
   node_modules/.bin/next start -p "$PORT" --hostname 0.0.0.0 \
   >"$TEST_TMPDIR/server.log" 2>&1 &
 SERVER_PID=$!

--- a/webservice/test/e2e_test.sh
+++ b/webservice/test/e2e_test.sh
@@ -87,7 +87,13 @@ log "Starting web service on port $PORT ..."
 cd "$WEBSERVICE_DIR"
 LOG_DIR="$TEST_TMPDIR/logs"
 mkdir -p "$LOG_DIR"
+# Force `--write-out all` so the c0 golden fixtures under
+# ``cases/c0/output/Demand/*_cost.csv`` keep matching the gtopt default
+# (which only emits reduced costs for Generator+Line as of the lean
+# ``rc_classes`` default in planning_options_lp.hpp:779).  The mirror
+# workaround used by ``integration_test/cmake/run_gtopt.cmake``.
 GTOPT_BIN="$GTOPT_BIN" GTOPT_DATA_DIR="$TEST_TMPDIR/data" GTOPT_LOG_DIR="$LOG_DIR" \
+  GTOPT_EXTRA_ARGS="--write-out all" \
   node_modules/.bin/next start -p "$PORT" --hostname 0.0.0.0 \
   >"$TEST_TMPDIR/server.log" 2>&1 &
 SERVER_PID=$!


### PR DESCRIPTION
## Summary

Restore the c0 webservice e2e parity that broke after the lean ``write_out`` default landed.  The default now emits reduced costs only for ``Generator``/``Line`` (see ``planning_options_lp.hpp:779``); the four ``cases/c0/output/Demand/{capacost,capainst,expmod,load}_cost.csv`` golden files have nothing to compare against under the new default, so the webservice e2e (which spawns gtopt without any extra flag) fails with four ``Missing output file`` errors.

Mirror the same workaround the ``integration_test`` framework already uses (``cmake/run_gtopt.cmake:45`` forces ``--write-out all``): force the flag for the e2e run only, leave production behaviour unchanged.

- ``webservice/src/lib/jobs.ts``: read whitespace-separated ``$GTOPT_EXTRA_ARGS`` from the environment and append the tokens to the spawned gtopt argv.  When unset, behaviour is byte-identical to the pre-change spawn.
- ``webservice/test/e2e_test.sh``: export ``GTOPT_EXTRA_ARGS="--write-out all"`` for the next-server child.

## Test plan

- [x] No-op when ``$GTOPT_EXTRA_ARGS`` is unset (preserves production behaviour)
- [x] e2e_test.sh sets the env so the four missing ``Demand/*_cost.csv`` shards are now emitted
- [x] Pre-existing PAMPL hygiene PR #497 cleared the unrelated CI blockers; this PR addresses the single remaining ``Ubuntu/webservice`` failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)