### PR TITLE
test(allowance_pool): cover additive drawdown, price+pool, pure-auction sign

### DIFF
--- a/source/allowance_pool_lp.cpp
+++ b/source/allowance_pool_lp.cpp
@@ -129,7 +129,7 @@ bool AllowancePoolLP::add_to_lp(SystemContext& sc,
   const auto st_key = std::tuple {scenario.uid(), stage.uid()};
   free_allocation_cols[st_key] = std::move(fa_cols);
 
-  // ── Phase 4: auction-purchase columns ─────────────────────────────────
+  // ── Auction-purchase columns ──────────────────────────────────────────
   // When ``auction_price`` is set on a (stage, block), add an ``auction``
   // column (absolute tCO₂, ``[0, auction_cap]``) that the LP may buy to
   // top up the bank instead of abating emissions.  Injected as a ``-1``

--- a/test/source/test_allowance_pool_auction.cpp
+++ b/test/source/test_allowance_pool_auction.cpp
@@ -191,3 +191,31 @@ TEST_CASE("AllowancePool auction: cap limits purchases")  // NOLINT
                                                  /*auction_cap=*/2.0));
   CHECK(obj == doctest::Approx(11.2).epsilon(0.01));
 }
+
+TEST_CASE(
+    "AllowancePool auction: zero free bank → every tonne is bought")  // NOLINT
+{
+  using namespace test_allowance_pool_auction;
+  // Empty initial bank, no free allocation — every tCO₂ must be bought
+  // at the $30 market price.  g1 still serves all 480 MWh because the
+  // all-in cost ($10 dispatch + $30·0.5 = $25/MWh) beats clean g2 ($50).
+  //   emissions = 480·0.5 = 240 tCO₂, all auctioned
+  //   obj = (480·$10 + 240·$30)/1000 = (4800 + 7200)/1000 = 12.0
+  // Also pins the energy-row sign: a +1 (outflow) coefficient bug would
+  // make the bank unfillable, forcing g2 to serve all → obj 24.0.
+  auto sys = make_auction_system(/*auction_price=*/30.0);
+  sys.allowance_pool_array[0].eini = 0.0;
+  CHECK(solve_obj(sys) == doctest::Approx(12.0).epsilon(0.01));
+}
+
+TEST_CASE(
+    "AllowancePool auction: unset price → no auction column built")  // NOLINT
+{
+  using namespace test_allowance_pool_auction;
+  // With auction_price unset the auction branch is skipped entirely;
+  // the pool reverts to the Phase-3 binding bank (eini=100 caps g1 at
+  // 200 MWh, g2 covers 280 MWh).
+  //   obj = (200·$10 + 280·$50)/1000 = 16.0
+  CHECK(solve_obj(make_auction_system(/*auction_price=*/-1.0))
+        == doctest::Approx(16.0).epsilon(0.01));
+}

--- a/test/source/test_allowance_pool_coupling.cpp
+++ b/test/source/test_allowance_pool_coupling.cpp
@@ -125,6 +125,29 @@ System make_coupled_system(double pool_eini, double zone_cap = -1.0)
   return sys;
 }
 
+/// Build the LP for `sys` on the standard 2-stage / 24h simulation,
+/// solve, and return the raw (scaled) objective.  Fails the test on a
+/// solve error.
+double solve_obj(const System& sys)
+{
+  const auto simulation = make_2stage_24h_simulation();
+  PlanningOptions popts;
+  popts.model_options.demand_fail_cost = 1000.0;
+  const PlanningOptionsLP options(popts);
+  SimulationLP simulation_lp(simulation, options);
+  SystemLP system_lp(sys, simulation_lp);
+
+  auto&& li = system_lp.linear_interface();
+  const auto result = li.resolve();
+  if (!result.has_value()) {
+    MESSAGE("resolve error code=" << static_cast<int>(result.error().code)
+                                  << " message=" << result.error().message);
+  }
+  REQUIRE(result.has_value());
+  REQUIRE(result.value() == 0);
+  return li.get_obj_value_raw();
+}
+
 }  // namespace test_allowance_pool_coupling
 
 TEST_CASE("EmissionZone JSON — allowance_pool FK round-trips")  // NOLINT
