### PR TITLE
feat(allowance_pool): auction-purchase column at market price (CO2 Phase 4)

### DIFF
--- a/docs/formulation/mathematical-formulation.md
+++ b/docs/formulation/mathematical-formulation.md
@@ -1445,11 +1445,31 @@ $$
 \begin{aligned}
 e_{a,s,t,b} \;=\;& e_{a,s,t,b-1}\,(1 - \lambda_a^h\,\Delta_b)
   \;+\; \Delta_b\,\phi_{a,s,t,b}
+  \;+\; \beta_{a,s,t,b}
   \;-\; \sum_{z:\,a(z)=a} q_{z,s,t,b}
 \qquad \forall \; a,\; s,t,b
 \end{aligned}
 $$
 <!-- source: source/emission_zone_lp.cpp:106-126 ; source/allowance_pool_lp.cpp -->
+
+**Auction purchases (cap-and-trade market).** When `auction_price`
+$\rho_{a,t,b}$ is set, an `auction` column $\beta_{a,s,t,b}$ [tCO₂]
+lets the bank buy allowances on the market instead of abating
+emissions:
+
+$$
+0 \;\leq\; \beta_{a,s,t,b} \;\leq\; \overline{B}_{a,t,b},
+\qquad \text{obj} \mathrel{+}= \rho_{a,t,b}\,\pi_s\,\delta_t\,\beta_{a,s,t,b}
+$$
+<!-- source: source/allowance_pool_lp.cpp -->
+
+where $\overline{B}_{a,t,b}$ is `auction_cap`, $\pi_s$ the scenario
+probability, and $\delta_t$ the stage discount. The price carries
+**no** duration factor because $\beta$ is an absolute tonnage (contrast
+the free-allocation rate $\phi$, whose energy-row coefficient is
+$\Delta_b$). The marginal allowance value — the dual of the bank
+balance — is thus capped at $\rho_{a,t,b}$: the LP abates only while
+abatement is cheaper than buying.
 
 Because the bank obeys $e_{a,s,t,b} \geq \underline{E}_a$ (default
 $0$) at every block and an optional terminal target

--- a/include/gtopt/allowance_pool_lp.hpp
+++ b/include/gtopt/allowance_pool_lp.hpp
@@ -19,12 +19,20 @@
  *     stages), with ``emin`` / ``emax`` / ``efin`` / ``efin_cost``
  *     handled by the base.
  *
- * Phase 3 will add: ``EmissionZone.production`` outflow stamping
- * into the per-block energy rows, replacing the standalone
- * ``EmissionZone.cap`` row with a pool-mediated cap.
+ * Phase 3 (done): ``EmissionZone.production`` outflow stamping into
+ * the per-block energy rows, replacing the standalone
+ * ``EmissionZone.cap`` row with a pool-mediated cap.  Wired from the
+ * zone side (``EmissionZoneLP::add_to_lp``) into this pool's
+ * ``energy_rows_at``.
  *
- * Phase 4 will add: optional auction-purchase column priced at
- * ``auction_price`` and capped by ``auction_cap``.
+ * Phase 4 (this file): optional **auction-purchase** column.  When
+ * ``auction_price`` is set, each (scenario, stage, block) gets an
+ * ``auction`` column (absolute tCO₂, ``[0, auction_cap]``) injected as
+ * a ``-1`` inflow into the energy-balance row, priced at
+ * ``auction_price`` [$/tCO₂] (probability × discount weighted; NO
+ * duration — the column is a tonnage, not a rate).  This lets the bank
+ * buy allowances on the market instead of forcing emission abatement
+ * when the marginal allowance value exceeds the auction price.
  */
 
 #pragma once
@@ -44,6 +52,10 @@ public:
   /// LP column name for the free-allocation inflow (per block,
   /// fixed-rate = delivery / stage_duration).
   static constexpr std::string_view FreeAllocationName {"free_allocation"};
+
+  /// LP column name for the auction-purchase inflow (per block,
+  /// absolute tCO₂, ``[0, auction_cap]``, priced at auction_price).
+  static constexpr std::string_view AuctionName {"auction"};
 
   using StorageBase = StorageLP<ObjectLP<AllowancePool>>;
 
