### PR TITLE
feat(ots): v1.2 — min_up_time/min_down_time/max_starts (issue #509)

### DIFF
--- a/include/gtopt/json/json_line_commitment.hpp
+++ b/include/gtopt/json/json_line_commitment.hpp
@@ -15,26 +15,39 @@
 namespace daw::json
 {
 using gtopt::LineCommitment;
+using gtopt::OptStartsScope;
+
+// Two-shape lookup for ``LineCommitment.starts_scope`` — same shape
+// as ``Commitment.starts_scope`` (see ``json_commitment.hpp``).  The
+// alternative ordering matches ``OptStartsScope = optional<variant<
+// Int, Name>>`` exactly so daw::json's index ↔ list correspondence
+// holds bidirectionally.
+using jvtl_LineStartsScope = json_variant_type_list<Int, Name>;
 
 template<>
 struct json_data_contract<LineCommitment>
 {
-  using type =
-      json_member_list<json_number<"uid", Uid>,
-                       json_string<"name", Name>,
-                       json_variant_null<"active", OptActive, jvtl_Active>,
-                       json_string_null<"type", OptName>,
-                       json_string_null<"description", OptName>,
-                       json_variant<"line", SingleId>,
-                       json_number_null<"initial_status", OptReal>,
-                       json_bool_null<"must_run", OptBool>,
-                       json_variant_null<"fixed_status",
-                                         OptTBRealFieldSched,
-                                         jvtl_TBRealFieldSched>,
-                       json_bool_null<"relax", OptBool>,
-                       json_number_null<"kvl_big_m", OptReal>,
-                       json_number_null<"startup_cost", OptReal>,
-                       json_number_null<"shutdown_cost", OptReal>>;
+  using type = json_member_list<
+      json_number<"uid", Uid>,
+      json_string<"name", Name>,
+      json_variant_null<"active", OptActive, jvtl_Active>,
+      json_string_null<"type", OptName>,
+      json_string_null<"description", OptName>,
+      json_variant<"line", SingleId>,
+      json_number_null<"initial_status", OptReal>,
+      json_bool_null<"must_run", OptBool>,
+      json_variant_null<"fixed_status",
+                        OptTBRealFieldSched,
+                        jvtl_TBRealFieldSched>,
+      json_bool_null<"relax", OptBool>,
+      json_number_null<"kvl_big_m", OptReal>,
+      json_number_null<"startup_cost", OptReal>,
+      json_number_null<"shutdown_cost", OptReal>,
+      json_number_null<"min_up_time", OptReal>,
+      json_number_null<"min_down_time", OptReal>,
+      json_number_null<"max_starts", OptInt>,
+      json_number_null<"min_starts", OptInt>,
+      json_variant_null<"starts_scope", OptStartsScope, jvtl_LineStartsScope>>;
 
   constexpr static auto to_json_data(LineCommitment const& obj)
   {
@@ -50,7 +63,12 @@ struct json_data_contract<LineCommitment>
                                  obj.relax,
                                  obj.kvl_big_m,
                                  obj.startup_cost,
-                                 obj.shutdown_cost);
+                                 obj.shutdown_cost,
+                                 obj.min_up_time,
+                                 obj.min_down_time,
+                                 obj.max_starts,
+                                 obj.min_starts,
+                                 obj.starts_scope);
   }
 };
 

--- a/include/gtopt/line_commitment.hpp
+++ b/include/gtopt/line_commitment.hpp
@@ -89,11 +89,20 @@ namespace gtopt
  *      baseline; iterative tightening per Pineda 2024 [3] is a v1
  *      follow-up that writes back to ``kvl_big_m``).
  *
