### PR TITLE
fix(mip-start): round-trip a complete optimal solution as an accepted start

### DIFF
--- a/include/gtopt/mip_start.hpp
+++ b/include/gtopt/mip_start.hpp
@@ -60,7 +60,7 @@ namespace detail
 /// their relaxation value.  Returns the dense raw candidate start (empty iff
 /// the relaxation has no primal).  Used by the default round+rules generator.
 [[nodiscard]] std::vector<double> rounded_start_with_rules(
-    MipStartContext& ctx, std::string_view generator_name);
+    const MipStartContext& ctx, std::string_view generator_name);
 }  // namespace detail
 
 /// Outcome of the MIP-start pipeline (for logging / tests).
@@ -150,13 +150,17 @@ public:
     std::span<const PeakInjectionInfo> injections = {},
     const FlatLinearProblem* flat_lp = nullptr);
 
-/// Dump the live MIP solution's integer-column RAW values to `path`, one
-/// `<index> <value>` line per integer column, preceded by an `ncols` header
-/// for a structural sanity check on replay.  Call AFTER a successful MIP solve
-/// (integrality intact, before any dual-recovery relaxation).  A later run
-/// replays the dump as a cross-solver MIP start via `mip_start.from_file`
-/// (`FileMipStart`): both runs build the identical deterministic flat LP, so
-/// raw column indices line up 1:1.
+/// Dump the live MIP solution's COMPLETE RAW column values to `path` — one
+/// `<index> <value>` line per column, integer AND continuous — preceded by
+/// `ncols` / `nint` headers (`ncols` is a structural sanity check on replay;
+/// `nint` is informational).  Call AFTER a successful MIP solve (integrality
+/// intact, before any dual-recovery relaxation).  A later run replays the
+/// dump as a MIP start via `mip_start.from_file` (`FileMipStart`): both runs
+/// build the identical deterministic flat LP, so raw column indices line up
+/// 1:1, and the replayed start is the complete, CONSISTENT solution — the
+/// exact optimum round-trips through a strict backend feasibility check
+/// (CPLEX CHECKFEAS) instead of being rejected for carrying relaxation
+/// continuous values under optimal integers.
 ///
 /// @return Empty on success, or a `FileIOError` if the file cannot be written.
 [[nodiscard]] std::expected<void, Error> dump_integer_solution(

--- a/include/gtopt/monolithic_options.hpp
+++ b/include/gtopt/monolithic_options.hpp
@@ -204,11 +204,16 @@ struct MipStartOptions
   MipStartInject inject {};
   /** @brief Optional path to an externally-computed start to REPLAY instead of
    * the round+rules candidate: a dump produced by a previous solve's
-   * `dump_file`.  Enables a cross-solver hand-off (e.g. HiGHS dumps a feasible
-   * incumbent, cuOpt replays it as its start). */
+   * `dump_file`.  A complete dump (integers AND continuous) reconstructs a
+   * consistent start — replaying an optimal dump is accepted verbatim under
+   * `inject.effort=check_feasibility`.  Enables a cross-solver hand-off (e.g.
+   * HiGHS dumps a feasible incumbent, cuOpt replays it as its start).  Pair
+   * with `skip_relaxation` to inject without solving the throwaway Stage-0
+   * relaxation. */
   OptName from_file {};
-  /** @brief Optional path to DUMP this solve's integer solution to, after the
-   * MIP solve completes.  A later run replays it via `from_file`. */
+  /** @brief Optional path to DUMP this solve's COMPLETE solution to (every
+   * column, integer and continuous), after the MIP solve completes.  A later
+   * run replays it via `from_file`. */
   OptName dump_file {};
   /** @brief Optional path to an external commitment SEED — a CSV
    * `generator_uid,block_uid,u` consumed by `SeedCommitmentRule` (registered
@@ -219,14 +224,14 @@ struct MipStartOptions
    * gtopt, nearest-historical, ML predictor) simply produces this CSV. */
   OptName seed_solution_file {};
   /** @brief Skip the Stage-0 LP relaxation solve when a `seed_solution_file`
-   * fully specifies the integer commitment.  The relaxation exists only to
-   * fill the rounded candidate; for a backend that injects the seed sparsely
-   * over the integer columns (CPLEX), its continuous output is discarded, so
-   * the relaxation is a throwaway LP solve that the MIP's own root then
-   * repeats.  With this set, the seed is built directly (zero base + domain
-   * rules) and injected; the backend completes the continuous dispatch as the
-   * single warm root LP (effort defaults to `solve_fixed` → dual simplex off
-   * the fixed integers, no crossover). Default false. */
+   * fully specifies the integer commitment or a `from_file` dump is being
+   * replayed.  The relaxation exists only to fill the rounded candidate; a
+   * seed/dump overrides it, so the relaxation is a throwaway LP solve that
+   * the MIP's own root then repeats.  With this set, the start is built
+   * directly (seed: zero base + domain rules; file: the dumped complete
+   * solution) and injected; the backend completes any missing continuous
+   * dispatch as the single warm root LP (effort defaults to `solve_fixed` →
+   * dual simplex off the fixed integers, no crossover). Default false. */
   OptBool skip_relaxation {};
   /** @brief Optional path to a cached ROOT LP basis (Experiment A).
    *

--- a/plugins/cplex/cplex_solver_backend.cpp
+++ b/plugins/cplex/cplex_solver_backend.cpp
@@ -780,7 +780,7 @@ void CplexSolverBackend::set_obj_coeffs(const double* values, int num_cols)
     return;
   }
   std::vector<int> indices(static_cast<size_t>(num_cols));
-  std::iota(indices.begin(), indices.end(), 0);
+  std::ranges::iota(indices, 0);
   CPXchgobj(m_env_lp_.env(), m_env_lp_.lp(), num_cols, indices.data(), values);
 }
 
@@ -1689,7 +1689,7 @@ bool CplexSolverBackend::set_mip_start(std::span<const double> col_values,
                                        MipStartEffort effort)
 {
   const int ncols = CPXgetnumcols(m_env_lp_.env(), m_env_lp_.lp());
-  if (col_values.empty() || static_cast<int>(col_values.size()) != ncols) {
+  if (col_values.empty() || std::cmp_not_equal(col_values.size(), ncols)) {
     return false;
   }
 
@@ -1713,29 +1713,49 @@ bool CplexSolverBackend::set_mip_start(std::span<const double> col_values,
       break;
   }
 
-  // SPARSE start over the INTEGER columns only — NOT a dense all-columns
-  // start.  The caller hands us a dense vector whose continuous entries are the
-  // LP-relaxation dispatch, which is inconsistent with the ROUNDED integers; a
-  // dense start makes CHECKFEAS reject on those continuous columns even when
-  // the integer commitment is feasible.  Feeding only the integer (status /
-  // startup / shutdown / …) columns lets CPLEX complete a consistent continuous
-  // dispatch itself — the intended "seed the commitment, let the solver
-  // dispatch" behaviour.  Continuous columns are identified by their ctype
-  // (restored by restore_integers before this call).
-  std::vector<char> ctype(static_cast<std::size_t>(ncols));
-  if (CPXgetctype(m_env_lp_.env(), m_env_lp_.lp(), ctype.data(), 0, ncols - 1)
-      != 0)
-  {
-    return false;  // no ctype info (pure LP / not a MIP) — nothing to seed
-  }
+  // Start shape depends on what the effort level PROMISES CPLEX:
+  //
+  //  - CHECKFEAS / NOCHECK trust the caller's values verbatim, so they get
+  //    the COMPLETE dense start (all columns).  CPLEX cannot check the
+  //    feasibility of a PARTIAL start — a sparse integer-only start under
+  //    CHECKFEAS is discarded at mipopt with "No solution found from N MIP
+  //    starts" even when the integers are the exact optimum (the CEN UC
+  //    round-trip bug).  The caller contract for these efforts is a
+  //    complete, consistent solution (e.g. a `FileMipStart` replay of a
+  //    dumped optimum), which CHECKFEAS verifies and accepts.
+  //
+  //  - SOLVEFIXED / SOLVEMIP / REPAIR recompute the continuous dispatch, so
+  //    they keep the SPARSE start over the INTEGER columns only: the dense
+  //    vector's continuous entries are typically the LP-relaxation dispatch
+  //    (round+rules candidate), inconsistent with the rounded integers, and
+  //    would only mislead the repair.  Feeding only the integer (status /
+  //    startup / shutdown / …) columns lets CPLEX complete a consistent
+  //    continuous dispatch itself — the intended "seed the commitment, let
+  //    the solver dispatch" behaviour.  Continuous columns are identified by
+  //    their ctype (restored by restore_integers before this call).
+  const bool trust_values = effort == MipStartEffort::check_feasibility
+      || effort == MipStartEffort::no_check;
   std::vector<int> indices;
   std::vector<double> values;
   indices.reserve(static_cast<std::size_t>(ncols));
   values.reserve(static_cast<std::size_t>(ncols));
-  for (int j = 0; j < ncols; ++j) {
-    if (ctype[static_cast<std::size_t>(j)] != CPX_CONTINUOUS) {
+  if (trust_values) {
+    for (int j = 0; j < ncols; ++j) {
       indices.push_back(j);
       values.push_back(col_values[static_cast<std::size_t>(j)]);
+    }
+  } else {
+    std::vector<char> ctype(static_cast<std::size_t>(ncols));
+    if (CPXgetctype(m_env_lp_.env(), m_env_lp_.lp(), ctype.data(), 0, ncols - 1)
+        != 0)
+    {
+      return false;  // no ctype info (pure LP / not a MIP) — nothing to seed
+    }
+    for (int j = 0; j < ncols; ++j) {
+      if (ctype[static_cast<std::size_t>(j)] != CPX_CONTINUOUS) {
+        indices.push_back(j);
+        values.push_back(col_values[static_cast<std::size_t>(j)]);
+      }
     }
   }
   if (indices.empty()) {
@@ -1950,8 +1970,7 @@ CplexSolverBackend::diagnose_infeasibility(int max_items)
   std::vector<std::string> conflicts;
   const int cap = (max_items > 0) ? max_items : outrows;
   conflicts.reserve(static_cast<std::size_t>(std::min(outrows, cap)));
-  for (int k = 0; k < outrows && static_cast<int>(conflicts.size()) < cap; ++k)
-  {
+  for (int k = 0; k < outrows && std::cmp_less(conflicts.size(), cap); ++k) {
     if (rowbdstat[static_cast<std::size_t>(k)] == CPX_CONFLICT_MEMBER) {
       conflicts.push_back(row_name(rowind[static_cast<std::size_t>(k)]));
     }
@@ -1965,7 +1984,7 @@ namespace
 // ticks (CPXgetdettime) as a per-solve delta on the env.  The generic
 // SolveEffort accounting (SolveEffortTotals, accumulated in LinearInterface)
 // reads this via last_solve_effort().
-[[nodiscard]] SolveEffort capture_cplex_effort(cpxenv* env,
+[[nodiscard]] SolveEffort capture_cplex_effort(const cpxenv* env,
                                                double t0_ticks,
                                                double t0_secs)
 {
@@ -2110,12 +2129,8 @@ bool CplexSolverBackend::is_proven_optimal() const
   // LinearInterface algorithm-fallback ladder re-solves (and, failing that,
   // the SDDP elastic/fallback path handles it) instead of trusting NaN.
   double obj = 0.0;
-  if (CPXgetobjval(m_env_lp_.env(), m_env_lp_.lp(), &obj) != 0
-      || !std::isfinite(obj))
-  {
-    return false;
-  }
-  return true;
+  return CPXgetobjval(m_env_lp_.env(), m_env_lp_.lp(), &obj) == 0
+      && std::isfinite(obj);
 }
 
 bool CplexSolverBackend::is_abandoned() const

--- a/plugins/gurobi/gurobi_solver_backend.cpp
+++ b/plugins/gurobi/gurobi_solver_backend.cpp
@@ -1022,9 +1022,25 @@ bool GurobiSolverBackend::set_mip_start(
 {
   // Gurobi's Start attribute IS the MIP start: it seeds the initial incumbent
   // and auto-completes/repairs partial or slightly-infeasible assignments.
-  // Its repair analog (effort=repair) is to let it spend branch-and-bound
-  // nodes completing/repairing the start (StartNodeLimit) and run more primal
-  // heuristics (Heuristics) — closest to CPLEX's MIP-start REPAIR.
+  // Start shape follows what the effort level PROMISES the solver (the same
+  // contract the CPLEX backend encodes):
+  //
+  //  - check_feasibility / no_check trust the caller's values verbatim, so
+  //    they get the COMPLETE dense start (all columns) — the caller contract
+  //    is a complete, consistent solution (e.g. a `FileMipStart` replay of a
+  //    dumped optimum), which Gurobi's start processing verifies and installs
+  //    as the initial incumbent.
+  //
+  //  - solve_fixed / solve_mip / repair recompute the continuous dispatch:
+  //    only the INTEGER columns are seeded and every continuous entry is set
+  //    to GRB_UNDEFINED, which is Gurobi's native "complete it yourself"
+  //    marker — start processing fixes the integers and solves the residual
+  //    continuous problem (its SOLVEFIXED analog).  Passing the dense
+  //    vector's continuous entries here would feed the LP-relaxation dispatch
+  //    (round+rules candidate), inconsistent with the rounded integers.
+  //    `repair` additionally lets Gurobi spend branch-and-bound nodes
+  //    completing/repairing the start (StartNodeLimit) and runs more primal
+  //    heuristics (Heuristics) — closest to CPLEX's MIP-start REPAIR.
   ensure_updated_();
   const auto ncols = static_cast<std::size_t>(get_num_cols());
   if (col_values.size() != ncols) {
@@ -1035,11 +1051,25 @@ bool GurobiSolverBackend::set_mip_start(
     GRBsetintparam(menv, GRB_INT_PAR_STARTNODELIMIT, 2000);
     GRBsetdblparam(menv, GRB_DBL_PAR_HEURISTICS, 0.2);
   }
-  GRBsetdblattrarray(m_model_,
-                     GRB_DBL_ATTR_START,
-                     0,
-                     static_cast<int>(ncols),
-                     const_cast<double*>(col_values.data()));  // NOLINT
+
+  const bool trust_values = effort == MipStartEffort::check_feasibility
+      || effort == MipStartEffort::no_check;
+  std::vector<double> start(col_values.begin(), col_values.end());
+  if (!trust_values && ncols > 0) {
+    std::vector<char> vtypes(ncols, GRB_CONTINUOUS);
+    GRBgetcharattrarray(m_model_,
+                        GRB_CHAR_ATTR_VTYPE,
+                        0,
+                        static_cast<int>(ncols),
+                        vtypes.data());
+    for (std::size_t j = 0; j < ncols; ++j) {
+      if (vtypes[j] == GRB_CONTINUOUS) {
+        start[j] = GRB_UNDEFINED;
+      }
+    }
+  }
+  GRBsetdblattrarray(
+      m_model_, GRB_DBL_ATTR_START, 0, static_cast<int>(ncols), start.data());
   m_dirty_ = true;
   return true;
 }

--- a/plugins/scip/scip_solver_backend.cpp
+++ b/plugins/scip/scip_solver_backend.cpp
@@ -197,9 +197,28 @@ SCIP_RETCODE scip_build_problem(SCIP* scip,
   return SCIP_OKAY;
 }
 
-/// Install a buffered MIP start as a SCIP partial solution over the integer
-/// columns, tuning the completesol heuristic under `effort == repair` so SCIP
-/// completes/repairs it into a feasible incumbent.
+/// Install a buffered MIP start, shaping it by what the effort level
+/// PROMISES the solver (the same contract the CPLEX backend encodes):
+///
+///  - `check_feasibility` / `no_check` trust the caller's values verbatim —
+///    the caller contract is a COMPLETE, consistent solution (e.g. a
+///    `FileMipStart` replay of a dumped optimum).  SCIP's analog of CPLEX's
+///    dense CHECKFEAS start is `SCIPtrySol` on the FULL assignment: transform
+///    the problem and try the complete solution, so an accepted start becomes
+///    the incumbent BEFORE presolve.  A partial (integers-only) start here
+///    would discard the caller's consistent continuous dispatch and rely on
+///    the completesol heuristic, which may never run (tiny models are solved
+///    outright by presolve first) — the start would contribute nothing.
+///    Acceptance is surfaced in SCIP's native log via `SCIPverbMessage`
+///    ("gtopt MIP start accepted/rejected"), the sharp signal the round-trip
+///    test asserts on (mirrors CPLEX's "1 of 1 MIP starts provided
+///    solutions." line).
+///
+///  - `solve_fixed` / `solve_mip` / `repair` recompute the continuous
+///    dispatch, so they seed a PARTIAL solution over the INTEGER columns only
+///    and let SCIP's completesol heuristic complete/repair it into a feasible
+///    incumbent (`repair` additionally raises the feasibility emphasis and
+///    lifts the completesol unknown-rate cap).
 SCIP_RETCODE scip_install_mip_start(SCIP* scip,
                                     const ScipModel& model,
                                     const std::vector<double>& start,
@@ -218,6 +237,52 @@ SCIP_RETCODE scip_install_mip_start(SCIP* scip,
   }
   if (!any_integer) {
     return SCIP_OKAY;  // pure LP — no integer start to repair
+  }
+
+  const bool trust_values = effort == MipStartEffort::check_feasibility
+      || effort == MipStartEffort::no_check;
+  if (trust_values) {
+    SCIP_CALL(SCIPtransformProb(scip));
+    SCIP_SOL* sol = nullptr;
+    SCIP_CALL(SCIPcreateSol(scip, &sol, nullptr));
+    for (int j = 0; j < model.num_cols; ++j) {
+      const auto u = static_cast<std::size_t>(j);
+      const double val =
+          model.col_type[u] == 'I' ? std::round(start[u]) : start[u];
+      SCIP_CALL(SCIPsetSolVal(scip, sol, vars[u], val));
+    }
+    SCIP_Bool stored = FALSE;
+    SCIP_CALL(SCIPtrySolFree(scip,
+                             &sol,
+                             FALSE,  // printreason
+                             TRUE,  // completely
+                             TRUE,  // checkbounds
+                             TRUE,  // checkintegrality
+                             TRUE,  // checklprows
+                             &stored));
+    // SCIPverbMessage is SCIP's printf-style (vararg) log entry point — the
+    // only way to surface the acceptance outcome in SCIP's native log file,
+    // where the round-trip test asserts on it.
+    if (stored == TRUE) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+      SCIPverbMessage(scip,
+                      SCIP_VERBLEVEL_NORMAL,
+                      nullptr,
+                      "gtopt MIP start accepted (complete start stored as "
+                      "incumbent by SCIPtrySol)\n");
+    } else {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+      SCIPverbMessage(scip,
+                      SCIP_VERBLEVEL_NORMAL,
+                      nullptr,
+                      "gtopt MIP start rejected (SCIPtrySol did not store "
+                      "the complete start)\n");
+      spdlog::warn(
+          "gtopt[scip]: complete MIP start rejected by SCIPtrySol "
+          "(effort={}) — solving cold",
+          static_cast<int>(effort));
+    }
+    return SCIP_OKAY;
   }
 
   if (effort == MipStartEffort::repair) {

--- a/source/benders_cut.cpp
+++ b/source/benders_cut.cpp
@@ -1180,7 +1180,7 @@ struct RelaxationSpec
   valid_rows.reserve(rows.size());
   std::vector<SparseCol> z_cols;
   z_cols.reserve(rows.size());
-  for (const auto row : rows) {
+  for (const auto& row : rows) {
     if (row == RowIndex {unknown_index} || row >= numrows) {
       SPDLOG_WARN(
           "apply_fcut_relaxations: fcut row {} outside clone row range "

--- a/source/mip_start.cpp
+++ b/source/mip_start.cpp
@@ -50,7 +50,9 @@ namespace detail
 /// base the remaining rules repair) and runs the default `DomainRulePipeline`
 /// (min-up/down, commitment-logic v/w, …).  Shared by the round-from-relaxation
 /// generator and the seed-only (no-relaxation) path.
-void apply_seed_and_domain_rules(MipStartContext& ctx,
+namespace
+{
+void apply_seed_and_domain_rules(const MipStartContext& ctx,
                                  std::vector<double>& start,
                                  std::string_view generator_name)
 {
@@ -81,8 +83,24 @@ void apply_seed_and_domain_rules(MipStartContext& ctx,
   }
 }
 
+/// Seed-only start: no LP relaxation.  Builds a zero base of width `ncols`
+/// and lets the seed + commitment-logic domain rules set every integer
+/// commitment column directly.  Continuous columns stay at 0 (a
+/// sparse-injecting backend like CPLEX drops them and completes the dispatch
+/// as its warm root LP).
+[[nodiscard]] std::vector<double> seed_only_start(
+    const MipStartContext& ctx, std::string_view generator_name)
+{
+  const auto ncols = static_cast<std::size_t>(ctx.li.get_numcols());
+  std::vector<double> start(ncols, 0.0);
+  apply_seed_and_domain_rules(ctx, start, generator_name);
+  return start;
+}
+
+}  // namespace
+
 [[nodiscard]] std::vector<double> rounded_start_with_rules(
-    MipStartContext& ctx, std::string_view generator_name)
+    const MipStartContext& ctx, std::string_view generator_name)
 {
   auto& li = ctx.li;
   const auto sol = li.get_col_sol_raw();
@@ -101,19 +119,6 @@ void apply_seed_and_domain_rules(MipStartContext& ctx,
     start[u] = round_with_threshold(sol[u], threshold, l, h);
   }
   // Stage 2 — domain rules (power-system knowledge: min-up/down, …).
-  apply_seed_and_domain_rules(ctx, start, generator_name);
-  return start;
-}
-
-/// Seed-only start: no LP relaxation.  Builds a zero base of width `ncols` and
-/// lets the seed + commitment-logic domain rules set every integer commitment
-/// column directly.  Continuous columns stay at 0 (a sparse-injecting backend
-/// like CPLEX drops them and completes the dispatch as its warm root LP).
-[[nodiscard]] std::vector<double> seed_only_start(
-    MipStartContext& ctx, std::string_view generator_name)
-{
-  const auto ncols = static_cast<std::size_t>(ctx.li.get_numcols());
-  std::vector<double> start(ncols, 0.0);
   apply_seed_and_domain_rules(ctx, start, generator_name);
   return start;
 }
@@ -146,17 +151,20 @@ public:
   }
 };
 
-/// File generator: replay an integer solution dumped by a previous solve
+/// File generator: replay a solution dumped by a previous solve
 /// (`dump_integer_solution`).  The dumped `<index> <value>` lines carry the
-/// integer-column raw values found by another solver; this overlays them onto
-/// THIS solver's own LP-relaxation primal (the continuous columns stay at the
-/// relaxation value, exactly like `warmstart`, but the integer columns come
-/// from the file instead of rounding).  Enables a cross-solver hand-off: e.g.
-/// HiGHS (strong MIP heuristics) finds a feasible incumbent and dumps it, then
-/// cuOpt replays it as its start.  Both runs build the identical deterministic
-/// flat LP, so raw column indices match 1:1 — validated by the `ncols` header
-/// and a per-index integer-column membership check (no silent skip on
-/// mismatch).
+/// COMPLETE raw solution (integer AND continuous columns) found by another
+/// run; every dumped column overlays the start, so replaying a complete
+/// optimal dump reconstructs the exact optimum — a CONSISTENT start that a
+/// strict backend feasibility check (CPLEX CHECKFEAS) accepts.  Legacy
+/// integer-only dumps still work: columns absent from the file keep this
+/// solver's own LP-relaxation primal when one is available (the pre-2026-07
+/// behaviour), and a zero base otherwise.  Overlaying optimal integers onto
+/// the RELAXATION continuous produced a mutually inconsistent start that
+/// CPLEX rejected with "No solution found from 1 MIP starts" even when the
+/// integers were the exact optimum — the CEN UC round-trip bug.  Both runs
+/// build the identical deterministic flat LP, so raw column indices match
+/// 1:1 — validated by the `ncols` header (a mismatched dump is refused).
 class FileMipStart final : public MipStartGenerator
 {
 public:
@@ -181,17 +189,34 @@ public:
       return std::nullopt;
     }
 
-    const auto sol = ctx.li.get_col_sol_raw();  // RAW relaxation primal = base
-    if (sol.empty()) {
-      return std::nullopt;
-    }
     const auto ncols = static_cast<std::size_t>(ctx.li.get_numcols());
     const std::unordered_set<int> int_set(ctx.int_cols.begin(),
                                           ctx.int_cols.end());
 
-    std::vector<double> start(sol.begin(), sol.end());
+    // Base for columns the dump does not cover (legacy integer-only dumps):
+    // the destination's own relaxation primal when available, zeros
+    // otherwise.  MUST NOT bail on an empty primal — the dump itself is the
+    // start; bailing here silently dropped the file replay (and the pipeline
+    // fell back to the round candidate).  A complete dump overlays every
+    // column, so the base then only pads structural gaps.
+    const auto sol = ctx.li.get_col_sol_raw();
+    std::vector<double> start;
+    if (sol.size() == ncols) {
+      start.assign(sol.begin(), sol.end());
+    } else {
+      if (!sol.empty()) {
+        spdlog::warn(
+            "MIP-start[file]: relaxation primal size {} != ncols {}; using a "
+            "zero base under the dumped values",
+            sol.size(),
+            ncols);
+      }
+      start.assign(ncols, 0.0);
+    }
+
     std::size_t file_ncols = 0;
-    std::size_t placed = 0;
+    std::size_t placed_int = 0;
+    std::size_t placed_cont = 0;
     std::size_t skipped = 0;
     std::string token;
     while (in >> token) {
@@ -223,30 +248,37 @@ public:
       } catch (const std::exception&) {
         continue;  // not an index token; skip
       }
-      if (!(in >> value)) {
+      in >> value;
+      if (in.fail()) {
         break;
       }
       const auto u = static_cast<std::size_t>(idx);
-      if (idx < 0 || u >= ncols || !int_set.contains(idx)) {
+      if (idx < 0 || u >= ncols) {
         ++skipped;
         continue;
       }
       start[u] = value;
-      ++placed;
+      if (int_set.contains(idx)) {
+        ++placed_int;
+      } else {
+        ++placed_cont;
+      }
     }
 
-    if (placed == 0) {
+    if (placed_int == 0) {
       spdlog::error(
           "MIP-start[file]: dump '{}' yielded no usable integer values "
-          "(placed=0, skipped={})",
+          "(continuous placed={}, out-of-range skipped={})",
           *path,
+          placed_cont,
           skipped);
       return std::nullopt;
     }
     spdlog::info(
-        "MIP-start[file]: replayed {} integer values from '{}' ({} skipped, "
-        "{} integer cols in this LP)",
-        placed,
+        "MIP-start[file]: replayed {} integer + {} continuous values from "
+        "'{}' ({} skipped, {} integer cols in this LP)",
+        placed_int,
+        placed_cont,
         *path,
         skipped,
         ctx.int_cols.size());
@@ -334,13 +366,13 @@ std::expected<void, Error> dump_integer_solution(const LinearInterface& li,
   }
   const int ncols = static_cast<int>(li.get_numcols());
 
-  // Collect integer columns + their raw values (integrality must still be
-  // intact at the call site — before any dual-recovery relaxation).
-  std::vector<std::pair<int, double>> ints;
-  ints.reserve((static_cast<std::size_t>(ncols) / 8) + 1);
+  // Count the integer columns for the informational `nint` header
+  // (integrality must still be intact at the call site — before any
+  // dual-recovery relaxation).
+  std::size_t nint = 0;
   for (int i = 0; i < ncols; ++i) {
     if (li.is_integer(ColIndex {i})) {
-      ints.emplace_back(i, sol[static_cast<std::size_t>(i)]);
+      ++nint;
     }
   }
 
@@ -352,12 +384,18 @@ std::expected<void, Error> dump_integer_solution(const LinearInterface& li,
             std::format("MIP-start dump: cannot open '{}' for writing", path),
     });
   }
-  out << "# gtopt mip_start integer solution (index value)\n";
+  // The dump carries the COMPLETE solution — every column, integer AND
+  // continuous — so a replay (`FileMipStart`) reconstructs a CONSISTENT
+  // start.  Dumping only the integers forced the replay to complete the
+  // start with the RELAXATION continuous, a mutually inconsistent vector
+  // that strict backend feasibility checks (CPLEX CHECKFEAS) reject even
+  // when the integers are the exact optimum.
+  out << "# gtopt mip_start complete solution (index value)\n";
   out << std::format("ncols {}\n", ncols);
-  out << std::format("nint {}\n", ints.size());
-  for (const auto& [idx, value] : ints) {
+  out << std::format("nint {}\n", nint);
+  for (int i = 0; i < ncols; ++i) {
     // `{}` renders the shortest round-trippable representation of the double.
-    out << std::format("{} {}\n", idx, value);
+    out << std::format("{} {}\n", i, sol[static_cast<std::size_t>(i)]);
   }
   if (!out) {
     return std::unexpected(Error {
@@ -365,8 +403,10 @@ std::expected<void, Error> dump_integer_solution(const LinearInterface& li,
         .message = std::format("MIP-start dump: write to '{}' failed", path),
     });
   }
-  spdlog::info(
-      "MIP-start dump: wrote {} integer columns to '{}'", ints.size(), path);
+  spdlog::info("MIP-start dump: wrote {} columns ({} integer) to '{}'",
+               ncols,
+               nint,
+               path);
   return {};
 }
 
@@ -410,7 +450,8 @@ std::expected<SeedCommitmentMap, Error> load_seed_commitment(
                                maybe_reader.status().ToString()),
     });
   }
-  auto maybe_table = (*maybe_reader)->Read();
+  const auto& table_reader = *maybe_reader;
+  auto maybe_table = table_reader->Read();
   if (!maybe_table.ok()) {
     return std::unexpected(Error {
         .code = ErrorCode::FileIOError,
@@ -420,7 +461,8 @@ std::expected<SeedCommitmentMap, Error> load_seed_commitment(
     });
   }
   // Combine chunks so the three columns are single, row-aligned arrays.
-  auto maybe_combined = (*maybe_table)->CombineChunks();
+  const auto& raw_table = *maybe_table;
+  auto maybe_combined = raw_table->CombineChunks();
   if (!maybe_combined.ok()) {
     return std::unexpected(Error {
         .code = ErrorCode::FileIOError,
@@ -501,17 +543,22 @@ std::expected<MipStartReport, Error> apply_mip_start(
   // global-side-effect crash.
   const auto restore_integrality = [&] { li.restore_integers(int_cols); };
 
-  // ── Fast path: seed-only, no throwaway relaxation ───────────────────────
-  // When `skip_relaxation` is set and a seed CSV fully specifies the integer
-  // commitment, skip Stage 0 entirely: the relaxation's only surviving output
-  // for a sparse-injecting backend (CPLEX) is the rounded integers, which the
-  // seed overrides anyway — so solving it is a throwaway LP the MIP root then
-  // repeats.  Build the seed start directly and inject; the backend completes
-  // the continuous dispatch as its single warm root LP (effort defaults to
-  // `solve_fixed` → dual simplex off the fixed integers, no crossover).
+  // ── Fast path: seed / file replay, no throwaway relaxation ──────────────
+  // When `skip_relaxation` is set and either a seed CSV fully specifies the
+  // integer commitment or a dumped solution is being replayed (`from_file`),
+  // skip Stage 0 entirely: the relaxation's only surviving output is the
+  // rounded integers, which the seed/dump overrides anyway — so solving it
+  // is a throwaway LP the MIP root then repeats.  Build the start directly
+  // and inject; a complete dump already carries a consistent continuous
+  // dispatch, and a seed-only start lets the backend complete it as its
+  // single warm root LP (effort defaults to `solve_fixed` → dual simplex off
+  // the fixed integers, no crossover).
+  const bool has_from_file =
+      opts.from_file.has_value() && !opts.from_file->empty();
+  const bool has_seed_file =
+      opts.seed_solution_file.has_value() && !opts.seed_solution_file->empty();
   if (enabled && opts.skip_relaxation.value_or(false)
-      && opts.seed_solution_file.has_value()
-      && !opts.seed_solution_file->empty())
+      && (has_from_file || has_seed_file))
   {
     MipStartContext ctx {
         .li = li,
@@ -522,14 +569,31 @@ std::expected<MipStartReport, Error> apply_mip_start(
         .injections = injections,
         .flat_lp = flat_lp,
     };
-    auto start = detail::seed_only_start(ctx, "seed");
+    std::optional<std::vector<double>> start;
+    std::string source;
+    if (has_from_file) {
+      auto gen = make_mip_start_generator(opts);  // → FileMipStart
+      start = gen->generate(ctx);
+      source = std::string {gen->name()};
+    } else {
+      start = detail::seed_only_start(ctx, "seed");
+      source = "seed";
+    }
+    if (!start.has_value()) {
+      spdlog::warn(
+          "MIP-start[{}]: produced no start under skip_relaxation; skipping "
+          "injection",
+          source);
+      return report;
+    }
     const auto effort =
         opts.inject.effort.value_or(MipStartEffort::solve_fixed);
-    report.injected = li.set_mip_start(start, effort);
-    report.source = "seed";
+    report.injected = li.set_mip_start(*start, effort);
+    report.source = source;
     spdlog::info(
-        "MIP-start[seed]: {} ({} integer cols, effort={}, skip_relaxation — "
+        "MIP-start[{}]: {} ({} integer cols, effort={}, skip_relaxation — "
         "no relaxation solve)",
+        source,
         report.injected ? "injected" : "backend declined",
         int_cols.size(),
         enum_name(effort));

--- a/source/solver_registry.cpp
+++ b/source/solver_registry.cpp
@@ -9,9 +9,11 @@
 #include <algorithm>
 #include <array>
 #include <cstdlib>
+#include <exception>
 #include <format>
 #include <numeric>
 #include <stdexcept>
+#include <string_view>
 
 #include <dlfcn.h>
 #include <gtopt/solver_registry.hpp>
@@ -444,6 +446,13 @@ bool SolverRegistry::validate_solver_subprocess(const PluginHandle& plugin,
       }
       delete backend;  // NOLINT(cppcoreguidelines-owning-memory)
       ::_exit(0);
+    } catch (const std::exception& e) {
+      // Licensed backends (gurobi, mindopt) throw from their constructor
+      // when no license is reachable (message contains "license") — report
+      // that with a distinct exit code so the parent logs an honest
+      // "license unavailable" skip instead of the ABI-mismatch diagnostic.
+      const std::string_view what {e.what()};
+      ::_exit(what.contains("icense") ? 3 : 1);
     } catch (...) {
       ::_exit(1);
     }
@@ -456,6 +465,20 @@ bool SolverRegistry::validate_solver_subprocess(const PluginHandle& plugin,
   //  - POSIX macros use bitwise ops
   if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
     return true;
+  }
+
+  // License-gated backend (child exit code 3): the plugin is healthy but the
+  // solver cannot start without a license (e.g. gurobi with no gurobi.lic,
+  // mindopt MDOstartenv rc=-10).  Removing it from the registry is the clean
+  // gate — `available_solvers()` / `exact_mip_solvers()` never list it, so
+  // every per-solver test sweep skips it instead of failing.
+  if (WIFEXITED(status) && WEXITSTATUS(status) == 3) {
+    SPDLOG_WARN(
+        "Solver '{}' from plugin '{}' is unavailable: license not found or "
+        "invalid — skipping it (install a valid license to enable it).",
+        solver_name,
+        plugin.plugin_name);
+    return false;
   }
 
   // Build a diagnostic message.

--- a/standalone/source/main.cpp
+++ b/standalone/source/main.cpp
@@ -42,8 +42,11 @@ using namespace gtopt;
 // extern "C" gives the exact unmangled name jemalloc looks up in the dynamic
 // symbol table; [[gnu::used, gnu::retain]] keeps it under --gc-sections.
 #if defined(GTOPT_HAVE_JEMALLOC)
-extern "C" [[gnu::used, gnu::retain]] const char* malloc_conf =
-    "background_thread:true";
+extern "C"
+{
+extern const char* malloc_conf;
+[[gnu::used, gnu::retain]] const char* malloc_conf = "background_thread:true";
+}
 #endif
 
 int main(int argc, char** argv)

--- a/test/source/test_mip_start.cpp
+++ b/test/source/test_mip_start.cpp
@@ -560,7 +560,10 @@ TEST_CASE(
 // real MIP solve, then dump).  Gated on a MIP solver because the dump must
 // read a SOLVED integer primal — `set_integer` before the solve is exactly the
 // production path, and re-reading the cached primal after a post-hoc
-// `set_integer` is invalid on some backends.
+// `set_integer` is invalid on some backends.  The dump is COMPLETE (integer
+// and continuous columns), so the replay reconstructs the source solution
+// verbatim — including the continuous values, which take precedence over the
+// destination's own relaxation primal.
 TEST_CASE("MipStart dump → file round-trips a solved MIP")  // NOLINT
 {
   SolverRegistry& reg = SolverRegistry::instance();
@@ -639,7 +642,9 @@ TEST_CASE("MipStart dump → file round-trips a solved MIP")  // NOLINT
   REQUIRE(start.has_value());
   CHECK((*start)[0] == doctest::Approx(1.0));  // dumped MIP value
   CHECK((*start)[1] == doctest::Approx(0.0));  // dumped MIP value
-  CHECK((*start)[2] == doctest::Approx(2.0));  // dst continuous, untouched
+  CHECK((*start)[2] == doctest::Approx(3.0));  // dumped continuous value —
+  // the complete dump wins over the dst relaxation (2.0): replaying it must
+  // reconstruct the SOURCE solution, not an integers-over-relaxation mix.
 
   std::filesystem::remove(path);
 }

--- a/test/source/test_mip_start_roundtrip.cpp
+++ b/test/source/test_mip_start_roundtrip.cpp
@@ -189,6 +189,13 @@ std::string slurp(const std::filesystem::path& path)
 constexpr std::string_view kCplexAccepted = "MIP starts provided solutions";
 constexpr std::string_view kCplexRejected = "No solution found from";
 
+/// SCIP prints the trusted-start `SCIPtrySol` outcome into its native log
+/// (emitted by the scip plugin's `scip_install_mip_start`): the analog of the
+/// CPLEX acceptance line, and just as sharp — a rejected start still solves
+/// cold to the same optimum, so only the log discriminates.
+constexpr std::string_view kScipAccepted = "gtopt MIP start accepted";
+constexpr std::string_view kScipRejected = "gtopt MIP start rejected";
+
 /// RAII: route the backend's native log to `<base>.log`, removing a stale
 /// file first (the backend appends).
 struct NativeLog
@@ -221,6 +228,25 @@ struct NativeLog
   opts.log_level = 1;
   opts.log_mode = SolverLogMode::detailed;
   return opts;
+}
+
+/// Sharp per-backend acceptance check on the captured native log, for the
+/// backends whose log carries an explicit MIP-start processing outcome
+/// (cplex, scip).  Other backends expose no such log line — for them the
+/// objective + optimality assertions in the caller remain the check.
+void check_native_log_accepted(const std::string& name, const NativeLog& log)
+{
+  if (name == "cplex") {
+    const auto text = log.text();
+    CAPTURE(text);
+    CHECK(text.contains(kCplexAccepted));
+    CHECK_FALSE(text.contains(kCplexRejected));
+  } else if (name == "scip") {
+    const auto text = log.text();
+    CAPTURE(text);
+    CHECK(text.contains(kScipAccepted));
+    CHECK_FALSE(text.contains(kScipRejected));
+  }
 }
 
 }  // namespace
@@ -301,16 +327,11 @@ TEST_CASE(  // NOLINT
     CHECK(warm.get_obj_value() == doctest::Approx(obj_cold).epsilon(1e-6));
     check_is_mip_optimum(m, warm.get_col_sol_raw());
 
-    // 3. Sharp acceptance assertion on CPLEX: the native log carries the
-    //    official MIP-start processing outcome.  Rejection ("No solution
-    //    found from 1 MIP starts") re-solves cold to the same objective, so
-    //    only the log discriminates — this is the CEN failure signature.
-    if (name == "cplex") {
-      const auto text = log.text();
-      CAPTURE(text);
-      CHECK(text.contains(kCplexAccepted));
-      CHECK_FALSE(text.contains(kCplexRejected));
-    }
+    // 3. Sharp acceptance assertion on the backends whose native log carries
+    //    the official MIP-start processing outcome (cplex, scip).  Rejection
+    //    re-solves cold to the same objective, so only the log discriminates
+    //    — this is the CEN failure signature.
+    check_native_log_accepted(name, log);
   }
 }
 
@@ -410,12 +431,7 @@ TEST_CASE(  // NOLINT
       REQUIRE(dst.is_optimal());
       CHECK(dst.get_obj_value() == doctest::Approx(kOptObj).epsilon(1e-6));
       check_is_mip_optimum(m, dst.get_col_sol_raw());
-      if (name == "cplex") {
-        const auto text = log.text();
-        CAPTURE(text);
-        CHECK(text.contains(kCplexAccepted));
-        CHECK_FALSE(text.contains(kCplexRejected));
-      }
+      check_native_log_accepted(name, log);
     }
 
     SUBCASE("skip_relaxation fast path (no throwaway relaxation solve)")
@@ -439,12 +455,7 @@ TEST_CASE(  // NOLINT
       REQUIRE(dst.is_optimal());
       CHECK(dst.get_obj_value() == doctest::Approx(kOptObj).epsilon(1e-6));
       check_is_mip_optimum(m, dst.get_col_sol_raw());
-      if (name == "cplex") {
-        const auto text = log.text();
-        CAPTURE(text);
-        CHECK(text.contains(kCplexAccepted));
-        CHECK_FALSE(text.contains(kCplexRejected));
-      }
+      check_native_log_accepted(name, log);
     }
 
     SUBCASE("file generator reconstructs the dump without a relaxation")

--- a/test/source/test_mip_start_roundtrip.cpp
+++ b/test/source/test_mip_start_roundtrip.cpp
@@ -1,0 +1,653 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @file      test_mip_start_roundtrip.cpp
+ * @brief     Per-solver round-trip tests for the MIP-start loading mechanism:
+ *            solve a tiny UC MIP, capture the COMPLETE optimal solution,
+ *            reload it as a MIP start, and verify it is accepted and
+ *            re-solves to the same optimum.
+ * @date      2026-07-13
+ * @author    claude
+ * @copyright BSD-3-Clause
+ *
+ * Invariant under test (docs/tasks/mipstart-roundtrip-prototype.md):
+ * reloading a complete, consistent, OPTIMAL solution as a MIP start MUST be
+ * accepted by every MIP-capable backend and re-solve to the same optimum
+ * with ~zero extra work.  On the real CEN UC MIP this round trip failed
+ * ("No solution found from 1 MIP starts") for two composing reasons:
+ *   1. the CPLEX backend filtered EVERY start down to a sparse integer-only
+ *      start, and CPLEX cannot check the feasibility of a partial start —
+ *      CHECKFEAS discards it even when the integers are the exact optimum;
+ *   2. `FileMipStart` overlaid the dumped optimal integers onto the
+ *      LP-RELAXATION continuous values — a mutually inconsistent start.
+ * The fixes: `check_feasibility`/`no_check` starts go to CPLEX DENSE
+ * (complete), and the dump/replay persists the COMPLETE solution.
+ *
+ * Fixture: 2-generator / 2-block unit commitment (closed form).
+ *   Gen A: Pmin 20, Pmax 60,  fixed cost 100/on-block, variable cost 10
+ *   Gen B: Pmin 40, Pmax 100, fixed cost  40/on-block, variable cost 50
+ *   Demand: block 1 = 50, block 2 = 90.
+ * Columns per block t: uA_t, uB_t binary; pA_t, pB_t continuous.
+ * Rows per block t:
+ *   balance : pA + pB == d_t
+ *   capX    : pX - Pmax_X uX <= 0
+ *   minX    : pX - Pmin_X uX >= 0
+ * MIP optimum (unique): u = (1,0,1,1), p = (50,0,50,40), obj = 3240.
+ * LP relaxation (unique, fractional): uA1=5/6, uB1=0, uA2=1, uB2=0.3,
+ * p = (50,0,60,30), obj = 8386/3 ≈ 2795.33 — the relaxed continuous
+ * dispatch (pA2=60, pB2=30) DIFFERS from the MIP-optimal one (50, 40),
+ * so any integers-over-relaxation overlay is provably inconsistent.
+ */
+
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <span>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <doctest/doctest.h>
+#include <gtopt/commitment.hpp>
+#include <gtopt/generator.hpp>
+#include <gtopt/linear_interface.hpp>
+#include <gtopt/linear_problem.hpp>
+#include <gtopt/mip_start.hpp>
+#include <gtopt/monolithic_options.hpp>
+#include <gtopt/planning_options_lp.hpp>
+#include <gtopt/simulation_lp.hpp>
+#include <gtopt/solver_enums.hpp>
+#include <gtopt/solver_options.hpp>
+#include <gtopt/solver_registry.hpp>
+#include <gtopt/system_lp.hpp>
+
+#include "solver_test_helpers.hpp"
+
+using namespace gtopt;
+
+namespace
+{
+
+constexpr double kOptObj = 3240.0;
+constexpr double kRelaxObj = 8386.0 / 3.0;
+constexpr std::size_t kNumCols = 8;
+
+struct TinyUc
+{
+  // column indices, blocks 1..2
+  ColIndex ua1 {}, ub1 {}, pa1 {}, pb1 {};
+  ColIndex ua2 {}, ub2 {}, pa2 {}, pb2 {};
+};
+
+/// Build the 2-gen / 2-block UC fixture into `lp` (8 cols, 10 rows).
+TinyUc build_tiny_uc(LinearInterface& lp)
+{
+  TinyUc m;
+
+  auto add_block =
+      [&lp](
+          double demand, ColIndex& ua, ColIndex& ub, ColIndex& pa, ColIndex& pb)
+  {
+    ua = lp.add_col(SparseCol {
+        .lowb = 0.0,
+        .uppb = 1.0,
+        .cost = 100.0,
+    });
+    ub = lp.add_col(SparseCol {
+        .lowb = 0.0,
+        .uppb = 1.0,
+        .cost = 40.0,
+    });
+    pa = lp.add_col(SparseCol {
+        .lowb = 0.0,
+        .cost = 10.0,
+    });
+    pb = lp.add_col(SparseCol {
+        .lowb = 0.0,
+        .cost = 50.0,
+    });
+    lp.set_integer(ua);
+    lp.set_integer(ub);
+
+    SparseRow balance;
+    balance[pa] = 1.0;
+    balance[pb] = 1.0;
+    balance.equal(demand);
+    (void)lp.add_row(balance);
+
+    SparseRow cap_a;
+    cap_a[pa] = 1.0;
+    cap_a[ua] = -60.0;
+    cap_a.less_equal(0.0);
+    (void)lp.add_row(cap_a);
+
+    SparseRow min_a;
+    min_a[pa] = 1.0;
+    min_a[ua] = -20.0;
+    min_a.greater_equal(0.0);
+    (void)lp.add_row(min_a);
+
+    SparseRow cap_b;
+    cap_b[pb] = 1.0;
+    cap_b[ub] = -100.0;
+    cap_b.less_equal(0.0);
+    (void)lp.add_row(cap_b);
+
+    SparseRow min_b;
+    min_b[pb] = 1.0;
+    min_b[ub] = -40.0;
+    min_b.greater_equal(0.0);
+    (void)lp.add_row(min_b);
+  };
+
+  add_block(50.0, m.ua1, m.ub1, m.pa1, m.pb1);
+  add_block(90.0, m.ua2, m.ub2, m.pa2, m.pb2);
+  return m;
+}
+
+/// Cold MIP solve.  `initial_solve` + `resolve`: on CBC `initial_solve` only
+/// solves the LP relaxation (branch-and-bound lives in `resolve()` — see
+/// OsiSolverBackend::initial_solve), and on every other backend the extra
+/// resolve is a cheap warm re-solve of the same MIP.
+void cold_solve(LinearInterface& lp, const SolverOptions& opts = {})
+{
+  REQUIRE(lp.initial_solve(opts).has_value());
+  REQUIRE(lp.resolve(opts).has_value());
+  REQUIRE(lp.is_optimal());
+}
+
+/// Verify a dense raw solution vector is the unique MIP optimum of the
+/// fixture: u = (1,0,1,1), p = (50,0,50,40).
+void check_is_mip_optimum(const TinyUc& m, std::span<const double> sol)
+{
+  const auto at = [&sol](ColIndex c)
+  { return sol[static_cast<std::size_t>(static_cast<int>(c))]; };
+  CHECK(at(m.ua1) == doctest::Approx(1.0));
+  CHECK(at(m.ub1) == doctest::Approx(0.0));
+  CHECK(at(m.pa1) == doctest::Approx(50.0));
+  CHECK(at(m.pb1) == doctest::Approx(0.0));
+  CHECK(at(m.ua2) == doctest::Approx(1.0));
+  CHECK(at(m.ub2) == doctest::Approx(1.0));
+  CHECK(at(m.pa2) == doctest::Approx(50.0));
+  CHECK(at(m.pb2) == doctest::Approx(40.0));
+}
+
+/// Read a whole text file (a solver native log / a dump) into a string.
+std::string slurp(const std::filesystem::path& path)
+{
+  std::ifstream in(path);
+  std::ostringstream ss;
+  ss << in.rdbuf();
+  return ss.str();
+}
+
+/// CPLEX prints the MIP-start processing outcome at the head of every
+/// mipopt: `1 of 1 MIP starts provided solutions.` on acceptance vs
+/// `Warning:  No solution found from 1 MIP starts.` on rejection.  This is
+/// the sharp, official acceptance signal — the objective alone cannot
+/// discriminate (a rejected start just solves cold to the same optimum).
+constexpr std::string_view kCplexAccepted = "MIP starts provided solutions";
+constexpr std::string_view kCplexRejected = "No solution found from";
+
+/// RAII: route the backend's native log to `<base>.log`, removing a stale
+/// file first (the backend appends).
+struct NativeLog
+{
+  std::filesystem::path log_path;
+
+  explicit NativeLog(LinearInterface& li, const std::string& tag)
+      : log_path(std::filesystem::temp_directory_path()
+                 / ("gtopt_mipstart_rt_" + tag))
+  {
+    std::filesystem::remove(with_ext());
+    li.set_log_file(log_path.string());
+  }
+
+  [[nodiscard]] std::filesystem::path with_ext() const
+  {
+    auto p = log_path;
+    p += ".log";
+    return p;
+  }
+
+  [[nodiscard]] std::string text() const { return slurp(with_ext()); }
+};
+
+/// Solver options that turn the backend's native file logging on (the
+/// destination comes from `LinearInterface::set_log_file`).
+[[nodiscard]] SolverOptions native_log_opts()
+{
+  SolverOptions opts;
+  opts.log_level = 1;
+  opts.log_mode = SolverLogMode::detailed;
+  return opts;
+}
+
+}  // namespace
+
+TEST_CASE("mip_start roundtrip - fixture sanity per MIP plugin")  // NOLINT
+{
+  const auto solvers = gtopt::solver_test::exact_mip_solvers();
+  if (solvers.empty()) {
+    MESSAGE("no MIP-capable solver plugin loaded — skipping");
+    return;
+  }
+  for (const auto& name : solvers) {
+    CAPTURE(name);
+    LinearInterface lp(name);
+    const auto m = build_tiny_uc(lp);
+
+    cold_solve(lp);
+    CHECK(lp.get_obj_value() == doctest::Approx(kOptObj).epsilon(1e-6));
+    check_is_mip_optimum(m, lp.get_col_sol_raw());
+
+    // Relaxation is fractional and its continuous dispatch differs from the
+    // MIP optimum — the property that makes the round trip non-trivial (an
+    // integers-over-relaxation overlay is NOT a feasible MIP solution).
+    // Checked on a FRESH interface: CBC's branch-and-bound leaves fixed
+    // bounds behind on the solved model, so relaxing in place is not a
+    // clean relaxation there.
+    LinearInterface rlp(name);
+    (void)build_tiny_uc(rlp);
+    (void)rlp.relax_integers();
+    REQUIRE(rlp.initial_solve().has_value());
+    REQUIRE(rlp.is_optimal());
+    CHECK(rlp.get_obj_value() == doctest::Approx(kRelaxObj).epsilon(1e-6));
+    const auto rsol = rlp.get_col_sol_raw();
+    const auto at = [&rsol](ColIndex c)
+    { return rsol[static_cast<std::size_t>(static_cast<int>(c))]; };
+    CHECK(at(m.ua1) == doctest::Approx(5.0 / 6.0));
+    CHECK(at(m.ub2) == doctest::Approx(0.3));
+    CHECK(at(m.pa2) == doctest::Approx(60.0));
+    CHECK(at(m.pb2) == doctest::Approx(30.0));
+  }
+}
+
+TEST_CASE(  // NOLINT
+    "mip_start roundtrip - complete optimal start is accepted per MIP plugin")
+{
+  const auto solvers = gtopt::solver_test::exact_mip_solvers();
+  if (solvers.empty()) {
+    MESSAGE("no MIP-capable solver plugin loaded — skipping");
+    return;
+  }
+  for (const auto& name : solvers) {
+    CAPTURE(name);
+
+    // 1. Cold solve: capture the COMPLETE optimal solution (integer AND
+    //    continuous columns) plus the basis when the backend exposes one.
+    LinearInterface cold(name);
+    const auto m = build_tiny_uc(cold);
+    cold_solve(cold);
+    const double obj_cold = cold.get_obj_value();
+    REQUIRE(obj_cold == doctest::Approx(kOptObj).epsilon(1e-6));
+    const auto raw = cold.get_col_sol_raw();
+    const std::vector<double> sol(raw.begin(), raw.end());
+    REQUIRE(sol.size() == kNumCols);
+    const auto basis = cold.get_basis();  // nullopt after a MIP on most
+
+    // 2. Fresh interface, SAME model, NO cold solve: inject the complete
+    //    solution under the strictest effort — an exact optimum is
+    //    feasible, so a working loading path MUST be accepted.
+    LinearInterface warm(name);
+    (void)build_tiny_uc(warm);
+    const NativeLog log(warm, "accept_" + name);
+    REQUIRE(warm.set_mip_start(sol, MipStartEffort::check_feasibility));
+    if (basis.has_value()) {
+      (void)warm.set_basis(*basis);  // best-effort root warm start
+    }
+    REQUIRE(warm.resolve(native_log_opts()).has_value());
+    REQUIRE(warm.is_optimal());
+    CHECK(warm.get_obj_value() == doctest::Approx(obj_cold).epsilon(1e-6));
+    check_is_mip_optimum(m, warm.get_col_sol_raw());
+
+    // 3. Sharp acceptance assertion on CPLEX: the native log carries the
+    //    official MIP-start processing outcome.  Rejection ("No solution
+    //    found from 1 MIP starts") re-solves cold to the same objective, so
+    //    only the log discriminates — this is the CEN failure signature.
+    if (name == "cplex") {
+      const auto text = log.text();
+      CAPTURE(text);
+      CHECK(text.contains(kCplexAccepted));
+      CHECK_FALSE(text.contains(kCplexRejected));
+    }
+  }
+}
+
+TEST_CASE(  // NOLINT
+    "mip_start roundtrip - perturbed complete start is repaired per MIP "
+    "plugin")
+{
+  const auto solvers = gtopt::solver_test::exact_mip_solvers();
+  if (solvers.empty()) {
+    MESSAGE("no MIP-capable solver plugin loaded — skipping");
+    return;
+  }
+  for (const auto& name : solvers) {
+    CAPTURE(name);
+
+    LinearInterface cold(name);
+    const auto m = build_tiny_uc(cold);
+    cold_solve(cold);
+    const auto raw = cold.get_col_sol_raw();
+    std::vector<double> start(raw.begin(), raw.end());
+    REQUIRE(start.size() == kNumCols);
+
+    // Flip ONE binary: uA2 1→0 leaves a fixed-integer-feasible commitment
+    // (B alone covers block 2) whose continuous entries are now stale — a
+    // "near-feasible complete start" the backend must repair back to the
+    // true optimum, not reject.
+    start[static_cast<std::size_t>(static_cast<int>(m.ua2))] = 0.0;
+
+    LinearInterface warm(name);
+    (void)build_tiny_uc(warm);
+    REQUIRE(warm.set_mip_start(start, MipStartEffort::repair));
+    REQUIRE(warm.resolve().has_value());
+    REQUIRE(warm.is_optimal());
+    CHECK(warm.get_obj_value() == doctest::Approx(kOptObj).epsilon(1e-6));
+    check_is_mip_optimum(m, warm.get_col_sol_raw());
+  }
+}
+
+TEST_CASE(  // NOLINT
+    "mip_start roundtrip - dump file replays through apply_mip_start per MIP "
+    "plugin")
+{
+  const auto solvers = gtopt::solver_test::exact_mip_solvers();
+  if (solvers.empty()) {
+    MESSAGE("no MIP-capable solver plugin loaded — skipping");
+    return;
+  }
+  for (const auto& name : solvers) {
+    CAPTURE(name);
+    const auto dump_path = std::filesystem::temp_directory_path()
+        / ("gtopt_mipstart_rt_" + name + ".dump");
+    std::filesystem::remove(dump_path);
+
+    // Solve cold and dump the COMPLETE solution.
+    LinearInterface src(name);
+    const auto m = build_tiny_uc(src);
+    cold_solve(src);
+    REQUIRE(dump_integer_solution(src, dump_path.string()).has_value());
+
+    // The dump must carry EVERY column (integer and continuous), not just
+    // the integers — a complete dump is what makes the replayed start
+    // consistent.
+    {
+      const auto text = slurp(dump_path);
+      CAPTURE(text);
+      CHECK(text.contains("ncols 8"));
+      CHECK(text.contains("nint 4"));
+      std::istringstream in(text);
+      std::string line;
+      std::size_t value_lines = 0;
+      while (std::getline(in, line)) {
+        if (!line.empty() && (std::isdigit(line.front()) != 0)) {
+          ++value_lines;
+        }
+      }
+      CHECK(value_lines == kNumCols);
+    }
+
+    SUBCASE("full pipeline (relaxation + file replay + inject)")
+    {
+      LinearInterface dst(name);
+      (void)build_tiny_uc(dst);
+      const NativeLog log(dst, "file_" + name);
+
+      MipStartOptions ms;
+      ms.enabled = true;
+      ms.from_file = dump_path.string();
+      ms.inject.effort = MipStartEffort::check_feasibility;
+      const auto report = apply_mip_start(dst, SolverOptions {}, ms);
+      REQUIRE(report.has_value());
+      CHECK(report->relaxation_solved);
+      CHECK(report->relaxation_feasible);
+      CHECK(report->injected);
+      CHECK(report->source == "file");
+
+      REQUIRE(dst.resolve(native_log_opts()).has_value());
+      REQUIRE(dst.is_optimal());
+      CHECK(dst.get_obj_value() == doctest::Approx(kOptObj).epsilon(1e-6));
+      check_is_mip_optimum(m, dst.get_col_sol_raw());
+      if (name == "cplex") {
+        const auto text = log.text();
+        CAPTURE(text);
+        CHECK(text.contains(kCplexAccepted));
+        CHECK_FALSE(text.contains(kCplexRejected));
+      }
+    }
+
+    SUBCASE("skip_relaxation fast path (no throwaway relaxation solve)")
+    {
+      LinearInterface dst(name);
+      (void)build_tiny_uc(dst);
+      const NativeLog log(dst, "skip_" + name);
+
+      MipStartOptions ms;
+      ms.enabled = true;
+      ms.from_file = dump_path.string();
+      ms.skip_relaxation = true;
+      ms.inject.effort = MipStartEffort::check_feasibility;
+      const auto report = apply_mip_start(dst, SolverOptions {}, ms);
+      REQUIRE(report.has_value());
+      CHECK_FALSE(report->relaxation_solved);
+      CHECK(report->injected);
+      CHECK(report->source == "file");
+
+      REQUIRE(dst.resolve(native_log_opts()).has_value());
+      REQUIRE(dst.is_optimal());
+      CHECK(dst.get_obj_value() == doctest::Approx(kOptObj).epsilon(1e-6));
+      check_is_mip_optimum(m, dst.get_col_sol_raw());
+      if (name == "cplex") {
+        const auto text = log.text();
+        CAPTURE(text);
+        CHECK(text.contains(kCplexAccepted));
+        CHECK_FALSE(text.contains(kCplexRejected));
+      }
+    }
+
+    SUBCASE("file generator reconstructs the dump without a relaxation")
+    {
+      // Destination NEVER solved: `get_col_sol_raw()` has no relaxation
+      // primal.  The generator must still produce the dumped solution
+      // (pre-fix it silently returned nullopt here, and the pipeline fell
+      // back to the round candidate — the CEN silent-fallback bug).
+      LinearInterface dst(name);
+      (void)build_tiny_uc(dst);
+      std::vector<int> int_cols;
+      for (int i = 0; i < static_cast<int>(kNumCols); ++i) {
+        if (dst.is_integer(ColIndex {i})) {
+          int_cols.push_back(i);
+        }
+      }
+      REQUIRE(int_cols.size() == 4);
+
+      MipStartOptions ms;
+      ms.from_file = dump_path.string();
+      const SolverOptions relax_opts;
+      MipStartContext ctx {
+          .li = dst,
+          .relax_opts = relax_opts,
+          .int_cols = int_cols,
+          .opts = ms,
+          .commitments = {},
+          .injections = {},
+      };
+      auto gen = make_mip_start_generator(ms);
+      REQUIRE(gen != nullptr);
+      CHECK(gen->name() == "file");
+      const auto start = gen->generate(ctx);
+      REQUIRE(start.has_value());
+      REQUIRE(start->size() == kNumCols);
+      check_is_mip_optimum(m, *start);
+    }
+
+    std::filesystem::remove(dump_path);
+  }
+}
+
+namespace
+{
+
+// ── SystemLP-level fixture: a 1-bus / 1-generator / 3-block commitment MIP
+// (the same shape as test_mip_start_integration.cpp).  Demand (0, 60, 60)
+// with startup cost ⇒ status binaries (0, 1, 1).
+
+const Simulation rt_three_block_simulation = {
+    .block_array =
+        {
+            {
+                .uid = Uid {0},
+                .duration = 1.0,
+            },
+            {
+                .uid = Uid {1},
+                .duration = 1.0,
+            },
+            {
+                .uid = Uid {2},
+                .duration = 1.0,
+            },
+        },
+    .stage_array =
+        {
+            {
+                .uid = Uid {0},
+                .first_block = 0,
+                .count_block = 3,
+                .chronological = true,
+            },
+        },
+    .scenario_array =
+        {
+            {
+                .uid = Uid {0},
+            },
+        },
+};
+
+[[nodiscard]] System make_rt_commitment_system()
+{
+  System system;
+  system.name = "MipStartRoundtrip";
+  system.bus_array = {
+      {
+          .uid = Uid {1},
+          .name = "b1",
+      },
+  };
+  system.demand_array = {
+      {
+          .uid = Uid {1},
+          .name = "d1",
+          .bus = Uid {1},
+          .lmax = TBRealFieldSched {std::vector<std::vector<Real>> {
+              {
+                  0.0,
+                  60.0,
+                  60.0,
+              },
+          }},
+          .capacity = 100.0,
+      },
+  };
+  system.generator_array = {
+      {
+          .uid = Uid {1},
+          .name = "g1",
+          .bus = Uid {1},
+          .pmin = 0.0,
+          .pmax = 100.0,
+          .gcost = 50.0,
+          .capacity = 100.0,
+      },
+  };
+  system.commitment_array = {
+      {
+          .uid = Uid {1},
+          .name = "cmt1",
+          .generator = Uid {1},
+          .startup_cost = 100.0,
+          .shutdown_cost = 50.0,
+          .pmin = 30.0,
+          .initial_status = 0.0,
+      },
+  };
+  return system;
+}
+
+/// Build + resolve one SystemLP over the commitment fixture with the given
+/// MIP-start options; return the optimal objective.
+[[nodiscard]] double resolve_rt_commitment_system(
+    const std::string& solver_name, const MipStartOptions& ms)
+{
+  System system = make_rt_commitment_system();
+
+  PlanningOptions poptions;
+  poptions.model_options.demand_fail_cost = 1000.0;
+  poptions.model_options.use_single_bus = true;
+  poptions.lp_matrix_options.solver_name = solver_name;
+  poptions.monolithic_options.mip_start = ms;
+
+  PlanningOptionsLP options(std::move(poptions));
+  SimulationLP simulation_lp(rt_three_block_simulation, options);
+  SystemLP system_lp(system, simulation_lp, LpMatrixOptions {});
+
+  const auto result = system_lp.resolve(SolverOptions {.log_level = 0});
+  REQUIRE(result.has_value());
+  auto&& lp = system_lp.linear_interface();
+  REQUIRE(lp.is_optimal());
+  return lp.get_obj_value();
+}
+
+}  // namespace
+
+TEST_CASE(  // NOLINT
+    "mip_start roundtrip - SystemLP dump_file to from_file round trip")
+{
+  // The exact path that broke on the CEN UC MIP: solve once dumping the
+  // solution via `mip_start.dump_file` (SystemLP::resolve hook), then solve
+  // a second, identical SystemLP replaying it via `mip_start.from_file`
+  // under the strictest inject effort — the replayed optimum must be
+  // accepted and land the same objective.
+  const auto solver_name = gtopt::solver_test::first_mip_solver();
+  if (solver_name.empty()) {
+    MESSAGE("no MIP-capable solver plugin loaded — skipping");
+    return;
+  }
+  CAPTURE(solver_name);
+
+  const auto dump_path = std::filesystem::temp_directory_path()
+      / ("gtopt_mipstart_rt_systemlp_" + solver_name + ".dump");
+  std::filesystem::remove(dump_path);
+
+  // Run 1 — cold solve, dump the complete solution.
+  MipStartOptions dump_opts;
+  dump_opts.dump_file = dump_path.string();
+  const double obj_cold = resolve_rt_commitment_system(solver_name, dump_opts);
+  REQUIRE(std::filesystem::exists(dump_path));
+  {
+    const auto text = slurp(dump_path);
+    CAPTURE(text);
+    CHECK(text.contains("ncols"));
+    CHECK(text.contains("nint"));
+  }
+
+  // Run 2 — replay the dump as the MIP start (full pipeline).
+  MipStartOptions replay_opts;
+  replay_opts.enabled = true;
+  replay_opts.from_file = dump_path.string();
+  replay_opts.inject.effort = MipStartEffort::check_feasibility;
+  const double obj_warm =
+      resolve_rt_commitment_system(solver_name, replay_opts);
+  CHECK(obj_warm == doctest::Approx(obj_cold).epsilon(1e-6));
+
+  // Run 3 — replay without the throwaway Stage-0 relaxation solve.
+  MipStartOptions skip_opts = replay_opts;
+  skip_opts.skip_relaxation = true;
+  const double obj_skip = resolve_rt_commitment_system(solver_name, skip_opts);
+  CHECK(obj_skip == doctest::Approx(obj_cold).epsilon(1e-6));
+
+  std::filesystem::remove(dump_path);
+}

--- a/test/source/test_sddp_strengthened_cuts.cpp
+++ b/test/source/test_sddp_strengthened_cuts.cpp
@@ -1074,7 +1074,7 @@ TEST_CASE(  // NOLINT
           for (const auto& [c, v] : ov.coefficients) {
             cols.insert(c);
           }
-          for (const auto col : cols) {
+          for (const auto& col : cols) {
             INFO("col ", static_cast<int>(col));
             CHECK(coeff_of(sc, col)
                   == doctest::Approx(coeff_of(ov, col)).epsilon(1.0e-15));


### PR DESCRIPTION
Fixes MIP-start rejection of a reloaded optimal solution ("No solution found from N MIP starts", seen on CEN PLEXOS 04-12, reproduced on an 8-col prototype).

Two composing root causes (confirmed by the new per-solver round-trip test):
1. CPLEX plugin filtered every start to sparse integer-only; CHECKFEAS cannot verify a PARTIAL start and discards it even at the exact optimum. Now trusting efforts (check_feasibility/no_check) pass the COMPLETE dense start; recomputing efforts (solve_fixed/solve_mip/repair) keep the sparse integer-only.
2. `FileMipStart` overlaid dumped integers on the LP-relaxation continuous (inconsistent) and silently fell back to the round candidate. `dump_integer_solution` now persists the COMPLETE solution (all cols); `FileMipStart` replays every dumped column (no silent bail); `skip_relaxation` covers `from_file`.

New: `test/source/test_mip_start_roundtrip.cpp` (per-solver, gated) — verified locally: 5/5 pass, CPLEX/SCIP accept the reloaded optimum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)