@@ -75,11 +87,24 @@ public:
   /// Free-allocation total per stage [tCO₂/stage]; the LP per-block
   /// inflow rate = ``delivery / stage_duration``.
   [[nodiscard]] auto param_delivery(StageUid s) const { return delivery.at(s); }
+  /// Per-(stage, block) market price for buying allowances [$/tCO₂].
+  [[nodiscard]] auto param_auction_price(StageUid s, BlockUid b) const
+  {
+    return auction_price_.at(s, b);
+  }
+  /// Per-(stage, block) cap on allowances purchasable [tCO₂].
+  [[nodiscard]] auto param_auction_cap(StageUid s, BlockUid b) const
+  {
+    return auction_cap_.at(s, b);
+  }
   /// @}
 
 private:
   OptTRealSched delivery;
+  OptTBRealSched auction_price_;
+  OptTBRealSched auction_cap_;
   STBIndexHolder<ColIndex> free_allocation_cols;
+  STBIndexHolder<ColIndex> auction_cols;
 };
 
 // Pin the data-struct constant value so an accidental rename of the

--- a/share/gtopt/naming_dialects.json
+++ b/share/gtopt/naming_dialects.json
@@ -312,6 +312,8 @@
     {"class": "allowance_pool",   "canonical": "eini",              "alt": "initial_bank",        "dialect": "gtopt-legacy"},
     {"class": "allowance_pool",   "canonical": "efin",              "alt": "terminal_bank",       "dialect": "gtopt-legacy"},
     {"class": "allowance_pool",   "canonical": "auction_price",     "alt": "market_price",        "dialect": "gtopt-legacy"},
+    {"class": "allowance_pool",   "canonical": "auction_cap",       "alt": "auction_volume",      "dialect": "gtopt-legacy"},
+    {"class": "allowance_pool",   "canonical": "auction_cap",       "alt": "Auction Volume",      "dialect": "plexos"},
     {"class": "allowance_pool",   "canonical": "delivery",          "alt": "Free Allocation",     "dialect": "plexos"},
 
     {"class": "line",             "canonical": "loss_pwl_layout",   "alt": "pwl_layout",          "dialect": "gtopt-legacy"},

--- a/source/allowance_pool_lp.cpp
+++ b/source/allowance_pool_lp.cpp
@@ -12,6 +12,7 @@
  */
 
 #include <gtopt/allowance_pool_lp.hpp>
+#include <gtopt/cost_helper.hpp>
 #include <gtopt/linear_problem.hpp>
 #include <gtopt/output_context.hpp>
 #include <gtopt/system_context.hpp>
@@ -24,6 +25,10 @@ AllowancePoolLP::AllowancePoolLP(const AllowancePool& pool,
                                  const InputContext& ic)
     : StorageBase(pool, ic, Element::class_name)
     , delivery(ic, Element::class_name, id(), std::move(object().delivery))
+    , auction_price_(
+          ic, Element::class_name, id(), std::move(object().auction_price))
+    , auction_cap_(
+          ic, Element::class_name, id(), std::move(object().auction_cap))
 {
 }
 