- * v0 (this commit) ships ONLY the capacity gating + KVL big-M
- * disjunction.  The u/v/w 3-bin transition logic, min-up / min-down
- * times, max-starts windows, and the indicator-constraint alternative
- * (PowerModels.jl-style IND+) land in follow-up commits — see issue
- * #509 §"Implementation roadmap".
+ * Roadmap status (see issue #509):
+ *   * v0   — capacity gating.
+ *   * v0.5 — node_angle KVL big-M disjunction.
+ *   * v1   — cycle_basis KVL big-M disjunction (both Kirchhoff modes
+ *            now supported); per-line ``kvl_big_m`` override.
+ *   * v1.1 — u/v/w three-binary decomposition with
+ *            ``startup_cost`` / ``shutdown_cost``.
+ *   * v1.2 — ``min_up_time`` / ``min_down_time`` anti-flicker rows,
+ *            ``max_starts`` / ``min_starts`` / ``starts_scope``
+ *            rolling-window cap (mirroring ``Commitment``).
+ *
+ * Deferred for v1.3+: PowerModels.jl IND+ indicator-constraint
+ * alternative, iterative big-M tightening (Pineda 2024 [3] pre-solve
+ * that writes back to ``kvl_big_m``), startup tiers.
  *
  * ### References
  *

--- a/include/gtopt/line_commitment.hpp
+++ b/include/gtopt/line_commitment.hpp
@@ -57,6 +57,7 @@
 
 #pragma once
 
+#include <gtopt/commitment.hpp>  // for StartsScope / OptStartsScope
 #include <gtopt/enum_option.hpp>
 #include <gtopt/lp_class_name.hpp>
 #include <gtopt/object.hpp>
@@ -189,6 +190,85 @@ struct LineCommitment
   /// decomposition.  Both default to zero (no event cost ⇒ the
   /// simple ``u_l``-only form remains in use).
   OptReal shutdown_cost {};
+
+  /// Minimum up time [hours].  Mirrors ``Commitment::min_up_time``.
+  /// Once the breaker closes (``v_l[t] = 1``), the LP must keep
+  /// ``u_l = 1`` for at least ``min_up_time`` hours starting at
+  /// block ``t``.  Emitted as the row family
+  ///   Σ_{q=t}^{t + UT_blocks − 1} u_l[q] ≥ UT_blocks · v_l[t]
+  /// where ``UT_blocks`` is the smallest number of forward blocks
+  /// whose cumulative duration covers ``min_up_time``.  Trivially
+  /// satisfied (and skipped) when the window collapses to 1 block.
+  /// Requires u/v/w (``startup_cost`` or ``shutdown_cost`` set);
+  /// silently inert when u/v/w is off.
+  OptReal min_up_time {};
+
+  /// Minimum down time [hours].  Mirrors ``Commitment::min_down_time``.
+  /// Symmetric to ``min_up_time``: once the breaker opens
+  /// (``w_l[t] = 1``), the LP must keep ``u_l = 0`` for at least
+  /// ``min_down_time`` hours.  Emitted as
+  ///   Σ_{q=t}^{t + DT_blocks − 1} u_l[q] + DT_blocks · w_l[t]
+  ///       ≤ DT_blocks
+  /// where ``DT_blocks`` covers ``min_down_time`` hours starting at
+  /// block ``t``.  Same activation gate as ``min_up_time``.
+  OptReal min_down_time {};
+
+  /// Upper bound on the number of CLOSE events (``v_l = 1``) over a
+  /// rolling time window.  Mirrors ``Commitment::max_starts`` (PLEXOS
+  /// "Max Starts {Hour|Day|Week|Month|Year}").  Emitted as one row
+  /// per window:
+  ///   Σ_{t ∈ window} v_l[t] ≤ max_starts
+  /// Window length is resolved by the SHARED ``starts_scope`` —
+  /// see ``LineCommitment::starts_window_hours``.
+  OptInt max_starts {};
+
+  /// Lower bound on the number of CLOSE events (``v_l = 1``) over a
+  /// rolling time window.  Mirrors ``Commitment::min_starts``.  Both
+  /// bounds share the same window LHS:
+  ///   min_starts ≤ Σ_{t ∈ window} v_l[t] ≤ max_starts
+  /// Unset ⇒ no lower row emitted (effectively 0).
+  OptInt min_starts {};
+
+  /// Window-scope for ``max_starts`` / ``min_starts``.  Mirrors
+  /// ``Commitment::starts_scope`` — accepts either the named enum
+  /// (``"hour" | "day" | "week" | "horizon"``; aliases ``"month"``
+  /// and ``"year"`` collapse to horizon) or an integer hour count
+  /// (e.g. ``48`` for 2 days).  Resolved at LP-build time by
+  /// ``starts_window_hours()``.  Unset / unknown ⇒ horizon (one row
+  /// per stage).
+  OptStartsScope starts_scope {};
+
+  /// Resolve ``starts_scope`` to a window length in hours.  Mirrors
+  /// ``Commitment::starts_window_hours()``: integer values pass
+  /// through verbatim; named values map ``hour → 1``, ``day → 24``,
+  /// ``week → 168``, ``horizon → 0`` (sentinel "never flush until
+  /// stage end").  Unrecognised names / unset both return ``0``.
+  [[nodiscard]] constexpr double starts_window_hours() const noexcept
+  {
+    if (!starts_scope.has_value()) {
+      return 0.0;
+    }
+    if (std::holds_alternative<Int>(*starts_scope)) {
+      const auto h = std::get<Int>(*starts_scope);
+      return h > 0 ? static_cast<double>(h) : 0.0;
+    }
+    const auto& name = std::get<Name>(*starts_scope);
+    const auto resolved = enum_from_name<StartsScope>(name);
+    if (!resolved.has_value()) {
+      return 0.0;
+    }
+    switch (*resolved) {
+      case StartsScope::Hour:
+        return 1.0;
+      case StartsScope::Day:
+        return 24.0;
+      case StartsScope::Week:
+        return 7.0 * 24.0;
+      case StartsScope::Horizon:
+        return 0.0;
+    }
+    return 0.0;
+  }
 };
 
 }  // namespace gtopt