@@ -233,4 +256,128 @@ TEST_CASE(  // NOLINT
 
   const auto obj = li.get_obj_value_raw();
   CHECK(obj == doctest::Approx(4.8).epsilon(0.01));
+}
+
+TEST_CASE("AllowancePool coupling: zone references pool by NAME")  // NOLINT
+{
+  using namespace test_allowance_pool_coupling;
+  // The `allowance_pool` FK must resolve by element name, not only uid.
+  // First confirm the JSON parses the string form into a Name variant,
+  // then confirm the LP path resolves it (same binding bank ⇒ 16.0).
+  constexpr std::string_view js = R"({
+    "uid": 1, "name": "z", "emission": "co2", "allowance_pool": "co2_pool"
+  })";
+  const auto z = daw::json::from_json<EmissionZone>(js);
+  REQUIRE(z.allowance_pool.has_value());
+  CHECK(std::holds_alternative<Name>(*z.allowance_pool));
+  CHECK(std::get<Name>(*z.allowance_pool) == "co2_pool");
+
+  auto sys = make_coupled_system(/*pool_eini=*/100.0);
+  sys.emission_zone_array[0].allowance_pool = OptSingleId {Name {"co2_pool"}};
+  CHECK(solve_obj(sys) == doctest::Approx(16.0).epsilon(0.01));
+}
+
+TEST_CASE(  // NOLINT
+    "AllowancePool coupling: two zones drain one shared pool additively")
+{
+  using namespace test_allowance_pool_coupling;
+  // g1 and g2 are identical dirty-cheap units (0.5 t/MWh, $10), each in
+  // its own EmissionZone, both pointing at ONE pool (eini = 100 t).  g3
+  // is a clean backstop ($50).  The shared bank caps COMBINED emissions
+  // at 100 t ⇒ g1+g2 ≤ 200 MWh; g3 serves the remaining 280 MWh.
+  //   obj = (200·$10 + 280·$50)/1000 = 16.0
+  // If the two zones' drawdowns OVERWROTE (instead of accumulating) on
+  // the shared energy row, only one generator would be capped and the
+  // other would serve all 480 MWh at $10 ⇒ obj 4.8.  The 16.0 golden
+  // proves the production columns add into the same row.
+  System sys;
+  sys.name = "co2_two_zone_pool";
+  sys.bus_array = {{.uid = Uid {1}, .name = "b1"}};
+  sys.demand_array = {
+      {.uid = Uid {1}, .name = "d1", .bus = Uid {1}, .capacity = 10.0},
+  };
+  sys.generator_array = {
+      {.uid = Uid {1},
+       .name = "g1",
+       .bus = Uid {1},
+       .pmin = 0.0,
+       .pmax = 100.0,
+       .gcost = 10.0,
+       .capacity = 100.0},
+      {.uid = Uid {2},
+       .name = "g2",
+       .bus = Uid {1},
+       .pmin = 0.0,
+       .pmax = 100.0,
+       .gcost = 10.0,
+       .capacity = 100.0},
+      {.uid = Uid {3},
+       .name = "g3_clean",
+       .bus = Uid {1},
+       .pmin = 0.0,
+       .pmax = 100.0,
+       .gcost = 50.0,
+       .capacity = 100.0},
+  };
+  sys.emission_array = {{.uid = Uid {1}, .name = "co2"}};
+  sys.emission_zone_array = {
+      {.uid = Uid {1},
+       .name = "z1",
+       .emissions = {{.emission = Uid {1}, .weight = 1.0}},
+       .allowance_pool = OptSingleId {Uid {1}}},
+      {.uid = Uid {2},
+       .name = "z2",
+       .emissions = {{.emission = Uid {1}, .weight = 1.0}},
+       .allowance_pool = OptSingleId {Uid {1}}},
+  };
+  sys.emission_source_array = {
+      {.uid = Uid {1},
+       .name = "g1_co2",
+       .generator = OptSingleId {Uid {1}},
+       .zone = Uid {1},
+       .emission = Uid {1},
+       .rate = 0.5},
+      {.uid = Uid {2},
+       .name = "g2_co2",
+       .generator = OptSingleId {Uid {2}},
+       .zone = Uid {2},
+       .emission = Uid {1},
+       .rate = 0.5},
+  };
+  sys.allowance_pool_array = {
+      {.uid = Uid {1},
+       .name = "co2_pool",
+       .emin = 0.0,
+       .emax = 1.0e6,
+       .eini = 100.0,
+       .capacity = 1.0e6,
+       .use_state_variable = true,
+       .daily_cycle = false},
+  };
+  CHECK(solve_obj(sys) == doctest::Approx(16.0).epsilon(0.01));
+}
+
+TEST_CASE(  // NOLINT
+    "AllowancePool coupling: per-ton price coexists with pool drawdown")
+{
+  using namespace test_allowance_pool_coupling;
+  // `price` (carbon tax on the production column) and `allowance_pool`
+  // (bank drawdown) wire independently — both must apply together.
+  SUBCASE("ample bank — tax applies to the full emissions")
+  {
+    // Bank ≫ demand ⇒ g1 serves all 480 MWh (240 tCO₂).  All-in g1 cost
+    // = $10 + $20·0.5 = $20/MWh, still below clean g2 ($50).
+    //   obj = (480·$10 + 240·$20)/1000 = (4800 + 4800)/1000 = 9.6
+    auto sys = make_coupled_system(/*pool_eini=*/1.0e6);
+    sys.emission_zone_array[0].price = 20.0;
+    CHECK(solve_obj(sys) == doctest::Approx(9.6).epsilon(0.01));
+  }
+  SUBCASE("binding bank — tax applies only to the abated 100 tCO₂")
+  {
+    // Bank caps g1 at 200 MWh (100 tCO₂); g2 covers 280 MWh.
+    //   obj = 16.0 (dispatch) + 100·$20/1000 = 16.0 + 2.0 = 18.0
+    auto sys = make_coupled_system(/*pool_eini=*/100.0);
+    sys.emission_zone_array[0].price = 20.0;
+    CHECK(solve_obj(sys) == doctest::Approx(18.0).epsilon(0.01));
+  }
 }


### PR DESCRIPTION
## Summary

Expands CO₂ allowance-pool test coverage on the LP-correctness paths the initial Phase 3/4 PRs left untested, plus a small comment cleanup. No production-behaviour change.

**New tests** (5):
- **zone references pool by NAME** — JSON parses the string FK into a `Name` variant and the LP resolves it end-to-end (obj 16.0).
- **two zones → one shared pool** — production columns must accumulate additively into the same energy row; golden 16.0 distinguishes correct behaviour from an overwrite bug (which would give 4.8).
- **`price` + `allowance_pool` coexist** — ample bank ⇒ carbon tax on full 240 t (obj 9.6); binding bank ⇒ tax on the abated 100 t (obj 18.0).
- **zero free bank** — every tonne is bought at auction (obj 12.0); also pins the energy-row sign (a `+1` outflow bug would force all-clean dispatch ⇒ 24.0).
- **unset `auction_price`** — no auction column built; Phase-3 banking fallback (obj 16.0).

**Cleanup:** shared `solve_obj(System)` helper in the coupling test namespace; dropped a rot-prone "Phase 4:" task-reference from an inline comment.

## Test plan

- [x] 3855/3855 C++ unit tests pass (5 new, all with exact reasoned goldens)
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)