@@ -124,6 +129,43 @@ bool AllowancePoolLP::add_to_lp(SystemContext& sc,
   const auto st_key = std::tuple {scenario.uid(), stage.uid()};
   free_allocation_cols[st_key] = std::move(fa_cols);
 
+  // ── Phase 4: auction-purchase columns ─────────────────────────────────
+  // When ``auction_price`` is set on a (stage, block), add an ``auction``
+  // column (absolute tCO₂, ``[0, auction_cap]``) that the LP may buy to
+  // top up the bank instead of abating emissions.  Injected as a ``-1``
+  // inflow into the StorageLP energy rows (mirrors the EmissionZone
+  // production drawdown with the opposite sign).  Priced at
+  // ``auction_price · probability · discount`` — NO duration, because
+  // the column is an absolute tonnage (contrast the ``delivery`` rate,
+  // which carries duration via the StorageLP ``finp`` path).
+  BIndexHolder<ColIndex> au_cols;
+  const auto& energy_rows = energy_rows_at(scenario, stage);
+  const auto disc_prob = CostHelper::cost_factor(
+      scenario.probability_factor(), stage.discount_factor(), 1.0);
+  for (auto&& block : blocks) {
+    const auto buid = block.uid();
+    const auto price = auction_price_.at(stage.uid(), buid);
+    if (!price.has_value()) {
+      continue;
+    }
+    const auto cap =
+        auction_cap_.at(stage.uid(), buid).value_or(LinearProblem::DblMax);
+    const auto col = lp.add_col(SparseCol {
+        .lowb = 0.0,
+        .uppb = cap,
+        .cost = *price * disc_prob,
+        .class_name = Element::class_name.full_name(),
+        .variable_name = AuctionName,
+        .variable_uid = uid(),
+        .context = make_block_context(scenario.uid(), stage.uid(), buid),
+    });
+    au_cols[buid] = col;
+    lp.set_coeff(energy_rows.at(buid), col, -1.0);
+  }
+  if (!au_cols.empty()) {
+    auction_cols[st_key] = std::move(au_cols);
+  }
+
   // Register PAMPL-visible columns.
   if (!free_allocation_cols.at(st_key).empty()) {
     sc.add_ampl_variable(ampl_name,
@@ -132,6 +174,14 @@ bool AllowancePoolLP::add_to_lp(SystemContext& sc,
                          scenario,
                          stage,
                          free_allocation_cols.at(st_key));
+  }
+  if (auction_cols.contains(st_key) && !auction_cols.at(st_key).empty()) {
+    sc.add_ampl_variable(ampl_name,
+                         uid(),
+                         AuctionName,
+                         scenario,
+                         stage,
+                         auction_cols.at(st_key));
   }
 
   return true;
@@ -144,6 +194,11 @@ bool AllowancePoolLP::add_to_output(OutputContext& out) const
   if (!free_allocation_cols.empty()) {
     out.add_col_sol(cname, FreeAllocationName, id(), free_allocation_cols);
     out.add_col_cost(cname, FreeAllocationName, id(), free_allocation_cols);
+  }
+
+  if (!auction_cols.empty()) {
+    out.add_col_sol(cname, AuctionName, id(), auction_cols);
+    out.add_col_cost(cname, AuctionName, id(), auction_cols);
   }
 
   return StorageBase::add_to_output(out, cname);

--- a/test/source/test_allowance_pool_auction.cpp
+++ b/test/source/test_allowance_pool_auction.cpp
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Phase 4 LP integration tests for AllowancePool auction purchases.
+// When `AllowancePool.auction_price` is set, the bank may buy
+// allowances on the market (an `auction` column, absolute tCO₂,
+// `[0, auction_cap]`, injected as a `-1` inflow into the energy-balance
+// row) instead of abating emissions.  The LP abates only while
+// abatement is cheaper than buying.
+//
+// Topology (shared): a dirty-cheap generator g1 ($10/MWh, 0.5 tCO₂/MWh)
+// and a clean-expensive g2 ($50/MWh, 0 tCO₂) serve a 10 MW demand over
+// a 48 h horizon (480 MWh).  A CO₂ EmissionZone is wired to an
+// AllowancePool whose free bank (eini = 100 tCO₂) caps g1 at 200 MWh.
+//
+// Marginal economics: one extra tCO₂ from g1 frees 2 MWh of g1
+// generation that displaces 2 MWh of g2 — a dispatch saving of
+// 2·($50−$10) = $80/tCO₂.  So the LP buys allowances iff the auction
+// price is below $80/tCO₂.
+
+#include <doctest/doctest.h>
+#include <gtopt/allowance_pool_lp.hpp>
+#include <gtopt/json/json_allowance_pool.hpp>
+#include <gtopt/linear_interface.hpp>
+#include <gtopt/simulation_lp.hpp>
+#include <gtopt/system_lp.hpp>
+
+using namespace gtopt;  // NOLINT(google-global-names-in-headers)
+
+namespace test_allowance_pool_auction
+{
+
+Simulation make_2stage_24h_simulation()
+{
+  Simulation sim;
+  sim.block_array.reserve(48);
+  for (int i = 0; i < 48; ++i) {
+    sim.block_array.push_back(Block {.uid = Uid {i}, .duration = 1.0});
+  }
+  sim.stage_array = {
+      {.uid = Uid {0},
+       .first_block = 0,
+       .count_block = 24,
+       .chronological = true},
+      {.uid = Uid {1},
+       .first_block = 24,
+       .count_block = 24,
+       .chronological = true},
+  };
+  sim.scenario_array = {{.uid = Uid {0}}};
+  return sim;
+}
+
+/// Copperplate system + CO₂ zone wired to a pool.  `auction_price < 0`
+/// leaves the auction unset (Phase-3 behaviour); `auction_cap < 0`
+/// leaves the cap at +∞.
+System make_auction_system(double auction_price, double auction_cap = -1.0)
+{
+  System sys;
+  sys.name = "co2_phase4_auction";
+  sys.bus_array = {{.uid = Uid {1}, .name = "b1"}};
+  sys.demand_array = {
+      {.uid = Uid {1}, .name = "d1", .bus = Uid {1}, .capacity = 10.0},
+  };
+  sys.generator_array = {
+      {.uid = Uid {1},
+       .name = "g1_dirty",
+       .bus = Uid {1},
+       .pmin = 0.0,
+       .pmax = 100.0,
+       .gcost = 10.0,
+       .capacity = 100.0},
+      {.uid = Uid {2},
+       .name = "g2_clean",
+       .bus = Uid {1},
+       .pmin = 0.0,
+       .pmax = 100.0,
+       .gcost = 50.0,
+       .capacity = 100.0},
+  };
+  sys.emission_array = {{.uid = Uid {1}, .name = "co2"}};
+  sys.emission_zone_array = {{
+      .uid = Uid {1},
+      .name = "global_co2",
+      .emissions = {{.emission = Uid {1}, .weight = 1.0}},
+      .allowance_pool = OptSingleId {Uid {1}},
+  }};
+  sys.emission_source_array = {{.uid = Uid {1},
+                                .name = "g1_co2",
+                                .generator = OptSingleId {Uid {1}},
+                                .zone = Uid {1},
+                                .emission = Uid {1},
+                                .rate = 0.5}};
+
+  AllowancePool pool {
+      .uid = Uid {1},
+      .name = "co2_pool",
+      .emin = 0.0,
+      .emax = 1.0e6,
+      .eini = 100.0,
+      .capacity = 1.0e6,
+      .use_state_variable = true,
+      .daily_cycle = false,
+  };
+  if (auction_price >= 0.0) {
+    pool.auction_price = auction_price;
+  }
+  if (auction_cap >= 0.0) {
+    pool.auction_cap = auction_cap;
+  }
+  sys.allowance_pool_array = {std::move(pool)};
+  return sys;
+}
+
+double solve_obj(const System& sys)
+{
+  const auto simulation = make_2stage_24h_simulation();
+  PlanningOptions popts;
+  popts.model_options.demand_fail_cost = 1000.0;
+  const PlanningOptionsLP options(popts);
+  SimulationLP simulation_lp(simulation, options);
+  SystemLP system_lp(sys, simulation_lp);
+
+  auto&& li = system_lp.linear_interface();
+  const auto result = li.resolve();
+  if (!result.has_value()) {
+    MESSAGE("resolve error code=" << static_cast<int>(result.error().code)
+                                  << " message=" << result.error().message);
+  }
+  REQUIRE(result.has_value());
+  REQUIRE(result.value() == 0);
+  return li.get_obj_value_raw();
+}
+
+}  // namespace test_allowance_pool_auction
+
+TEST_CASE(
+    "AllowancePool JSON — auction_price / auction_cap round-trip")  // NOLINT
+{
+  constexpr std::string_view js = R"({
+    "uid": 5,
+    "name": "ets_pool",
+    "eini": 100.0,
+    "auction_price": 30.0,
+    "auction_cap": 2.0
+  })";
+  const auto p = daw::json::from_json<AllowancePool>(js);
+  REQUIRE(p.auction_price.has_value());
+  REQUIRE(p.auction_cap.has_value());
+
+  const auto js2 = daw::json::to_json(p);
+  const auto p2 = daw::json::from_json<AllowancePool>(js2);
+  CHECK(p2.auction_price.has_value());
+  CHECK(p2.auction_cap.has_value());
+}
+
+TEST_CASE(
+    "AllowancePool auction: cheap price → LP buys instead of abating")  // NOLINT
+{
+  using namespace test_allowance_pool_auction;
+  // auction_price = $30/tCO₂ < $80 marginal abatement value ⇒ the LP
+  // buys allowances and runs the dirty-cheap g1 for the whole 480 MWh.
+  //   dispatch = 480·$10 = $4 800
+  //   emissions = 240 tCO₂; free bank = 100 ⇒ buy 140 @ $30 = $4 200
+  //   obj = (4 800 + 4 200)/1000 = 9.0   (vs 16.0 with no auction)
+  const auto obj = solve_obj(make_auction_system(/*auction_price=*/30.0));
+  CHECK(obj == doctest::Approx(9.0).epsilon(0.01));
+}
+
+TEST_CASE(
+    "AllowancePool auction: dear price → LP abates instead of buying")  // NOLINT
+{
+  using namespace test_allowance_pool_auction;
+  // auction_price = $200/tCO₂ > $80 ⇒ never worth buying.  The LP
+  // falls back to the Phase-3 outcome: g1 capped at 200 MWh by the
+  // free bank, g2 covers 280 MWh.
+  //   obj = (200·$10 + 280·$50)/1000 = 16.0
+  const auto obj = solve_obj(make_auction_system(/*auction_price=*/200.0));
+  CHECK(obj == doctest::Approx(16.0).epsilon(0.01));
+}
+
+TEST_CASE("AllowancePool auction: cap limits purchases")  // NOLINT
+{
+  using namespace test_allowance_pool_auction;
+  // Cheap price ($30) but auction_cap = 2 tCO₂/block ⇒ at most
+  // 48·2 = 96 tCO₂ bought over the horizon.  Total allowances =
+  // 100 (free) + 96 (auction) = 196 ⇒ g1 ≤ 392 MWh, g2 = 88 MWh.
+  //   dispatch = 392·$10 + 88·$50 = $3 920 + $4 400 = $8 320
+  //   auction  = 96·$30 = $2 880
+  //   obj = (8 320 + 2 880)/1000 = 11.2
+  const auto obj = solve_obj(make_auction_system(/*auction_price=*/30.0,
+                                                 /*auction_cap=*/2.0));
+  CHECK(obj == doctest::Approx(11.2).epsilon(0.01));
+}