--- a/include/gtopt/line_commitment_lp.hpp
+++ b/include/gtopt/line_commitment_lp.hpp
@@ -33,6 +33,16 @@
  *     replaced by two inequalities with per-cycle big-M
  *     ``M_C = 2·θ_max · |C| · row_scale + Σ |φ_e| · row_scale``.
  *
+ * **v1.2 scope additions** (mirroring ``CommitmentLP``):
+ *   - **min_up_time** [hours] — anti-flicker: Σ_{q ∈ window} u[q]
+ *     ≥ UT · v[t], where UT is the smallest block-window covering
+ *     ``min_up_time`` hours.  Trivially satisfied (skipped) when
+ *     UT ≤ 1.  Requires u/v/w (silently inert otherwise).
+ *   - **min_down_time** [hours] — symmetric down-time guard.
+ *   - **max_starts** / **min_starts** — two-sided rolling cap on
+ *     Σ_{t ∈ window} v[t].  Window length resolved from
+ *     ``starts_scope`` via ``starts_window_hours()``.
+ *
  * **Mode gates** (enforced by ``validate_planning``):
  *   - ``method ∈ {sddp, cascade}`` is rejected — Benders cuts on a
  *     mixed-integer subproblem are unsound (Zou-Ahmed-Sun 2019).
@@ -71,6 +81,10 @@ public:
   /// C3 exclusion row: ``v[t] + w[t] ≤ 1`` (mutual exclusion of the
   /// startup and shutdown indicators).
   static constexpr std::string_view ExclusionName {"exclusion"};
+  /// v1.2 time-based constraint labels (mirror ``CommitmentLP``).
+  static constexpr std::string_view MinUpTimeName {"min_up_time"};
+  static constexpr std::string_view MinDownTimeName {"min_down_time"};
+  static constexpr std::string_view MaxStartsName {"max_starts"};
 
   using Base = ObjectLP<LineCommitment>;
 
@@ -115,6 +129,11 @@ private:
   STBIndexHolder<ColIndex> shutdown_cols_;
   STBIndexHolder<RowIndex> logic_rows_;
   STBIndexHolder<RowIndex> exclusion_rows_;
+  /// v1.2 time-based row holders.  Only populated when the
+  /// corresponding schema field is set AND u/v/w is active.
+  STBIndexHolder<RowIndex> min_up_time_rows_;
+  STBIndexHolder<RowIndex> min_down_time_rows_;
+  STBIndexHolder<RowIndex> max_starts_rows_;
 };
 
 // Pin the data-struct constant value so an accidental rename of the

--- a/source/line_commitment_lp.cpp
+++ b/source/line_commitment_lp.cpp
@@ -526,6 +526,178 @@ bool LineCommitmentLP::add_to_lp(SystemContext& sc,
     if (!erows.empty()) {
       exclusion_rows_[st_key] = std::move(erows);
     }
+
+    // ── (v1.2) Min up time ──────────────────────────────────────────
+    // Σ_{q=t..t+UT-1} u[q] ≥ UT · v[t].
+    // UT (in blocks) is the smallest k s.t. Σ duration[t..t+k-1] ≥ min_up_time.
+    // Trivially satisfied when UT ≤ 1 (skip the row).  Mirrors
+    // ``CommitmentLP`` C6.
+    const double min_up_hours = lc.min_up_time.value_or(0.0);
+    const auto& v_holder = startup_cols_.find(st_key);
+    const bool have_v_cols =
+        (v_holder != startup_cols_.end()) && !v_holder->second.empty();
+    if (min_up_hours > 0.0 && have_v_cols) {
+      BIndexHolder<RowIndex> mut_rows;
+      map_reserve(mut_rows, blocks.size());
+      for (size_t t = 0; t < blocks.size(); ++t) {
+        const auto buid_t = blocks[t].uid();
+        const auto v_it = v_holder->second.find(buid_t);
+        if (v_it == v_holder->second.end()) {
+          continue;
+        }
+        // Forward-walk to find UT (in blocks) covering min_up_hours.
+        double acc = 0.0;
+        size_t ut = 0;
+        for (size_t q = t; q < blocks.size() && acc < min_up_hours; ++q) {
+          acc += blocks[q].duration();
+          ++ut;
+        }
+        if (ut <= 1) {
+          continue;
+        }
+        SparseRow row {
+            .class_name = cname,
+            .constraint_name = MinUpTimeName,
+            .variable_uid = cuid,
+            .context = make_block_context(scenario.uid(), stage.uid(), buid_t),
+        };
+        row.greater_equal(0.0);
+        for (size_t q = t; q < t + ut && q < blocks.size(); ++q) {
+          const auto u_it = ucols.find(blocks[q].uid());
+          if (u_it != ucols.end()) {
+            row[u_it->second] = 1.0;
+          }
+        }
+        row[v_it->second] = -static_cast<double>(ut);
+        mut_rows[buid_t] = lp.add_row(std::move(row));
+      }
+      if (!mut_rows.empty()) {
+        min_up_time_rows_[st_key] = std::move(mut_rows);
+      }
+    }
+
+    // ── (v1.2) Min down time ────────────────────────────────────────
+    // Σ_{q=t..t+DT-1} u[q] + DT · w[t] ≤ span.
+    // Derived from Σ (1 − u[q]) ≥ DT · w[t] over the DT-block window.
+    // Mirrors ``CommitmentLP`` C7.
+    const double min_down_hours = lc.min_down_time.value_or(0.0);
+    const auto& w_holder = shutdown_cols_.find(st_key);
+    const bool have_w_cols =
+        (w_holder != shutdown_cols_.end()) && !w_holder->second.empty();
+    if (min_down_hours > 0.0 && have_w_cols) {
+      BIndexHolder<RowIndex> mdt_rows;
+      map_reserve(mdt_rows, blocks.size());
+      for (size_t t = 0; t < blocks.size(); ++t) {
+        const auto buid_t = blocks[t].uid();
+        const auto w_it = w_holder->second.find(buid_t);
+        if (w_it == w_holder->second.end()) {
+          continue;
+        }
+        double acc = 0.0;
+        size_t dt = 0;
+        for (size_t q = t; q < blocks.size() && acc < min_down_hours; ++q) {
+          acc += blocks[q].duration();
+          ++dt;
+        }
+        if (dt <= 1) {
+          continue;
+        }
+        const auto span = std::min(t + dt, blocks.size()) - t;
+        SparseRow row {
+            .class_name = cname,
+            .constraint_name = MinDownTimeName,
+            .variable_uid = cuid,
+            .context = make_block_context(scenario.uid(), stage.uid(), buid_t),
+        };
+        row.less_equal(static_cast<double>(span));
+        for (size_t q = t; q < t + dt && q < blocks.size(); ++q) {
+          const auto u_it = ucols.find(blocks[q].uid());
+          if (u_it != ucols.end()) {
+            row[u_it->second] = 1.0;
+          }
+        }
+        row[w_it->second] = static_cast<double>(dt);
+        mdt_rows[buid_t] = lp.add_row(std::move(row));
+      }
+      if (!mdt_rows.empty()) {
+        min_down_time_rows_[st_key] = std::move(mdt_rows);
+      }
+    }
+
+    // ── (v1.2) max_starts / min_starts rolling-window cap ───────────
+    // Two-sided bound:
+    //   min_starts ≤ Σ_{t ∈ window} v[t] ≤ max_starts
+    // Window length resolved from ``starts_scope`` via
+    // ``starts_window_hours()``: 0 (or unset) ⇒ horizon (one row per
+    // stage); positive N ⇒ flush when accumulated block duration ≥ N.
+    // Mirrors ``CommitmentLP`` C9.
+    const bool has_max_starts = lc.max_starts.has_value();
+    const bool has_min_starts = lc.min_starts.has_value();
+    if ((has_max_starts || has_min_starts) && have_v_cols) {
+      const double window_hours = lc.starts_window_hours();
+      const auto max_starts_v =
+          has_max_starts ? static_cast<double>(*lc.max_starts) : 0.0;
+      const auto min_starts_v =
+          has_min_starts ? static_cast<double>(*lc.min_starts) : 0.0;
+
+      BIndexHolder<RowIndex> ms_rows;
+      auto fresh_row = [&]() -> SparseRow
+      {
+        SparseRow r;
+        r.class_name = cname;
+        r.constraint_name = MaxStartsName;
+        r.variable_uid = cuid;
+        return r;
+      };
+      SparseRow window_row = fresh_row();
+      bool row_open = false;
+      double acc_hours = 0.0;
+      BlockUid window_end_block {};
+
+      auto flush_window = [&]()
+      {
+        if (!row_open) {
+          return;
+        }
+        if (has_max_starts) {
+          SparseRow upper {window_row};
+          auto bound = std::move(upper).less_equal(max_starts_v);
+          const auto idx = lp.add_row(std::move(bound));
+          ms_rows[window_end_block] = idx;
+        }
+        if (has_min_starts) {
+          SparseRow lower {window_row};
+          auto bound = std::move(lower).greater_equal(min_starts_v);
+          [[maybe_unused]] const auto lower_idx = lp.add_row(std::move(bound));
+        }
+        window_row = fresh_row();
+        row_open = false;
+        acc_hours = 0.0;
+      };
+
+      for (const auto& block : blocks) {
+        const auto buid_b = block.uid();
+        const auto v_it = v_holder->second.find(buid_b);
+        if (v_it == v_holder->second.end()) {
+          continue;
+        }
+        if (!row_open) {
+          window_row.context =
+              make_block_context(scenario.uid(), stage.uid(), buid_b);
+          row_open = true;
+        }
+        window_row[v_it->second] = 1.0;
+        acc_hours += block.duration();
+        window_end_block = buid_b;
+        if (window_hours > 0.0 && acc_hours >= window_hours) {
+          flush_window();
+        }
+      }
+      flush_window();
+      if (!ms_rows.empty()) {
+        max_starts_rows_[st_key] = std::move(ms_rows);
+      }
+    }
   }
 
   // Store index holders.