### PR DESCRIPTION
## Summary

Completes the cap-and-trade market. When `AllowancePool.auction_price` is set, each (scenario, stage, block) gets an `auction` column — absolute tCO₂, bounded `[0, auction_cap]` — injected as a `-1` inflow into the StorageLP energy-balance row, letting the bank **buy allowances** on the market instead of forcing abatement:

`bank_b = (1-loss)·bank_{b-1} + free_allocation·dur + auction_b − Σ_z production_{z,b}`

Priced at `auction_price · probability · discount` — **no** duration factor, because the column is an absolute tonnage (contrast the free-allocation rate, whose energy-row coefficient carries `dur`). This caps the marginal allowance value (the bank-balance dual) at the auction price: the LP abates only while abatement is cheaper than buying.

**Scope:** this is the BUY side (primary auction), which is what the `auction_price`/`auction_cap` data model supports. A SELL side would need its own price/cap fields and is deferred.

## Changes

| File | Change |
|------|--------|
| `allowance_pool_lp.{hpp,cpp}` | `auction` col + energy-row injection, holders, accessors, PAMPL reg, output |
| `test_allowance_pool_auction.cpp` | 4 new LP integration tests |
| `naming_dialects.json` | `auction_cap ← "auction_volume" / "Auction Volume"` |
| `mathematical-formulation.md` | §5.14 bis extended with the auction term |

(FIELD_META already carried `auction_price`/`auction_cap` from Phase 1; `market_price → auction_price` alias already existed.)

## Test plan

- [x] JSON `auction_price`/`auction_cap` round-trip on `AllowancePool`
- [x] Cheap price ($30 < $80 marginal abatement) → LP buys, runs dirty gen fully (obj 9.0)
- [x] Dear price ($200 > $80) → LP abates, never buys (obj 16.0, = Phase 3 outcome)
- [x] `auction_cap` = 2 t/block binds → partial buy (obj 11.2)
- [x] 3850/3850 C++ unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)