@@ -573,6 +745,12 @@ bool LineCommitmentLP::add_to_output(OutputContext& out) const
   out.add_col_cost(cname, ShutdownName, pid, shutdown_cols_);
   out.add_row_dual(cname, LogicName, pid, logic_rows_);
   out.add_row_dual(cname, ExclusionName, pid, exclusion_rows_);
+
+  // v1.2 time-based row duals (empty when the corresponding schema
+  // field is unset; ``add_row_dual`` no-ops on empty holders).
+  out.add_row_dual(cname, MinUpTimeName, pid, min_up_time_rows_);
+  out.add_row_dual(cname, MinDownTimeName, pid, min_down_time_rows_);
+  out.add_row_dual(cname, MaxStartsName, pid, max_starts_rows_);
 
   return true;
 }

--- a/test/source/test_line_commitment.cpp
+++ b/test/source/test_line_commitment.cpp
@@ -888,3 +888,250 @@ TEST_CASE("LineCommitment JSON round-trip — startup_cost + shutdown_cost")
   CHECK(lc2.startup_cost.value_or(-1.0) == doctest::Approx(250.5));
   CHECK(lc2.shutdown_cost.value_or(-1.0) == doctest::Approx(75.0));
 }
+
+// ── (10) v1.2: min_up_time / min_down_time / max_starts ─────────────
+//
+// Anti-flicker + rolling-window cap, mirroring CommitmentLP's C6/C7/C9.
+
+[[nodiscard]] std::string make_5block_uvw_extras_json(
+    double startup_cost,
+    double shutdown_cost,
+    double initial_status,
+    double min_up_time,
+    double min_down_time,
+    int max_starts,
+    const std::string& starts_scope_str)
+{
+  std::string out = R"({
+    "options": {
+      "annual_discount_rate": 0.0,
+      "output_format": "csv",
+      "output_compression": "uncompressed",
+      "model_options": {
+        "use_single_bus": false,
+        "use_kirchhoff": false,
+        "scale_objective": 1000,
+        "demand_fail_cost": 1000
+      }
+    },
+    "simulation": {
+      "block_array": [
+        { "uid": 1, "duration": 1 },
+        { "uid": 2, "duration": 1 },
+        { "uid": 3, "duration": 1 },
+        { "uid": 4, "duration": 1 },
+        { "uid": 5, "duration": 1 }
+      ],
+      "stage_array": [
+        { "uid": 1, "first_block": 0, "count_block": 5,
+          "active": 1, "chronological": true }
+      ],
+      "scenario_array": [{ "uid": 1, "probability_factor": 1 }]
+    },
+    "system": {
+      "name": "ots_uvw_extras",
+      "bus_array": [
+        { "uid": 1, "name": "b1" },
+        { "uid": 2, "name": "b2" }
+      ],
+      "generator_array": [
+        { "uid": 1, "name": "g1", "bus": "b1", "pmin": 0, "pmax": 500, "gcost": 10, "capacity": 500 }
+      ],
+      "demand_array": [
+        { "uid": 1, "name": "d2", "bus": "b2",
+          "lmax": [[100.0, 100.0, 100.0, 100.0, 100.0]] }
+      ],
+      "line_array": [
+        { "uid": 1, "name": "l1_2", "bus_a": "b1", "bus_b": "b2",
+          "tmax_ab": 100, "tmax_ba": 100 }
+      ],
+      "line_commitment_array": [
+        { "uid": 1, "name": "l1_2_ots", "line": "l1_2", "relax": true,
+          "initial_status": )";
+  out += std::to_string(initial_status);
+  out += R"(, "startup_cost": )";
+  out += std::to_string(startup_cost);
+  out += R"(, "shutdown_cost": )";
+  out += std::to_string(shutdown_cost);
+  if (min_up_time > 0.0) {
+    out += R"(, "min_up_time": )";
+    out += std::to_string(min_up_time);
+  }
+  if (min_down_time > 0.0) {
+    out += R"(, "min_down_time": )";
+    out += std::to_string(min_down_time);
+  }
+  if (max_starts >= 0) {
+    out += R"(, "max_starts": )";
+    out += std::to_string(max_starts);
+    if (!starts_scope_str.empty()) {
+      out += R"(, "starts_scope": ")";
+      out += starts_scope_str;
+      out += R"(")";
+    }
+  }
+  out += R"( }
+      ]
+    }
+  })";
+  return out;
+}
+
+TEST_CASE(
+    "LineCommitmentLP v1.2: min_up_time emits row family per block (v1.2)")
+{
+  if (!mip_available()) {
+    MESSAGE("Skipping MIP test — no MIP solver available");
+    return;
+  }
+  // min_up_time = 3 hours over 5 unit-duration blocks ⇒ UT ≥ 2 at
+  // every block except the last (only 1 block remains, UT = 1 ⇒ skip
+  // trivially-satisfied row).  Expected = 4 rows.
+  Planning planning;
+  planning.merge(parse_planning_json(make_5block_uvw_extras_json(
+      /*startup_cost=*/100.0,
+      /*shutdown_cost=*/50.0,
+      /*initial_status=*/0.0,
+      /*min_up_time=*/3.0,
+      /*min_down_time=*/0.0,
+      /*max_starts=*/-1,
+      /*starts_scope_str=*/"")));
+  LpMatrixOptions flat_opts;
+  flat_opts.row_with_names = true;
+  flat_opts.row_with_name_map = true;
+  PlanningLP planning_lp(std::move(planning), flat_opts);
+  REQUIRE(planning_lp.resolve().has_value());
+  const auto& li = planning_lp.systems().front().front().linear_interface();
+  CHECK(tlcom_count_rows_containing(li, "linecommitment_min_up_time") == 4);
+}
+
+TEST_CASE(
+    "LineCommitmentLP v1.2: min_down_time emits row family per block "
+    "symmetric to min_up_time (v1.2)")
+{
+  if (!mip_available()) {
+    MESSAGE("Skipping MIP test — no MIP solver available");
+    return;
+  }
+  Planning planning;
+  planning.merge(parse_planning_json(make_5block_uvw_extras_json(
+      /*startup_cost=*/100.0,
+      /*shutdown_cost=*/50.0,
+      /*initial_status=*/1.0,
+      /*min_up_time=*/0.0,
+      /*min_down_time=*/3.0,
+      /*max_starts=*/-1,
+      /*starts_scope_str=*/"")));
+  LpMatrixOptions flat_opts;
+  flat_opts.row_with_names = true;
+  flat_opts.row_with_name_map = true;
+  PlanningLP planning_lp(std::move(planning), flat_opts);
+  REQUIRE(planning_lp.resolve().has_value());
+  const auto& li = planning_lp.systems().front().front().linear_interface();
+  CHECK(tlcom_count_rows_containing(li, "linecommitment_min_down_time") == 4);
+}
+
+TEST_CASE(
+    "LineCommitmentLP v1.2: max_starts horizon scope emits one row per "
+    "stage (v1.2)")
+{
+  if (!mip_available()) {
+    MESSAGE("Skipping MIP test — no MIP solver available");
+    return;
+  }
+  // starts_scope unset ⇒ horizon = 0 hours ⇒ one window per stage ⇒
+  // 1 max_starts row.
+  Planning planning;
+  planning.merge(parse_planning_json(make_5block_uvw_extras_json(
+      /*startup_cost=*/100.0,
+      /*shutdown_cost=*/50.0,
+      /*initial_status=*/0.0,
+      /*min_up_time=*/0.0,
+      /*min_down_time=*/0.0,
+      /*max_starts=*/2,
+      /*starts_scope_str=*/"")));
+  LpMatrixOptions flat_opts;
+  flat_opts.row_with_names = true;
+  flat_opts.row_with_name_map = true;
+  PlanningLP planning_lp(std::move(planning), flat_opts);
+  REQUIRE(planning_lp.resolve().has_value());
+  const auto& li = planning_lp.systems().front().front().linear_interface();
+  CHECK(tlcom_count_rows_containing(li, "linecommitment_max_starts") == 1);
+}
+
+TEST_CASE(
+    "LineCommitmentLP v1.2: max_starts hour scope emits one row per "
+    "block (v1.2)")
+{
+  if (!mip_available()) {
+    MESSAGE("Skipping MIP test — no MIP solver available");
+    return;
+  }
+  // starts_scope = "hour" with 1-hour blocks ⇒ 5 windows ⇒ 5 rows.
+  Planning planning;
+  planning.merge(parse_planning_json(make_5block_uvw_extras_json(
+      /*startup_cost=*/100.0,
+      /*shutdown_cost=*/50.0,
+      /*initial_status=*/0.0,
+      /*min_up_time=*/0.0,
+      /*min_down_time=*/0.0,
+      /*max_starts=*/1,
+      /*starts_scope_str=*/"hour")));
+  LpMatrixOptions flat_opts;
+  flat_opts.row_with_names = true;
+  flat_opts.row_with_name_map = true;
+  PlanningLP planning_lp(std::move(planning), flat_opts);
+  REQUIRE(planning_lp.resolve().has_value());
+  const auto& li = planning_lp.systems().front().front().linear_interface();
+  CHECK(tlcom_count_rows_containing(li, "linecommitment_max_starts") == 5);
+}
+
+TEST_CASE("LineCommitment JSON round-trip — v1.2 time-based fields")
+{
+  std::string_view json_str = R"({
+    "uid": 7,
+    "name": "lc_v12",
+    "line": "L_18_19",
+    "startup_cost": 100,
+    "min_up_time": 4.5,
+    "min_down_time": 2,
+    "max_starts": 3,
+    "min_starts": 1,
+    "starts_scope": "day"
+  })";
+
+  const auto lc = daw::json::from_json<LineCommitment>(json_str);
+  CHECK(lc.min_up_time.value_or(-1.0) == doctest::Approx(4.5));
+  CHECK(lc.min_down_time.value_or(-1.0) == doctest::Approx(2.0));
+  CHECK(lc.max_starts.value_or(-1) == 3);
+  CHECK(lc.min_starts.value_or(-1) == 1);
+  REQUIRE(lc.starts_scope.has_value());
+  // ``day`` → 24 hours.
+  CHECK(lc.starts_window_hours() == doctest::Approx(24.0));
+
+  const auto out = daw::json::to_json(lc);
+  const auto lc2 = daw::json::from_json<LineCommitment>(out);
+  CHECK(lc2.min_up_time.value_or(-1.0) == doctest::Approx(4.5));
+  CHECK(lc2.max_starts.value_or(-1) == 3);
+  CHECK(lc2.starts_window_hours() == doctest::Approx(24.0));
+}
+
+TEST_CASE("LineCommitment starts_window_hours — direct value cases")
+{
+  LineCommitment lc;
+  lc.starts_scope = StartsScopeValue {Int {48}};
+  CHECK(lc.starts_window_hours() == doctest::Approx(48.0));
+
+  lc.starts_scope = StartsScopeValue {Name {"week"}};
+  CHECK(lc.starts_window_hours() == doctest::Approx(168.0));
+
+  lc.starts_scope = StartsScopeValue {Name {"horizon"}};
+  CHECK(lc.starts_window_hours() == doctest::Approx(0.0));
+
+  lc.starts_scope = std::nullopt;
+  CHECK(lc.starts_window_hours() == doctest::Approx(0.0));
+
+  // Unrecognised name ⇒ horizon (0).
+  lc.starts_scope = StartsScopeValue {Name {"fortnight"}};
+  CHECK(lc.starts_window_hours() == doctest::Approx(0.0));
+}

--- a/test/source/test_line_losses_sos2.cpp
+++ b/test/source/test_line_losses_sos2.cpp
@@ -535,7 +535,7 @@ namespace test_line_losses_sos2_convergence_ns  // NOLINT(cert-dcl59-cpp,fuchsia
 namespace  // NOLINT(cert-dcl59-cpp,fuchsia-header-anon-namespaces,google-build-namespaces,misc-anonymous-namespace-in-header)
 {
 
-constexpr double kEnvelope = 200.0;
+constexpr double kSos2Envelope = 200.0;
 constexpr double kR = 0.01;
 constexpr double kV2 = 100.0 * 100.0;
 constexpr double kCoeff = kR / kV2;  // c = R/V²
@@ -547,7 +547,7 @@ constexpr double kCoeff = kR / kV2;  // c = R/V²
 /// MW (= units of ℓ).
 [[nodiscard]] double sos2_chord_worst_gap(int L)
 {
-  const double w = kEnvelope / static_cast<double>(L);
+  const double w = kSos2Envelope / static_cast<double>(L);
   return kCoeff * (w / 2.0) * (w / 2.0);  // c · (w/2)²
 }
 
@@ -555,7 +555,7 @@ constexpr double kCoeff = kR / kV2;  // c = R/V²
 }  // namespace test_line_losses_sos2_convergence_ns
 
 using test_line_losses_sos2_convergence_ns::kCoeff;
-using test_line_losses_sos2_convergence_ns::kEnvelope;
+using test_line_losses_sos2_convergence_ns::kSos2Envelope;
 using test_line_losses_sos2_convergence_ns::sos2_chord_worst_gap;
 
 TEST_CASE("tangent_signed_flow L-secant: worst-gap shrinks O(1/L²) under SOS2")
@@ -585,7 +585,7 @@ TEST_CASE("tangent_signed_flow L-secant: worst-gap shrinks O(1/L²) under SOS2")
 
   SUBCASE("gap·L² is constant (envelope²·c/4) for every L")
   {
-    const double constant = kCoeff * kEnvelope * kEnvelope / 4.0;
+    const double constant = kCoeff * kSos2Envelope * kSos2Envelope / 4.0;
     CHECK((g1 * 1.0) == doctest::Approx(constant).epsilon(1e-12));
     CHECK((g2 * 4.0) == doctest::Approx(constant).epsilon(1e-12));
     CHECK((g4 * 16.0) == doctest::Approx(constant).epsilon(1e-12));
@@ -596,7 +596,7 @@ TEST_CASE("tangent_signed_flow L-secant: worst-gap shrinks O(1/L²) under SOS2")
   SUBCASE("absolute worst-gap matches c·(envelope/(2L))²")
   {
     for (const int L : {1, 2, 4, 8, 16, 32}) {
-      const double half_w = kEnvelope / (2.0 * static_cast<double>(L));
+      const double half_w = kSos2Envelope / (2.0 * static_cast<double>(L));
       const double predicted = kCoeff * half_w * half_w;
       CHECK(sos2_chord_worst_gap(L)
             == doctest::Approx(predicted).epsilon(1e-12));
@@ -611,7 +611,7 @@ TEST_CASE("tangent_signed_flow L-secant: worst-gap shrinks O(1/L²) under SOS2")
     // peak loss at fmax).  L=4 → gap/L_max = 1/64 ≈ 1.56%.  L=10 →
     // gap/L_max = 1/400 ≈ 0.25%.  Pin the analytic claim so any
     // regression in the chord-formula constants surfaces immediately.
-    const double L_max = kCoeff * kEnvelope * kEnvelope;
+    const double L_max = kCoeff * kSos2Envelope * kSos2Envelope;
     CHECK((sos2_chord_worst_gap(4) / L_max)
           == doctest::Approx(1.0 / 64.0).epsilon(1e-12));
     CHECK((sos2_chord_worst_gap(10) / L_max)
@@ -627,7 +627,7 @@ TEST_CASE(
   // the true quadratic exactly (verified directly from the chord-slope
   // formula).  Used to ground the worst-gap formula above.
   for (const int L : {2, 4, 8}) {
-    const double w = kEnvelope / static_cast<double>(L);
+    const double w = kSos2Envelope / static_cast<double>(L);
     for (int l = 1; l <= L; ++l) {
       // True quadratic at |f| = l·w.
       const double f_break = static_cast<double>(l) * w;


### PR DESCRIPTION
## Summary

Adds CommitmentLP's anti-flicker + rolling-window-cap machinery to LineCommitment with EXACT same field names and semantics, per request to "use the concept names as close as possible to Commitment".

## Schema

  * \`min_up_time\` : OptReal hours — mirrors Commitment
  * \`min_down_time\` : OptReal hours — mirrors Commitment
  * \`max_starts\` / \`min_starts\` : OptInt — two-sided rolling cap
  * \`starts_scope\` : OptStartsScope variant<Int, Name> — reuses commitment.hpp's type
  * \`starts_window_hours()\` method — same body as Commitment's

## LP rows (only when u/v/w is active)

  * C6 min_up_time:  Σ_{q=t..t+UT-1} u[q] ≥ UT · v[t]
  * C7 min_down_time: Σ u[q] + DT · w[t] ≤ span
  * C9 max_starts: min_starts ≤ Σ_{t∈window} v[t] ≤ max_starts

## Tests

6 new TEST_CASEs; 35/35 LineCommitment pass; full unit suite green (100%).

## Drive-by

Rename \`kEnvelope\` → \`kSos2Envelope\` in test_line_losses_sos2.cpp to fix a unity-build collision (pre-existing from #511 merge but only surfaced now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)